### PR TITLE
Add ability to take sum and product of kernels directly, add linear and periodic kernels, create `active_dims`

### DIFF
--- a/gpytorch/kernels/__init__.py
+++ b/gpytorch/kernels/__init__.py
@@ -1,20 +1,22 @@
-from .kernel import Kernel
-from .rbf_kernel import RBFKernel
-from .matern_kernel import MaternKernel
-from .spectral_mixture_kernel import SpectralMixtureKernel
-from .index_kernel import IndexKernel
-from .grid_interpolation_kernel import GridInterpolationKernel
 from .additive_grid_interpolation_kernel import AdditiveGridInterpolationKernel
+from .grid_interpolation_kernel import GridInterpolationKernel
+from .index_kernel import IndexKernel
+from .kernel import Kernel
+from .linear_kernel import LinearKernel
+from .matern_kernel import MaternKernel
 from .multiplicative_grid_interpolation_kernel import MultiplicativeGridInterpolationKernel
+from .periodic_kernel import PeriodicKernel
+from .rbf_kernel import RBFKernel
+from .spectral_mixture_kernel import SpectralMixtureKernel
 
 
 __all__ = [
-    Kernel,
-    RBFKernel,
-    MaternKernel,
-    SpectralMixtureKernel,
-    IndexKernel,
-    GridInterpolationKernel,
     AdditiveGridInterpolationKernel,
-    MultiplicativeGridInterpolationKernel,
+    GridInterpolationKernel,
+    IndexKernel,
+    Kernel,
+    LinearKernel,
+    MaternKernel,
+    PeriodicKernel,
+    SpectralMixtureKernel,
 ]

--- a/gpytorch/kernels/additive_grid_interpolation_kernel.py
+++ b/gpytorch/kernels/additive_grid_interpolation_kernel.py
@@ -1,11 +1,28 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from torch.autograd import Variable
 from .grid_interpolation_kernel import GridInterpolationKernel
 from ..utils import Interpolation
 
 
 class AdditiveGridInterpolationKernel(GridInterpolationKernel):
-    def __init__(self, base_kernel_module, grid_size, grid_bounds, n_components):
-        super(AdditiveGridInterpolationKernel, self).__init__(base_kernel_module, grid_size, grid_bounds)
+    def __init__(
+        self,
+        base_kernel_module,
+        grid_size,
+        grid_bounds,
+        n_components,
+        active_dims=None,
+    ):
+        super(AdditiveGridInterpolationKernel, self).__init__(
+            base_kernel_module,
+            grid_size,
+            grid_bounds,
+            active_dims=active_dims,
+        )
         self.n_components = n_components
 
     def _compute_grid(self, inputs):

--- a/gpytorch/kernels/grid_interpolation_kernel.py
+++ b/gpytorch/kernels/grid_interpolation_kernel.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from .grid_kernel import GridKernel
@@ -6,7 +11,7 @@ from ..utils import Interpolation
 
 
 class GridInterpolationKernel(GridKernel):
-    def __init__(self, base_kernel_module, grid_size, grid_bounds):
+    def __init__(self, base_kernel_module, grid_size, grid_bounds, active_dims=None):
         grid = torch.zeros(len(grid_bounds), grid_size)
         for i in range(len(grid_bounds)):
             grid_diff = float(grid_bounds[i][1] - grid_bounds[i][0]) / (grid_size - 2)
@@ -23,7 +28,12 @@ class GridInterpolationKernel(GridKernel):
                     inducing_points[j * grid_size ** i:(j + 1) * grid_size ** i, :i].copy_(prev_points)
             prev_points = inducing_points[:grid_size ** (i + 1), :(i + 1)]
 
-        super(GridInterpolationKernel, self).__init__(base_kernel_module, inducing_points, grid)
+        super(GridInterpolationKernel, self).__init__(
+            base_kernel_module,
+            inducing_points,
+            grid,
+            active_dims=active_dims,
+        )
 
     def _compute_grid(self, inputs):
         batch_size, n_data, n_dimensions = inputs.size()

--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from .kernel import Kernel
@@ -6,8 +11,8 @@ from .. import settings
 
 
 class GridKernel(Kernel):
-    def __init__(self, base_kernel_module, inducing_points, grid):
-        super(GridKernel, self).__init__()
+    def __init__(self, base_kernel_module, inducing_points, grid, active_dims=None):
+        super(GridKernel, self).__init__(active_dims=active_dims)
         self.base_kernel_module = base_kernel_module
         if inducing_points.ndimension() != 2:
             raise RuntimeError('Inducing points should be 2 dimensional')

--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -1,18 +1,46 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch import nn
 from .kernel import Kernel
 
 
 class IndexKernel(Kernel):
-    def __init__(self, n_tasks, rank=1, covar_factor_bounds=(-100, 100), log_var_bounds=(-100, 100)):
-        super(IndexKernel, self).__init__()
-        self.register_parameter('covar_factor', nn.Parameter(torch.randn(n_tasks, rank)),
-                                bounds=covar_factor_bounds)
-        self.register_parameter('log_var', nn.Parameter(torch.randn(n_tasks)), bounds=log_var_bounds)
+    def __init__(
+        self,
+        n_tasks,
+        rank=1,
+        covar_factor_bounds=(-100, 100),
+        log_var_bounds=(-100, 100),
+        active_dims=None,
+    ):
+        if active_dims is not None and len(active_dims) > 1:
+            raise ValueError(
+                "Index must be with respect to a single column. Received {}"
+                .format(active_dims)
+            )
+        super(IndexKernel, self).__init__(active_dims=active_dims)
+        self.register_parameter(
+            'covar_factor',
+            nn.Parameter(torch.randn(n_tasks, rank)),
+            bounds=covar_factor_bounds
+        )
+        self.register_parameter(
+            'log_var',
+            nn.Parameter(torch.randn(n_tasks)),
+            bounds=log_var_bounds,
+        )
 
     def forward(self, i1, i2):
         covar_matrix = self.covar_factor.matmul(self.covar_factor.transpose(-1, -2))
         covar_matrix += self.log_var.exp().diag()
         covar_matrix = covar_matrix.unsqueeze(0)
-        output_covar = covar_matrix.index_select(-2, i1.view(-1)).index_select(-1, i2.view(-1))
+        output_covar = (
+            covar_matrix.
+            index_select(-2, i1.view(-1)).
+            index_select(-1, i2.view(-1))
+        )
         return output_covar

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -1,11 +1,28 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ..module import Module
 
 
 class Kernel(Module):
+    def __init__(self, active_dims=None):
+        self.active_dims = active_dims
+        super(Kernel, self).__init__()
+
     def forward(self, x1, x2, **params):
         raise NotImplementedError()
 
-    def __call__(self, x1, x2=None, **params):
+    def __call__(self, x1_, x2_=None, **params):
+        if self.active_dims is not None:
+            x1 = x1_[:, self.active_dims]
+            if x2_ is not None:
+                x2 = x2_[:, self.active_dims]
+        else:
+            x1 = x1_
+            x2 = x2_
+
         if x2 is None:
             x2 = x1
 
@@ -27,3 +44,29 @@ class Kernel(Module):
         if not is_batch:
             res = res[0]
         return res
+
+    def __add__(self, other):
+        return AdditiveKernel(self, other)
+
+    def __mul__(self, other):
+        return ProductKernel(self, other)
+
+
+class AdditiveKernel(Kernel):
+    def __init__(self, kernel_1, kernel_2):
+        super(AdditiveKernel, self).__init__()
+        self.kernel_1 = kernel_1
+        self.kernel_2 = kernel_2
+
+    def forward(self, x1, x2):
+        return self.kernel_1(x1, x2) + self.kernel_2(x1, x2)
+
+
+class ProductKernel(Kernel):
+    def __init__(self, kernel_1, kernel_2):
+        super(ProductKernel, self).__init__()
+        self.kernel_1 = kernel_1
+        self.kernel_2 = kernel_2
+
+    def forward(self, x1, x2):
+        return self.kernel_1(x1, x2) * self.kernel_2(x1, x2)

--- a/gpytorch/kernels/linear_kernel.py
+++ b/gpytorch/kernels/linear_kernel.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import torch
+from torch import nn
+from ..lazy.matmul_lazy_variable import MatmulLazyVariable
+from .kernel import Kernel
+
+
+class LinearKernel(Kernel):
+    def __init__(
+        self,
+        num_dimensions,
+        variance_bounds=(-10000, 10000),
+        offset_bounds=(-10000, 10000),
+        eps=1e-5,
+        active_dims=None,
+    ):
+        super(LinearKernel, self).__init__(active_dims=active_dims)
+        self.eps = eps
+        self.register_parameter(
+            'variance',
+            nn.Parameter(torch.zeros(1)),
+            bounds=variance_bounds,
+        )
+        self.register_parameter(
+            'offset',
+            nn.Parameter(torch.zeros(1, 1, num_dimensions)),
+            bounds=offset_bounds,
+        )
+
+    def forward(self, x1, x2):
+        prod = MatmulLazyVariable(
+            x1 - self.offset,
+            (x2 - self.offset).transpose(2, 1)
+        )
+
+        return prod + self.variance.expand_as(prod)

--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import math
 import torch
 from torch import nn
@@ -5,12 +10,21 @@ from gpytorch.kernels import Kernel
 
 
 class MaternKernel(Kernel):
-    def __init__(self, nu, log_lengthscale_bounds=(-10000, 10000)):
-        super(MaternKernel, self).__init__()
+    def __init__(
+        self,
+        nu,
+        log_lengthscale_bounds=(-10000, 10000),
+        active_dims=None,
+    ):
+        super(MaternKernel, self).__init__(active_dims=active_dims)
         if nu not in [0.5, 1.5, 2.5]:
             raise RuntimeError('nu expected to be 0.5, 1.5, or 2.5')
         self.nu = nu
-        self.register_parameter('log_lengthscale', nn.Parameter(torch.zeros(1, 1, 1)), bounds=log_lengthscale_bounds)
+        self.register_parameter(
+            'log_lengthscale',
+            nn.Parameter(torch.zeros(1, 1, 1)),
+            bounds=log_lengthscale_bounds,
+        )
 
     def forward(self, x1, x2):
         lengthscale = (self.log_lengthscale.exp()).sqrt()

--- a/gpytorch/kernels/multiplicative_grid_interpolation_kernel.py
+++ b/gpytorch/kernels/multiplicative_grid_interpolation_kernel.py
@@ -1,18 +1,42 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from torch.autograd import Variable
 from .grid_interpolation_kernel import GridInterpolationKernel
 from ..utils import Interpolation
 
 
 class MultiplicativeGridInterpolationKernel(GridInterpolationKernel):
-    def __init__(self, base_kernel_module, grid_size, grid_bounds, n_components):
-        super(MultiplicativeGridInterpolationKernel, self).__init__(base_kernel_module, grid_size, grid_bounds)
+    def __init__(
+        self,
+        base_kernel_module,
+        grid_size,
+        grid_bounds,
+        n_components,
+        active_dims=None,
+    ):
+        super(MultiplicativeGridInterpolationKernel, self).__init__(
+            base_kernel_module,
+            grid_size,
+            grid_bounds,
+            active_dims=active_dims
+        )
         self.n_components = n_components
 
     def _compute_grid(self, inputs):
         inputs = inputs.view(inputs.size(0), inputs.size(1), self.n_components, -1)
         batch_size, n_data, n_components, n_dimensions = inputs.size()
-        inputs = inputs.transpose(0, 2).contiguous().view(n_components * batch_size * n_data, n_dimensions)
-        interp_indices, interp_values = Interpolation().interpolate(Variable(self.grid), inputs)
+        inputs = (
+            inputs.transpose(0, 2).
+            contiguous().
+            view(n_components * batch_size * n_data, n_dimensions)
+        )
+        interp_indices, interp_values = (
+            Interpolation().
+            interpolate(Variable(self.grid), inputs)
+        )
         interp_indices = interp_indices.view(n_components * batch_size, n_data, -1)
         interp_values = interp_values.view(n_components * batch_size, n_data, -1)
         return interp_indices, interp_values

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import math
+
+import torch
+from torch import nn
+from .kernel import Kernel
+
+
+class PeriodicKernel(Kernel):
+
+    def __init__(
+        self,
+        log_lengthscale_bounds=(-10000, 10000),
+        log_period_length_bounds=(-10000, 10000),
+        eps=1e-5,
+        active_dims=None,
+    ):
+        super(PeriodicKernel, self).__init__(active_dims=active_dims)
+        self.eps = eps
+        self.register_parameter(
+            'log_lengthscale',
+            nn.Parameter(torch.zeros(1, 1, 1)),
+            bounds=log_lengthscale_bounds,
+        )
+        self.register_parameter(
+            'log_period_length',
+            nn.Parameter(torch.zeros(1, 1, 1)),
+            bounds=log_period_length_bounds,
+        )
+
+    def forward(self, x1, x2):
+        lengthscale = (self.log_lengthscale.exp() + self.eps).sqrt_()
+        period_length = (self.log_period_length.exp() + self.eps).sqrt_()
+        diff = torch.sum((x1.unsqueeze(2) - x2.unsqueeze(1)).abs(), -1)
+        res = - 2 * torch.sin(math.pi * diff / period_length).pow(2) / lengthscale
+        return res.exp()
+

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -1,11 +1,21 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch import nn
 from .kernel import Kernel
 
 
 class RBFKernel(Kernel):
-    def __init__(self, log_lengthscale_bounds=(-10000, 10000), eps=1e-5):
-        super(RBFKernel, self).__init__()
+    def __init__(
+        self,
+        log_lengthscale_bounds=(-10000, 10000),
+        eps=1e-5,
+        active_dims=None,
+    ):
+        super(RBFKernel, self).__init__(active_dims=active_dims)
         self.eps = eps
         self.register_parameter('log_lengthscale', nn.Parameter(torch.zeros(1, 1)),
                                 bounds=log_lengthscale_bounds)

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import math
 import torch
 from torch import nn
@@ -5,12 +10,19 @@ from .kernel import Kernel
 
 
 class SpectralMixtureKernel(Kernel):
-    def __init__(self, n_mixtures, n_dims=1, log_mixture_weight_bounds=(-100, 100),
-                 log_mixture_mean_bounds=(-100, 100), log_mixture_scale_bounds=(-100, 100)):
+    def __init__(
+        self,
+        n_mixtures,
+        n_dims=1,
+        log_mixture_weight_bounds=(-100, 100),
+        log_mixture_mean_bounds=(-100, 100),
+        log_mixture_scale_bounds=(-100, 100),
+        active_dims=None,
+    ):
         self.n_mixtures = n_mixtures
         self.n_dims = n_dims
 
-        super(SpectralMixtureKernel, self).__init__()
+        super(SpectralMixtureKernel, self).__init__(active_dims=active_dims)
         self.register_parameter('log_mixture_weights', nn.Parameter(torch.zeros(self.n_mixtures)),
                                 bounds=log_mixture_weight_bounds)
         self.register_parameter('log_mixture_means', nn.Parameter(torch.zeros(self.n_mixtures, self.n_dims)),

--- a/test/kernels/test_additive_kernel.py
+++ b/test/kernels/test_additive_kernel.py
@@ -1,0 +1,71 @@
+import math
+import torch
+import unittest
+from torch.autograd import Variable
+from gpytorch.kernels import RBFKernel
+
+
+class TestAdditiveKernel(unittest.TestCase):
+    def test_computes_product_of_radial_basis_function(self):
+        a = torch.Tensor([4, 2, 8]).view(3, 1)
+        b = torch.Tensor([0, 2]).view(2, 1)
+        lengthscale = 2
+
+        kernel_1 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel_2 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel = kernel_1 * kernel_2
+        kernel.eval()
+        actual = torch.Tensor([
+            [16, 4],
+            [4, 0],
+            [64, 36],
+        ]).mul_(-1).div_(lengthscale).exp() ** 2
+
+        res = kernel(Variable(a), Variable(b)).data
+        self.assertLess(torch.norm(res - actual), 1e-5)
+
+    def test_computes_sum_of_radial_basis_function(self):
+        a = torch.Tensor([4, 2, 8]).view(3, 1)
+        b = torch.Tensor([0, 2]).view(2, 1)
+        lengthscale = 2
+
+        kernel_1 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel_2 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel = kernel_1 + kernel_2
+        kernel.eval()
+        actual = torch.Tensor([
+            [16, 4],
+            [4, 0],
+            [64, 36],
+        ]).mul_(-1).div_(lengthscale).exp() * 2
+
+        res = kernel(Variable(a), Variable(b)).data
+        self.assertLess(torch.norm(res - actual), 1e-5)
+
+    def test_computes_sum_radial_basis_function_gradient(self):
+        a = torch.Tensor([4, 2, 8]).view(3, 1)
+        b = torch.Tensor([0, 2, 2]).view(3, 1)
+        lengthscale = 2
+
+        kernel_1 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel_2 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel = kernel_1 + kernel_2
+        kernel.eval()
+        param = Variable(
+            torch.Tensor(3, 3).fill_(math.log(lengthscale)),
+            requires_grad=True,
+        )
+        diffs = Variable(a.expand(3, 3) - b.expand(3, 3).transpose(0, 1))
+        actual_output = (-(diffs ** 2) / (param.exp())).exp()
+        actual_output.backward(torch.eye(3))
+        actual_param_grad = param.grad.data.sum() * 2
+
+        output = kernel(Variable(a), Variable(b))
+        output.backward(gradient=torch.eye(3))
+        res = kernel.kernel_1.log_lengthscale.grad.data
+        res += kernel.kernel_2.log_lengthscale.grad.data
+        self.assertLess(torch.norm(res - actual_param_grad), 1e-5)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/kernels/test_linear_kernel.py
+++ b/test/kernels/test_linear_kernel.py
@@ -10,7 +10,7 @@ from gpytorch.kernels import LinearKernel
 
 
 class TestLinearKernel(unittest.TestCase):
-    def test_computes_linear_function(self):
+    def test_computes_linear_function_rectangular(self):
         a = torch.Tensor([4, 2, 8]).view(3, 1)
         b = torch.Tensor([0, 2]).view(2, 1)
 
@@ -23,6 +23,20 @@ class TestLinearKernel(unittest.TestCase):
         kernel.eval()
         actual = 1 + torch.matmul(a, b.t())
         res = kernel(Variable(a), Variable(b)).evaluate()
+        self.assertLess(torch.norm(res.data - actual), 1e-5)
+
+    def test_computes_linear_function_square(self):
+        a = torch.Tensor([4, 2, 8]).view(3, 1)
+
+        kernel = LinearKernel(
+            num_dimensions=1,
+        ).initialize(
+            offset=0,
+            variance=1.0,
+        )
+        kernel.eval()
+        actual = 1 + torch.matmul(a, a.t())
+        res = kernel(Variable(a), Variable(a)).evaluate()
         self.assertLess(torch.norm(res.data - actual), 1e-5)
 
 

--- a/test/kernels/test_linear_kernel.py
+++ b/test/kernels/test_linear_kernel.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import torch
+import unittest
+from torch.autograd import Variable
+from gpytorch.kernels import LinearKernel
+
+
+class TestLinearKernel(unittest.TestCase):
+    def test_computes_linear_function(self):
+        a = torch.Tensor([4, 2, 8]).view(3, 1)
+        b = torch.Tensor([0, 2]).view(2, 1)
+
+        kernel = LinearKernel(
+            num_dimensions=1,
+        ).initialize(
+            offset=0,
+            variance=1.0,
+        )
+        kernel.eval()
+        actual = 1 + torch.matmul(a, b.t())
+        res = kernel(Variable(a), Variable(b)).evaluate()
+        self.assertLess(torch.norm(res.data - actual), 1e-5)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/kernels/test_periodic_kernel.py
+++ b/test/kernels/test_periodic_kernel.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import math
+import torch
+import unittest
+from torch.autograd import Variable
+from gpytorch.kernels import PeriodicKernel
+
+
+class TestPeriodicKernel(unittest.TestCase):
+    def test_computes_periodic_function(self):
+        a = torch.Tensor([4, 2, 8]).view(3, 1)
+        b = torch.Tensor([0, 2]).view(2, 1)
+        lengthscale = 2
+        period = 1
+        kernel = PeriodicKernel().initialize(
+            log_lengthscale=math.log(lengthscale),
+            log_period_length=math.log(period),
+        )
+        kernel.eval()
+
+        actual = torch.zeros(3, 2)
+        for i in range(3):
+            for j in range(2):
+                val = 2 * torch.pow(torch.sin(math.pi * (a[i] - b[j])), 2) / lengthscale
+                actual[i, j] = torch.exp(-val)[0]
+
+        res = kernel(Variable(a), Variable(b)).data
+        self.assertLess(torch.norm(res - actual), 1e-5)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/kernels/test_rbf_kernel.py
+++ b/test/kernels/test_rbf_kernel.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import math
 import torch
 import unittest
@@ -6,6 +11,24 @@ from gpytorch.kernels import RBFKernel
 
 
 class TestRBFKernel(unittest.TestCase):
+    def test_subset_active_compute_radial_basis_function(self):
+        a = torch.Tensor([4, 2, 8]).view(3, 1)
+        a_p = torch.Tensor([1, 2, 3]).view(3, 1)
+        a = torch.cat((a, a_p), 1)
+        b = torch.Tensor([0, 2]).view(2, 1)
+        lengthscale = 2
+
+        kernel = RBFKernel(active_dims=[0]).initialize(log_lengthscale=math.log(lengthscale))
+        kernel.eval()
+        actual = torch.Tensor([
+            [16, 4],
+            [4, 0],
+            [64, 36],
+        ]).mul_(-1).div_(lengthscale).exp()
+
+        res = kernel(Variable(a), Variable(b)).data
+        self.assertLess(torch.norm(res - actual), 1e-5)
+
     def test_computes_radial_basis_function(self):
         a = torch.Tensor([4, 2, 8]).view(3, 1)
         b = torch.Tensor([0, 2]).view(2, 1)
@@ -41,6 +64,30 @@ class TestRBFKernel(unittest.TestCase):
         output = kernel(Variable(a), Variable(b))
         output.backward(gradient=torch.eye(3))
         res = kernel.log_lengthscale.grad.data
+        self.assertLess(torch.norm(res - actual_param_grad), 1e-5)
+
+    def test_subset_active_computes_radial_basis_function_gradient(self):
+        a_1 = torch.Tensor([4, 2, 8]).view(3, 1)
+        a_p = torch.Tensor([1, 2, 3]).view(3, 1)
+        a = torch.cat((a_1, a_p), 1)
+        b = torch.Tensor([0, 2, 2]).view(3, 1)
+        lengthscale = 2
+
+        kernel = RBFKernel(active_dims=[0]).initialize(log_lengthscale=math.log(lengthscale))
+        kernel.eval()
+        param = Variable(
+            torch.Tensor(3, 3).fill_(math.log(lengthscale)),
+            requires_grad=True,
+        )
+        output = kernel(Variable(a), Variable(b))
+        output.backward(gradient=torch.eye(3))
+        res = kernel.log_lengthscale.grad.data
+
+        diffs = Variable(a_1.expand(3, 3) - b.expand(3, 3).transpose(0, 1))
+        actual_output = (-(diffs ** 2) / (param.exp())).exp()
+        actual_output.backward(torch.eye(3))
+        actual_param_grad = param.grad.data.sum()
+
         self.assertLess(torch.norm(res - actual_param_grad), 1e-5)
 
 


### PR DESCRIPTION
This has two new features:
* You can now add two kernels using `+` and `*` and an AdditiveKernel or ProductKernel is returned. 
* `active_dims` can be sent via the constructor to subset dimensions, mirroring the capabilities of GPy

Small items: adding linear and periodic kernel, and adding `six` imports to make sure there aren't python 2.x / 3.x discrepancies