### PR TITLE
Fixes to gpytorch to be compatible with PyTorch master

### DIFF
--- a/build.py
+++ b/build.py
@@ -31,5 +31,6 @@ ffi = create_extension(
     library_dirs=library_dirs,
     with_cuda=with_cuda,
     package=True,
+    extra_compile_args=["-std=c99"],
     relative_to=__file__,
 )

--- a/gpytorch/functions/log_normal_cdf.py
+++ b/gpytorch/functions/log_normal_cdf.py
@@ -31,7 +31,7 @@ class LogNormalCDF(Function):
         if z_near_zero.sum() > 0:
             log_phi_first = -z.masked_select(z_near_zero).div_(math.sqrt(2 * math.pi))
             f = 0
-            for c_i in self.c:
+            for c_i in self.c.tolist():
                 f = log_phi_first.mul(c_i + f)
 
             log_phi_z.masked_scatter_(z_near_zero, f.mul_(-2).sub_(math.log(2)))

--- a/gpytorch/lazy/interpolated_lazy_variable.py
+++ b/gpytorch/lazy/interpolated_lazy_variable.py
@@ -274,7 +274,7 @@ class InterpolatedLazyVariable(LazyVariable):
                                                                              train_train_covar_inv_labels, base_size))
 
             # Prevent backprop through this variable
-            precomputed_cache.detach_()
+            precomputed_cache = precomputed_cache.detach()
 
         # Compute the exact predictive posterior
         n_test = self.size(-1) - n_train
@@ -352,11 +352,11 @@ class InterpolatedLazyVariable(LazyVariable):
                 inside = self.base_lazy_variable + RootLazyVariable(root).mul(-1)
                 inside_root = inside.root_decomposition()
                 # Prevent backprop through this variable
-                inside_root.detach_()
+                inside_root = inside_root.detach()
                 precomputed_cache = inside_root, None
             else:
                 # Prevent backprop through this variable
-                root.detach_()
+                root = root.detach()
                 precomputed_cache = None, root
 
         # Compute the exact predictive posterior

--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -679,6 +679,7 @@ class LazyVariable(object):
                 raise RuntimeError('Cannot assign %s to LazyVariable before calling LazyVariable.__init__()' % name)
         object.__setattr__(self, name, val)
 
+
 def _import_dotted_name(name):
     components = name.split('.')
     obj = __import__(components[0])

--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -563,7 +563,7 @@ class LazyVariable(object):
     @property
     def tensor_cls(self):
         if not hasattr(self, '_tensor_cls'):
-            self._tensor_cls = type(self.representation()[0].data)
+            self._tensor_cls = _import_dotted_name(self.representation()[0].data.type())
         return self._tensor_cls
 
     def trace_log_det_quad_form(self, mu_diffs, chol_covar_1):
@@ -678,3 +678,10 @@ class LazyVariable(object):
             if not hasattr(self, '_args'):
                 raise RuntimeError('Cannot assign %s to LazyVariable before calling LazyVariable.__init__()' % name)
         object.__setattr__(self, name, val)
+
+def _import_dotted_name(name):
+    components = name.split('.')
+    obj = __import__(components[0])
+    for component in components[1:]:
+        obj = getattr(obj, component)
+    return obj

--- a/gpytorch/utils/fft.py
+++ b/gpytorch/utils/fft.py
@@ -4,7 +4,7 @@ from .. import libfft
 def fft1(input):
     # [..., d]
     orig_size = input.size()
-    orig_type = type(input)
+    orig_type = input.type()
 
     input = input.view(-1, input.size(-1))
     n, d = input.size()
@@ -21,15 +21,12 @@ def fft1(input):
     else:
         output_size = [(d // 2) + 1, 2]
 
-    if not isinstance(output, orig_type):
-        return output.view(*output_size).type(orig_type)
-    else:
-        return output.view(*output_size)
+    return output.view(*output_size).type(orig_type)
 
 
 def ifft1(input, size=None):
     # [..., d, 2]
-    orig_type = type(input)
+    orig_type = input.type()
 
     if not size:
         size = list(input.size())[:-1]
@@ -46,7 +43,4 @@ def ifft1(input, size=None):
         output = output.float()
         libfft.fft1_c2r(input.float(), output)
     output.div_(d)
-    if not isinstance(output, orig_type):
-        return output.view(size).type(orig_type)
-    else:
-        return output.view(size)
+    return output.view(size).type(orig_type)

--- a/gpytorch/utils/function_factory.py
+++ b/gpytorch/utils/function_factory.py
@@ -96,6 +96,7 @@ def matmul_factory(matmul_closure_factory=_default_matmul_closure_factory,
                 raise NotImplementedError
             args = self.saved_tensors[:-1]
             rhs = self.saved_tensors[-1]
+            rhs_shape = rhs.shape
             closure_args = self.args + args
 
             arg_grads = [None] * len(args)
@@ -119,6 +120,9 @@ def matmul_factory(matmul_closure_factory=_default_matmul_closure_factory,
             # input_2 gradient
             if self.needs_input_grad[-1]:
                 rhs_grad = t_matmul_closure_factory(*closure_args)(grad_output)
+                # TODO: the matmul closure factory should return the same
+                # shape as rhs.
+                rhs_grad = rhs_grad.view(rhs_shape)
 
             return tuple(arg_grads + [rhs_grad])
 
@@ -261,6 +265,7 @@ def exact_gp_mll_factory(matmul_closure_factory=_default_matmul_closure_factory,
             mat_inv_labels = solves.narrow(-1, num_random_probes, 1)
             # Inverse quad form
             res = (mat_inv_labels * labels).sum(-1).sum(-1)
+            res = float(res)
 
             # Log det
             if not labels.dim() == 3:
@@ -276,7 +281,7 @@ def exact_gp_mll_factory(matmul_closure_factory=_default_matmul_closure_factory,
             self.solves = solves
             self.save_for_backward(*args)
             if torch.is_tensor(res):
-                return res
+                return res.view(1)
             return labels.new().resize_(1).fill_(res)
 
         def backward(self, grad_output):
@@ -402,9 +407,9 @@ def root_decomposition_factory(matmul_closure_factory=_default_matmul_closure_fa
             # Taken from http://homepages.inf.ed.ac.uk/imurray2/pub/16choldiff/choldiff.pdf
             if any(self.needs_input_grad):
                 args = self.saved_tensors
-                if root_grad_output.numel() == 1 and root_grad_output[0] == 0:
+                if root_grad_output.numel() == 0 or (root_grad_output.numel() == 1 and root_grad_output[0] == 0):
                     root_grad_output = None
-                if inverse_grad_output.numel() == 1 and inverse_grad_output[0] == 0:
+                if inverse_grad_output.numel() == 0 or (inverse_grad_output.numel() == 1 and inverse_grad_output[0] == 0):
                     inverse_grad_output = None
 
                 if root_grad_output is not None:

--- a/gpytorch/utils/function_factory.py
+++ b/gpytorch/utils/function_factory.py
@@ -404,12 +404,15 @@ def root_decomposition_factory(matmul_closure_factory=_default_matmul_closure_fa
             return root, inverse
 
         def backward(self, root_grad_output, inverse_grad_output):
+            def is_empty(tensor):
+                return tensor.numel() == 0 or (tensor.numel() == 1 and tensor[0] == 0)
+
             # Taken from http://homepages.inf.ed.ac.uk/imurray2/pub/16choldiff/choldiff.pdf
             if any(self.needs_input_grad):
                 args = self.saved_tensors
-                if root_grad_output.numel() == 0 or (root_grad_output.numel() == 1 and root_grad_output[0] == 0):
+                if is_empty(root_grad_output):
                     root_grad_output = None
-                if inverse_grad_output.numel() == 0 or (inverse_grad_output.numel() == 1 and inverse_grad_output[0] == 0):
+                if is_empty(inverse_grad_output):
                     inverse_grad_output = None
 
                 if root_grad_output is not None:

--- a/gpytorch/utils/sparse.py
+++ b/gpytorch/utils/sparse.py
@@ -17,7 +17,7 @@ def make_sparse_from_indices_and_values(interp_indices, interp_values, n_rows):
         SparseTensor - (batch_size) x n_cols x n_rows
     """
 
-    if isinstance(interp_indices, Variable):
+    if not torch.is_tensor(interp_indices):
         raise RuntimeError('interp_indices and interp_values should be tensors')
 
     # Is it batch mode?
@@ -64,10 +64,11 @@ def make_sparse_from_indices_and_values(interp_indices, interp_values, n_rows):
         interp_size = torch.Size([n_rows, n_target_points])
 
     # Make the sparse tensor
+    type_name = value_tensor.type().split('.')[-1]  # e.g. FloatTensor
     if index_tensor.is_cuda:
-        cls = getattr(torch.cuda.sparse, value_tensor.__class__.__name__)
+        cls = getattr(torch.cuda.sparse, type_name)
     else:
-        cls = getattr(torch.sparse, value_tensor.__class__.__name__)
+        cls = getattr(torch.sparse, type_name)
     res = cls(index_tensor, value_tensor, interp_size)
 
     # Wrap things as a variable, if necessary

--- a/gpytorch/utils/sparse.py
+++ b/gpytorch/utils/sparse.py
@@ -1,5 +1,4 @@
 import torch
-from torch.autograd import Variable
 
 
 def make_sparse_from_indices_and_values(interp_indices, interp_values, n_rows):

--- a/test/util/function_factory_test.py
+++ b/test/util/function_factory_test.py
@@ -1,0 +1,388 @@
+import math
+import torch
+import gpytorch
+import numpy as np
+from torch.autograd import Variable
+from gpytorch.utils import approx_equal, function_factory
+from gpytorch.lazy import NonLazyVariable
+
+
+_exact_gp_mll_class = function_factory.exact_gp_mll_factory()
+
+
+def test_forward_inv_mm():
+    for n_cols in [2, 3, 4]:
+        a = torch.Tensor([
+            [5, -3, 0],
+            [-3, 5, 0],
+            [0, 0, 2],
+        ])
+        b = torch.randn(3, n_cols)
+        actual = a.inverse().mm(b)
+
+        a_var = Variable(a)
+        b_var = Variable(b)
+        out_var = gpytorch.inv_matmul(a_var, b_var)
+        res = out_var.data
+
+        assert(torch.norm(actual - res) < 1e-4)
+
+
+def test_backward_inv_mm():
+    for n_cols in [2, 3, 4]:
+        a = torch.Tensor([
+            [5, -3, 0],
+            [-3, 5, 0],
+            [0, 0, 2],
+        ])
+        b = torch.ones(3, 3).fill_(2)
+        c = torch.randn(3, n_cols)
+        actual_a_grad = -torch.mm(
+            a.inverse().mul_(0.5).mm(torch.eye(3, n_cols)),
+            a.inverse().mul_(0.5).mm(c).t()
+        ) * 2 * 2
+        actual_c_grad = (a.inverse() / 2).t().mm(torch.eye(3, n_cols)) * 2
+
+        a_var = Variable(a, requires_grad=True)
+        c_var = Variable(c, requires_grad=True)
+        out_var = a_var.mul(Variable(b))
+        out_var = gpytorch.inv_matmul(out_var, c_var)
+        out_var = out_var.mul(Variable(torch.eye(3, n_cols))).sum() * 2
+        out_var.backward()
+        a_res = a_var.grad.data
+        c_res = c_var.grad.data
+
+        assert(torch.norm(actual_a_grad - a_res) < 1e-4)
+        assert(torch.norm(actual_c_grad - c_res) < 1e-4)
+
+
+def test_forward_inv_mv():
+    a = torch.Tensor([
+        [5, -3, 0],
+        [-3, 5, 0],
+        [0, 0, 2],
+    ])
+    b = torch.randn(3)
+    actual = a.inverse().mv(b)
+
+    a_var = Variable(a)
+    b_var = Variable(b)
+    out_var = gpytorch.inv_matmul(a_var, b_var)
+    res = out_var.data
+
+    assert(torch.norm(actual - res) < 1e-4)
+
+
+def test_backward_inv_mv():
+    a = torch.Tensor([
+        [5, -3, 0],
+        [-3, 5, 0],
+        [0, 0, 2],
+    ])
+    b = torch.ones(3, 3).fill_(2)
+    c = torch.randn(3)
+    actual_a_grad = -torch.ger(a.inverse().mul_(0.5).mv(torch.ones(3)), a.inverse().mul_(0.5).mv(c)) * 2 * 2
+    actual_c_grad = (a.inverse() / 2).t().mv(torch.ones(3)) * 2
+
+    a_var = Variable(a, requires_grad=True)
+    c_var = Variable(c, requires_grad=True)
+    out_var = a_var.mul(Variable(b))
+    out_var = gpytorch.inv_matmul(out_var, c_var)
+    out_var = out_var.sum() * 2
+    out_var.backward()
+    a_res = a_var.grad.data
+    c_res = c_var.grad.data
+
+    assert(torch.norm(actual_a_grad - a_res) < 1e-4)
+    assert(torch.norm(actual_c_grad - c_res) < 1e-4)
+
+
+def test_normal_gp_mll_forward():
+    covar = torch.Tensor([
+        [3, -1, 0],
+        [-1, 3, 0],
+        [0, 0, 3],
+    ])
+    y = torch.randn(3)
+
+    actual = y.dot(covar.inverse().mv(y))
+    actual += math.log(np.linalg.det(covar.numpy()))
+    actual += math.log(2 * math.pi) * len(y)
+    actual *= -0.5
+
+    covarvar = Variable(covar)
+    yvar = Variable(y)
+
+    res = _exact_gp_mll_class()(covarvar, yvar)
+    assert((torch.abs(actual - res.data).div(res.data) < 0.1).all())
+
+
+def test_normal_gp_mll_backward():
+    covar = torch.Tensor([
+        [3, -1, 0],
+        [-1, 3, 0],
+        [0, 0, 3],
+    ])
+    y = torch.randn(3)
+
+    covarvar = Variable(covar, requires_grad=True)
+    yvar = Variable(y, requires_grad=True)
+    actual_mat_grad = torch.ger(covar.inverse().mv(y), covar.inverse().mv(y))
+    actual_mat_grad -= covar.inverse()
+    actual_mat_grad *= 0.5
+    actual_mat_grad *= 3  # For grad output
+
+    actual_y_grad = -covar.inverse().mv(y)
+    actual_y_grad *= 3  # For grad output
+
+    covarvar = Variable(covar, requires_grad=True)
+    yvar = Variable(y, requires_grad=True)
+    with gpytorch.settings.num_trace_samples(1000):
+        output = _exact_gp_mll_class()(covarvar, yvar) * 3
+        output.backward()
+
+    assert(torch.norm(actual_mat_grad - covarvar.grad.data) < 1e-1)
+    assert(torch.norm(actual_y_grad - yvar.grad.data) < 1e-4)
+
+    with gpytorch.settings.num_trace_samples(0):
+        covarvar = Variable(covar, requires_grad=True)
+        yvar = Variable(y, requires_grad=True)
+        with gpytorch.settings.num_trace_samples(1000):
+            output = _exact_gp_mll_class()(covarvar, yvar) * 3
+            output.backward()
+
+    assert(torch.norm(actual_mat_grad - covarvar.grad.data) < 1e-1)
+    assert(torch.norm(actual_y_grad - yvar.grad.data) < 1e-4)
+
+
+def test_normal_trace_log_det_quad_form_forward():
+    covar = torch.Tensor([
+        [3, -1, 0],
+        [-1, 3, 0],
+        [0, 0, 3],
+    ])
+    mu_diffs = torch.Tensor([0, -1, 1])
+    chol_covar = torch.Tensor([
+        [1, -2, 0],
+        [0, 1, -2],
+        [0, 0, 1],
+    ])
+
+    actual = mu_diffs.dot(covar.inverse().matmul(mu_diffs))
+    actual += math.log(np.linalg.det(covar.numpy()))
+    actual += (covar.inverse().matmul(chol_covar.t().matmul(chol_covar))).trace()
+
+    covarvar = Variable(covar)
+    chol_covarvar = Variable(chol_covar)
+    mu_diffsvar = Variable(mu_diffs)
+
+    res = gpytorch.trace_logdet_quad_form(mu_diffsvar, chol_covarvar, covarvar)
+    assert((torch.abs(actual - res.data).div(res.data) < 0.1).all())
+
+
+def test_normal_trace_log_det_quad_form_backward():
+    covar = Variable(torch.Tensor([
+        [3, -1, 0],
+        [-1, 3, 0],
+        [0, 0, 3],
+    ]), requires_grad=True)
+    mu_diffs = Variable(torch.Tensor([0, -1, 1]), requires_grad=True)
+    chol_covar = Variable(torch.Tensor([
+        [1, -2, 0],
+        [0, 1, -2],
+        [0, 0, 1],
+    ]), requires_grad=True)
+
+    actual = mu_diffs.dot(covar.inverse().matmul(mu_diffs))
+    actual += (covar.inverse().matmul(chol_covar.t().matmul(chol_covar))).trace()
+    actual.backward()
+
+    actual_covar_grad = covar.grad.data.clone() + covar.data.inverse()
+    actual_mu_diffs_grad = mu_diffs.grad.data.clone()
+    actual_chol_covar_grad = chol_covar.grad.data.clone()
+
+    covar = Variable(torch.Tensor([
+        [3, -1, 0],
+        [-1, 3, 0],
+        [0, 0, 3],
+    ]), requires_grad=True)
+    mu_diffs = Variable(torch.Tensor([0, -1, 1]), requires_grad=True)
+    chol_covar = Variable(torch.Tensor([
+        [1, -2, 0],
+        [0, 1, -2],
+        [0, 0, 1],
+    ]), requires_grad=True)
+
+    with gpytorch.settings.num_trace_samples(1000):
+        res = gpytorch.trace_logdet_quad_form(mu_diffs, chol_covar, covar)
+        res.backward()
+
+    res_covar_grad = covar.grad.data
+    res_mu_diffs_grad = mu_diffs.grad.data
+    res_chol_covar_grad = chol_covar.grad.data
+
+    assert torch.norm(actual_covar_grad - res_covar_grad) < 1e-1
+    assert torch.norm(actual_mu_diffs_grad - res_mu_diffs_grad) < 1e-1
+    assert torch.norm(actual_chol_covar_grad - res_chol_covar_grad) < 1e-1
+
+
+def test_batch_trace_log_det_quad_form_forward():
+    covar = torch.Tensor([
+        [
+            [3, -1, 0],
+            [-1, 3, 0],
+            [0, 0, 3],
+        ], [
+            [10, -2, 1],
+            [-2, 10, 0],
+            [1, 0, 10],
+        ]
+    ])
+    mu_diffs = torch.Tensor([
+        [0, -1, 1],
+        [1, 2, 3]
+    ])
+    chol_covar = torch.Tensor([
+        [
+            [1, -2, 0],
+            [0, 1, -2],
+            [0, 0, 1],
+        ], [
+            [2, -4, 0],
+            [0, 2, -4],
+            [0, 0, 2],
+        ]
+    ])
+
+    actual = mu_diffs[0].dot(covar[0].inverse().matmul(mu_diffs[0]))
+    actual += math.log(np.linalg.det(covar[0].numpy()))
+    actual += (covar[0].inverse().matmul(chol_covar[0].t().matmul(chol_covar[0]))).trace()
+    actual += mu_diffs[1].dot(covar[1].inverse().matmul(mu_diffs[1]))
+    actual += math.log(np.linalg.det(covar[1].numpy()))
+    actual += (covar[1].inverse().matmul(chol_covar[1].t().matmul(chol_covar[1]))).trace()
+
+    covarvar = Variable(covar)
+    chol_covarvar = Variable(chol_covar)
+    mu_diffsvar = Variable(mu_diffs)
+
+    res = gpytorch.trace_logdet_quad_form(mu_diffsvar, chol_covarvar, covarvar)
+    assert((torch.abs(actual - res.data).div(res.data) < 0.1).all())
+
+
+def test_batch_trace_log_det_quad_form_backward():
+    covar = Variable(torch.Tensor([
+        [
+            [3, -1, 0],
+            [-1, 3, 0],
+            [0, 0, 3],
+        ], [
+            [10, -2, 1],
+            [-2, 10, 0],
+            [1, 0, 10],
+        ]
+    ]), requires_grad=True)
+    mu_diffs = Variable(torch.Tensor([
+        [0, -1, 1],
+        [1, 2, 3]
+    ]), requires_grad=True)
+    chol_covar = Variable(torch.Tensor([
+        [
+            [1, -2, 0],
+            [0, 1, -2],
+            [0, 0, 1],
+        ], [
+            [2, -4, 0],
+            [0, 2, -4],
+            [0, 0, 2],
+        ]
+    ]), requires_grad=True)
+
+    actual = mu_diffs[0].dot(covar[0].inverse().matmul(mu_diffs[0]))
+    actual += (covar[0].inverse().matmul(chol_covar[0].t().matmul(chol_covar[0]))).trace()
+    actual += mu_diffs[1].dot(covar[1].inverse().matmul(mu_diffs[1]))
+    actual += (covar[1].inverse().matmul(chol_covar[1].t().matmul(chol_covar[1]))).trace()
+    actual.backward()
+
+    actual_covar_grad = covar.grad.data.clone() + torch.cat([covar[0].data.inverse().unsqueeze(0),
+                                                             covar[1].data.inverse().unsqueeze(0)])
+    actual_mu_diffs_grad = mu_diffs.grad.data.clone()
+    actual_chol_covar_grad = chol_covar.grad.data.clone()
+
+    covar.grad.data.fill_(0)
+    mu_diffs.grad.data.fill_(0)
+    chol_covar.grad.data.fill_(0)
+    with gpytorch.settings.num_trace_samples(1000):
+        res = gpytorch.trace_logdet_quad_form(mu_diffs, chol_covar, covar)
+        res.backward()
+
+    res_covar_grad = covar.grad.data
+    res_mu_diffs_grad = mu_diffs.grad.data
+    res_chol_covar_grad = chol_covar.grad.data
+
+    assert torch.norm(actual_covar_grad - res_covar_grad) < 1e-1
+    assert torch.norm(actual_mu_diffs_grad - res_mu_diffs_grad) < 1e-1
+    assert torch.norm(actual_chol_covar_grad - res_chol_covar_grad) < 1e-1
+
+
+def test_root_decomposition_forward():
+    a = torch.randn(5, 5)
+    a = torch.matmul(a, a.t())
+
+    a_lv = NonLazyVariable(Variable(a, requires_grad=True))
+    a_root = a_lv.root_decomposition()
+
+    assert torch.max(((a_root.matmul(a_root.transpose(-1, -2)).data - a)).abs()) < 1e-2
+
+
+def test_root_decomposition_backward():
+    a = torch.Tensor([
+        [5.0212, 0.5504, -0.1810, 1.5414, 2.9611],
+        [0.5504, 2.8000, 1.9944, 0.6208, -0.8902],
+        [-0.1810, 1.9944, 3.0505, 1.0790, -1.1774],
+        [1.5414, 0.6208, 1.0790, 2.9430, 0.4170],
+        [2.9611, -0.8902, -1.1774, 0.4170, 3.3208],
+    ])
+
+    a_var = Variable(a, requires_grad=True)
+    a_lv = NonLazyVariable(a_var)
+    a_root = a_lv.root_decomposition()
+    res = a_root.matmul(a_root.transpose(-1, -2))
+    res.trace().backward()
+
+    a_var_copy = Variable(a, requires_grad=True)
+    a_var_copy.trace().backward()
+
+    assert approx_equal(a_var.grad.data, a_var_copy.grad.data)
+
+
+def test_root_decomposition_inv_forward():
+    a = torch.randn(5, 5)
+    a = torch.matmul(a, a.t())
+
+    a_lv = NonLazyVariable(Variable(a, requires_grad=True))
+    a_root = a_lv.root_inv_decomposition()
+
+    actual = a.inverse()
+    diff = (a_root.matmul(a_root.transpose(-1, -2)).data - actual).abs()
+    assert torch.max(diff / actual) < 1e-2
+
+
+def test_root_decomposition_inv_backward():
+    a = torch.Tensor([
+        [5.0212, 0.5504, -0.1810, 1.5414, 2.9611],
+        [0.5504, 2.8000, 1.9944, 0.6208, -0.8902],
+        [-0.1810, 1.9944, 3.0505, 1.0790, -1.1774],
+        [1.5414, 0.6208, 1.0790, 2.9430, 0.4170],
+        [2.9611, -0.8902, -1.1774, 0.4170, 3.3208],
+    ])
+
+    a_var = Variable(a, requires_grad=True)
+    a_lv = NonLazyVariable(a_var)
+    a_root = a_lv.root_inv_decomposition()
+    res = a_root.matmul(a_root.transpose(-1, -2))
+    res.trace().backward()
+
+    a_var_copy = Variable(a, requires_grad=True)
+    a_var_copy.inverse().trace().backward()
+
+    assert approx_equal(a_var.grad.data, a_var_copy.grad.data)

--- a/test/util/interp_test.py
+++ b/test/util/interp_test.py
@@ -1,0 +1,127 @@
+import torch
+from torch.autograd import Variable
+from gpytorch.utils import left_interp, left_t_interp, approx_equal
+
+interp_indices = Variable(torch.LongTensor([[2, 3], [3, 4], [4, 5]])).repeat(3, 1)
+interp_values = Variable(torch.Tensor([[1, 2], [0.5, 1], [1, 3]])).repeat(3, 1)
+
+interp_indices_2 = Variable(torch.LongTensor([[0, 1], [1, 2], [2, 3]])).repeat(3, 1)
+interp_values_2 = Variable(torch.Tensor([[1, 2], [2, 0.5], [1, 3]])).repeat(3, 1)
+batch_interp_indices = torch.cat([interp_indices.unsqueeze(0), interp_indices_2.unsqueeze(0)], 0)
+batch_interp_values = torch.cat([interp_values.unsqueeze(0), interp_values_2.unsqueeze(0)], 0)
+
+interp_matrix = torch.Tensor([
+    [0, 0, 1, 2, 0, 0],
+    [0, 0, 0, 0.5, 1, 0],
+    [0, 0, 0, 0, 1, 3],
+    [0, 0, 1, 2, 0, 0],
+    [0, 0, 0, 0.5, 1, 0],
+    [0, 0, 0, 0, 1, 3],
+    [0, 0, 1, 2, 0, 0],
+    [0, 0, 0, 0.5, 1, 0],
+    [0, 0, 0, 0, 1, 3],
+])
+
+batch_interp_matrix = torch.Tensor([
+    [
+        [0, 0, 1, 2, 0, 0],
+        [0, 0, 0, 0.5, 1, 0],
+        [0, 0, 0, 0, 1, 3],
+        [0, 0, 1, 2, 0, 0],
+        [0, 0, 0, 0.5, 1, 0],
+        [0, 0, 0, 0, 1, 3],
+        [0, 0, 1, 2, 0, 0],
+        [0, 0, 0, 0.5, 1, 0],
+        [0, 0, 0, 0, 1, 3],
+    ], [
+        [1, 2, 0, 0, 0, 0],
+        [0, 2, 0.5, 0, 0, 0],
+        [0, 0, 1, 3, 0, 0],
+        [1, 2, 0, 0, 0, 0],
+        [0, 2, 0.5, 0, 0, 0],
+        [0, 0, 1, 3, 0, 0],
+        [1, 2, 0, 0, 0, 0],
+        [0, 2, 0.5, 0, 0, 0],
+        [0, 0, 1, 3, 0, 0],
+    ]
+])
+
+
+def test_left_interp_on_a_vector():
+    vector = torch.randn(6)
+
+    res = left_interp(interp_indices, interp_values, Variable(vector)).data
+    actual = torch.matmul(interp_matrix, vector)
+    assert approx_equal(res, actual)
+
+
+def test_left_t_interp_on_a_vector():
+    vector = torch.randn(9)
+
+    res = left_t_interp(interp_indices, interp_values, Variable(vector), 6).data
+    actual = torch.matmul(interp_matrix.transpose(-1, -2), vector)
+    assert approx_equal(res, actual)
+
+
+def test_batch_left_interp_on_a_vector():
+    vector = torch.randn(6)
+
+    actual = torch.matmul(batch_interp_matrix, vector.unsqueeze(-1).unsqueeze(0)).squeeze(-1)
+    res = left_interp(batch_interp_indices, batch_interp_values, Variable(vector)).data
+    assert approx_equal(res, actual)
+
+
+def test_batch_left_t_interp_on_a_vector():
+    vector = torch.randn(9)
+
+    actual = torch.matmul(batch_interp_matrix.transpose(-1, -2), vector.unsqueeze(-1).unsqueeze(0)).squeeze(-1)
+    res = left_t_interp(batch_interp_indices, batch_interp_values, Variable(vector), 6).data
+    assert approx_equal(res, actual)
+
+
+def test_left_interp_on_a_matrix():
+    matrix = torch.randn(6, 3)
+
+    res = left_interp(interp_indices, interp_values, Variable(matrix)).data
+    actual = torch.matmul(interp_matrix, matrix)
+    assert approx_equal(res, actual)
+
+
+def test_left_t_interp_on_a_matrix():
+    matrix = torch.randn(9, 3)
+
+    res = left_t_interp(interp_indices, interp_values, Variable(matrix), 6).data
+    actual = torch.matmul(interp_matrix.transpose(-1, -2), matrix)
+    assert approx_equal(res, actual)
+
+
+def test_batch_left_interp_on_a_matrix():
+    batch_matrix = torch.randn(6, 3)
+
+    res = left_interp(batch_interp_indices, batch_interp_values, Variable(batch_matrix)).data
+    actual = torch.matmul(batch_interp_matrix, batch_matrix.unsqueeze(0))
+    assert approx_equal(res, actual)
+
+
+def test_batch_left_t_interp_on_a_matrix():
+    batch_matrix = torch.randn(9, 3)
+
+    res = left_t_interp(batch_interp_indices, batch_interp_values, Variable(batch_matrix), 6).data
+    actual = torch.matmul(batch_interp_matrix.transpose(-1, -2), batch_matrix.unsqueeze(0))
+    assert approx_equal(res, actual)
+
+
+def test_batch_left_interp_on_a_batch_matrix():
+    batch_matrix = torch.randn(2, 6, 3)
+
+    res = left_interp(batch_interp_indices, batch_interp_values, Variable(batch_matrix)).data
+    actual = torch.matmul(batch_interp_matrix, batch_matrix)
+    assert approx_equal(res, actual)
+
+
+def test_batch_left_t_interp_on_a_batch_matrix():
+    batch_matrix = torch.randn(2, 9, 3)
+
+    res = left_t_interp(batch_interp_indices, batch_interp_values, Variable(batch_matrix), 6).data
+    actual = torch.matmul(batch_interp_matrix.transpose(-1, -2), batch_matrix)
+    assert approx_equal(res, actual)

--- a/test/util/test_function_factory.py
+++ b/test/util/test_function_factory.py
@@ -179,7 +179,7 @@ class TestFunctionFactory(unittest.TestCase):
         mu_diffsvar = Variable(mu_diffs)
 
         res = gpytorch.trace_logdet_quad_form(mu_diffsvar, chol_covarvar, covarvar)
-        self.assertTrue(all(torch.abs(actual - res.data).div(res.data) < 0.1))
+        self.assertTrue((torch.abs(actual - res.data).div(res.data) < 0.1).all())
 
     def test_normal_trace_log_det_quad_form_backward(self):
         covar = Variable(torch.Tensor([
@@ -279,7 +279,7 @@ class TestFunctionFactory(unittest.TestCase):
         mu_diffsvar = Variable(mu_diffs)
 
         res = gpytorch.trace_logdet_quad_form(mu_diffsvar, chol_covarvar, covarvar)
-        self.assertTrue(all(torch.abs(actual - res.data).div(res.data) < 0.1))
+        self.assertTrue((torch.abs(actual - res.data).div(res.data) < 0.1).all())
 
     def test_batch_trace_log_det_quad_form_backward(self):
         covar = Variable(torch.Tensor([

--- a/test/util/test_interp.py
+++ b/test/util/test_interp.py
@@ -94,7 +94,7 @@ class TestInterp(unittest.TestCase):
         actual = torch.matmul(
             self.batch_interp_matrix,
             vector.unsqueeze(-1).unsqueeze(0)
-        ).squeeze(0)
+        ).squeeze(-1)
         res = left_interp(
             self.batch_interp_indices,
             self.batch_interp_values,
@@ -108,7 +108,7 @@ class TestInterp(unittest.TestCase):
         actual = torch.matmul(
             self.batch_interp_matrix.transpose(-1, -2),
             vector.unsqueeze(-1).unsqueeze(0)
-        ).squeeze(0)
+        ).squeeze(-1)
         res = left_t_interp(
             self.batch_interp_indices,
             self.batch_interp_values,


### PR DESCRIPTION
This retains compatiblity with PyTorch 0.3.

The file gpytorch/utils/function_factory.py deserves some attention: The
`t_matmul_closure_factory` does not always return the correct shape for
the gradient. This is a bug: gradients should have the exact same shape
as the differnetiated variable. PyTorch is missing some checks for this
behavior, but future versions of PyTorch are likely to raise an
exception if shapes don't exactly match.

(This depends on https://github.com/pytorch/pytorch/pull/5643 in PyTorch)