### PR TITLE
Marginal log likelihood (and function factory) refactor

### DIFF
--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -111,7 +111,7 @@ class LazyVariable(object):
         This could potentially be implemented as a no-op, however this could lead to numerical instabilities,
         so this should only be done at the user's risk.
         """
-        diag = Variable(self.tensor_cls(1).fill_(1e-4))
+        diag = Variable(self.tensor_cls(1).fill_(1e-3))
         return self.add_diag(diag)
 
     def cpu(self):
@@ -318,6 +318,7 @@ class LazyVariable(object):
                 dqff = None
             self._inv_matmul_class = function_factory.inv_matmul_factory(self._matmul_closure_factory, dqff)
 
+        # Work out batch dimension, if necessary
         lazy_var = self
         if lazy_var.ndimension() == 3 and tensor.ndimension() == 3:
             if lazy_var.size(0) == 1 and tensor.size(0) > 1:
@@ -327,8 +328,84 @@ class LazyVariable(object):
         elif self.ndimension() > 3 or tensor.ndimension() > 3:
             raise RuntimeError
 
-        args = list(lazy_var.representation()) + [tensor]
-        return lazy_var._inv_matmul_class()(*args)
+        res = lazy_var._inv_matmul_class()(*(list(lazy_var.representation()) + [tensor]))
+        return res
+
+    def inv_quad(self, tensor):
+        """
+        Computes an inverse quadratic form (w.r.t self) with several right hand sides.
+        I.e. computes tr( tensor^T self^{-1} tensor )
+
+        NOTE: Don't overwrite this function!
+        Instead, overwrite inv_quad_log_det
+
+        Args:
+            - tensor (tensor nxk) - Vector (or matrix) for inverse quad
+
+        Returns:
+            - tensor - tr( tensor^T (self)^{-1} tensor )
+        """
+        res, _ = self.inv_quad_log_det(inv_quad_rhs=tensor, log_det=False)
+        return res
+
+    def inv_quad_log_det(self, inv_quad_rhs=None, log_det=False):
+        """
+        Computes an inverse quadratic form (w.r.t self) with several right hand sides.
+        I.e. computes tr( tensor^T self^{-1} tensor )
+        In addition, computes an (approximate) log determinant of the the matrix
+
+        Args:
+            - tensor (tensor nxk) - Vector (or matrix) for inverse quad
+
+        Returns:
+            - scalar - tr( tensor^T (self)^{-1} tensor )
+            - scalar - log determinant
+        """
+        if not hasattr(self, '_inv_quad_log_det_class'):
+            if hasattr(self, '_derivative_quadratic_form_factory'):
+                dqff = self._derivative_quadratic_form_factory
+            else:
+                dqff = None
+            self._inv_quad_log_det_class = function_factory.inv_quad_log_det_factory(self._matmul_closure_factory,
+                                                                                     dqff)
+
+        # Work out batch dimension, if necessary
+        lazy_var = self
+        if inv_quad_rhs is not None:
+            if lazy_var.ndimension() == 3 and inv_quad_rhs.ndimension() == 3:
+                if lazy_var.size(0) == 1 and inv_quad_rhs.size(0) > 1:
+                    lazy_var = lazy_var.repeat(inv_quad_rhs.size(0), 1, 1)
+                elif inv_quad_rhs.size(0) == 1:
+                    inv_quad_rhs = inv_quad_rhs.expand(lazy_var.size(0), inv_quad_rhs.size(1),
+                                                       inv_quad_rhs.size(2))
+            elif self.ndimension() > 3 or inv_quad_rhs.ndimension() > 3:
+                raise RuntimeError
+
+        args = lazy_var.representation()
+        matrix_size = self.size(-1)
+        batch_size = self.size(0) if self.ndimension() == 3 else None
+        tensor_cls = self.tensor_cls
+        if inv_quad_rhs is None:
+            return lazy_var._inv_quad_log_det_class(matrix_size=matrix_size, batch_size=batch_size,
+                                                    tensor_cls=tensor_cls, inv_quad=False,
+                                                    log_det=log_det)(*args)
+        else:
+            return lazy_var._inv_quad_log_det_class(matrix_size=matrix_size, batch_size=batch_size,
+                                                    tensor_cls=tensor_cls, inv_quad=True,
+                                                    log_det=log_det)(*(list(args) + [inv_quad_rhs]))
+
+    def log_det(self):
+        """
+        Computes an (approximate) log determinant of the matrix
+
+        NOTE: Don't overwrite this function!
+        Instead, overwrite inv_quad_log_det
+
+        Returns:
+            - scalar - log determinant
+        """
+        _, res = self.inv_quad_log_det(inv_quad_rhs=None, log_det=True)
+        return res
 
     def matmul(self, tensor):
         """

--- a/gpytorch/mlls/variational_marginal_log_likelihood.py
+++ b/gpytorch/mlls/variational_marginal_log_likelihood.py
@@ -18,7 +18,7 @@ class VariationalMarginalLogLikelihood(MarginalLogLikelihood):
         n_batch = target.size(0)
 
         log_likelihood = self.likelihood.log_probability(output, target).div(n_batch)
-        kl_divergence = sum(variational_strategy.kl_divergence()
+        kl_divergence = sum(variational_strategy.kl_divergence().sum()
                             for variational_strategy in self.model.variational_strategies()).div(self.n_data)
 
         res = log_likelihood - kl_divergence

--- a/gpytorch/utils/__init__.py
+++ b/gpytorch/utils/__init__.py
@@ -46,6 +46,8 @@ def approx_equal(self, other, epsilon=1e-4):
     Returns:
         - bool
     """
+    if self.size() != other.size():
+        raise RuntimeError('Size mismatch between self (%s) and other (%s)' % (str(self.size()), str(other.size())))
     if isinstance(self, Variable):
         self = self.data
     if isinstance(other, Variable):

--- a/gpytorch/variational/mvn_variational_strategy.py
+++ b/gpytorch/variational/mvn_variational_strategy.py
@@ -1,13 +1,16 @@
 import torch
-import gpytorch
 from .variational_strategy import VariationalStrategy
-from ..lazy import RootLazyVariable
+from ..lazy import LazyVariable, NonLazyVariable, RootLazyVariable
 
 
 class MVNVariationalStrategy(VariationalStrategy):
     def kl_divergence(self):
         prior_mean = self.prior_dist.mean()
         prior_covar = self.prior_dist.covar()
+        if not isinstance(prior_covar, LazyVariable):
+            prior_covar = NonLazyVariable(prior_covar)
+        prior_covar = prior_covar.add_jitter()
+
         variational_mean = self.variational_dist.mean()
         variational_covar = self.variational_dist.covar()
         if not isinstance(variational_covar, RootLazyVariable):
@@ -15,7 +18,7 @@ class MVNVariationalStrategy(VariationalStrategy):
         chol_variational_covar = variational_covar.root.evaluate()
 
         mean_diffs = prior_mean - variational_mean
-        chol_variational_covar = chol_variational_covar
+        inv_quad_rhs = torch.cat([chol_variational_covar.transpose(-1, -2), mean_diffs.unsqueeze(-1)], -1)
 
         if chol_variational_covar.ndimension() == 2:
             matrix_diag = chol_variational_covar.diag()
@@ -32,9 +35,14 @@ class MVNVariationalStrategy(VariationalStrategy):
             raise RuntimeError('Invalid number of variational covar dimensions')
 
         logdet_variational_covar = matrix_diag.log().sum() * 2
-        trace_logdet_quad_form = gpytorch.trace_logdet_quad_form(mean_diffs, chol_variational_covar,
-                                                                 gpytorch.add_jitter(prior_covar))
+        trace_plus_inv_quad_form, logdet_prior_covar = prior_covar.inv_quad_log_det(inv_quad_rhs=inv_quad_rhs,
+                                                                                    log_det=True)
 
         # Compute the KL Divergence.
-        res = 0.5 * (trace_logdet_quad_form - logdet_variational_covar - len(mean_diffs))
+        res = 0.5 * sum([
+            logdet_prior_covar,
+            logdet_variational_covar.mul(-1),
+            trace_plus_inv_quad_form,
+            -float(mean_diffs.size(-1)),
+        ])
         return res

--- a/test/lazy/test_sum_lazy_variable.py
+++ b/test/lazy/test_sum_lazy_variable.py
@@ -1,5 +1,4 @@
 import os
-import math
 import torch
 import unittest
 from torch.autograd import Variable
@@ -53,73 +52,6 @@ class TestSumLazyVariable(unittest.TestCase):
                 res.data - (self.t1_eval + self.t2_eval).inverse().matmul(mat)
             ),
             1e-3,
-        )
-
-    def test_exact_gp_mll(self):
-        labels_var = Variable(torch.randn(4))
-
-        # Test case
-        c1_var = Variable(torch.Tensor([5, 1, 2, 0]), requires_grad=True)
-        c2_var = Variable(torch.Tensor([6, 0, 1, -1]), requires_grad=True)
-        actual = ToeplitzLazyVariable(c1_var + c2_var)
-
-        # Actual case
-        sum_lv = make_sum_lazy_var()
-        t1, t2 = sum_lv.lazy_vars
-
-        # Test forward
-        mll_res = sum_lv.exact_gp_marginal_log_likelihood(labels_var)
-        mll_actual = actual.exact_gp_marginal_log_likelihood(labels_var)
-        self.assertLess(
-            math.fabs(mll_res.data.squeeze()[0] - mll_actual.data.squeeze()[0]),
-            5e-1,
-        )
-
-        # Test backwards
-        mll_res.backward()
-        mll_actual.backward()
-        self.assertLess(
-            math.fabs(c1_var.grad.data[0] - t1.column.grad.data[0]),
-            1e-1,
-        )
-        self.assertLess(
-            math.fabs(c2_var.grad.data[0] - t2.column.grad.data[0]),
-            1e-1,
-        )
-
-    def test_trace_log_det_quad_form(self):
-        mu_diffs_var = Variable(torch.randn(4))
-        chol_covar_1_var = Variable(torch.eye(4))
-
-        # Test case
-        c1_var = Variable(torch.Tensor([5, 1, 2, 0]), requires_grad=True)
-        c2_var = Variable(torch.Tensor([6, 0, 1, -1]), requires_grad=True)
-        actual = ToeplitzLazyVariable(c1_var + c2_var)
-
-        # Actual case
-        sum_lv = make_sum_lazy_var()
-        t1, t2 = sum_lv.lazy_vars
-
-        # Test forward
-        tldqf_res = sum_lv.trace_log_det_quad_form(mu_diffs_var, chol_covar_1_var)
-        tldqf_actual = actual.trace_log_det_quad_form(mu_diffs_var, chol_covar_1_var)
-        self.assertLess(
-            math.fabs(
-                tldqf_res.data.squeeze()[0] - tldqf_actual.data.squeeze()[0]
-            ),
-            1.5,
-        )
-
-        # Test backwards
-        tldqf_res.backward()
-        tldqf_actual.backward()
-        self.assertLess(
-            math.fabs(c1_var.grad.data[0] - t1.column.grad.data[0]),
-            1e-1,
-        )
-        self.assertLess(
-            math.fabs(c2_var.grad.data[0] - t2.column.grad.data[0]),
-            1e-1,
         )
 
     def test_getitem(self):

--- a/test/util/test_function_factory.py
+++ b/test/util/test_function_factory.py
@@ -1,242 +1,61 @@
+import os
 import math
 import torch
 import unittest
 import gpytorch
 import numpy as np
 from torch.autograd import Variable
-from gpytorch.utils import approx_equal, function_factory
+from gpytorch.utils import approx_equal
 from gpytorch.lazy import NonLazyVariable
 
 
-_exact_gp_mll_class = function_factory.exact_gp_mll_factory()
-
-
-class TestFunctionFactory(unittest.TestCase):
-    def test_forward_inv_mm(self):
-        for n_cols in [2, 3, 4]:
-            a = torch.Tensor([
-                [5, -3, 0],
-                [-3, 5, 0],
-                [0, 0, 2],
-            ])
-            b = torch.randn(3, n_cols)
-            actual = a.inverse().mm(b)
-
-            a_var = Variable(a)
-            b_var = Variable(b)
-            out_var = gpytorch.inv_matmul(a_var, b_var)
-            res = out_var.data
-
-            self.assertLess(torch.norm(actual - res), 1e-4)
-
-    def test_backward_inv_mm(self):
-        for n_cols in [2, 3, 4]:
-            a = torch.Tensor([
-                [5, -3, 0],
-                [-3, 5, 0],
-                [0, 0, 2],
-            ])
-            b = torch.ones(3, 3).fill_(2)
-            c = torch.randn(3, n_cols)
-            actual_a_grad = -torch.mm(
-                a.inverse().mul_(0.5).mm(torch.eye(3, n_cols)),
-                a.inverse().mul_(0.5).mm(c).t()
-            ) * 2 * 2
-            actual_c_grad = (a.inverse() / 2).t().mm(torch.eye(3, n_cols)) * 2
-
-            a_var = Variable(a, requires_grad=True)
-            c_var = Variable(c, requires_grad=True)
-            out_var = a_var.mul(Variable(b))
-            out_var = gpytorch.inv_matmul(out_var, c_var)
-            out_var = out_var.mul(Variable(torch.eye(3, n_cols))).sum() * 2
-            out_var.backward()
-            a_res = a_var.grad.data
-            c_res = c_var.grad.data
-
-            self.assertLess(torch.norm(actual_a_grad - a_res), 1e-4)
-            self.assertLess(torch.norm(actual_c_grad - c_res), 1e-4)
-
-    def test_forward_inv_mv(self):
-        a = torch.Tensor([
-            [5, -3, 0],
-            [-3, 5, 0],
-            [0, 0, 2],
-        ])
-        b = torch.randn(3)
-        actual = a.inverse().mv(b)
-
-        a_var = Variable(a)
-        b_var = Variable(b)
-        out_var = gpytorch.inv_matmul(a_var, b_var)
-        res = out_var.data
-
-        self.assertLess(torch.norm(actual - res), 1e-4)
-
-    def test_backward_inv_mv(self):
-        a = torch.Tensor([
-            [5, -3, 0],
-            [-3, 5, 0],
-            [0, 0, 2],
-        ])
-        b = torch.ones(3, 3).fill_(2)
-        c = torch.randn(3)
-        actual_a_grad = -(
-            torch.ger(
-                a.inverse().mul_(0.5).mv(torch.ones(3)),
-                a.inverse().mul_(0.5).mv(c)
-            ) * 2 * 2
-        )
-        actual_c_grad = (a.inverse() / 2).t().mv(torch.ones(3)) * 2
-
-        a_var = Variable(a, requires_grad=True)
-        c_var = Variable(c, requires_grad=True)
-        out_var = a_var.mul(Variable(b))
-        out_var = gpytorch.inv_matmul(out_var, c_var)
-        out_var = out_var.sum() * 2
-        out_var.backward()
-        a_res = a_var.grad.data
-        c_res = c_var.grad.data
-
-        self.assertLess(torch.norm(actual_a_grad - a_res), 1e-4)
-        self.assertLess(torch.norm(actual_c_grad - c_res), 1e-4)
-
-    def test_normal_gp_mll_forward(self):
-        covar = torch.Tensor([
+class TestMatmulNonBatch(unittest.TestCase):
+    def setUp(self):
+        mat = torch.Tensor([
             [3, -1, 0],
             [-1, 3, 0],
             [0, 0, 3],
         ])
-        y = torch.randn(3)
+        vec = torch.randn(3)
+        vecs = torch.randn(3, 4)
 
-        actual = y.dot(covar.inverse().mv(y))
-        actual += math.log(np.linalg.det(covar.numpy()))
-        actual += math.log(2 * math.pi) * len(y)
-        actual *= -0.5
+        self.mat_var = Variable(mat, requires_grad=True)
+        self.mat_var_clone = Variable(mat, requires_grad=True)
+        self.vec_var = Variable(vec, requires_grad=True)
+        self.vec_var_clone = Variable(vec, requires_grad=True)
+        self.vecs_var = Variable(vecs, requires_grad=True)
+        self.vecs_var_clone = Variable(vecs, requires_grad=True)
 
-        covarvar = Variable(covar)
-        yvar = Variable(y)
+    def test_matmul_vec(self):
+        # Forward
+        res = NonLazyVariable(self.mat_var).matmul(self.vec_var)
+        actual = self.mat_var_clone.matmul(self.vec_var_clone)
+        self.assertTrue(approx_equal(res, actual))
 
-        res = _exact_gp_mll_class()(covarvar, yvar)
-        for d in torch.abs(actual - res.data).div(res.data):
-            self.assertLess(d, 0.1)
+        # Backward
+        grad_output = torch.Tensor(3)
+        res.backward(gradient=grad_output)
+        actual.backward(gradient=grad_output)
+        self.assertTrue(approx_equal(self.mat_var_clone.grad.data, self.mat_var.grad.data))
+        self.assertTrue(approx_equal(self.vec_var_clone.grad.data, self.vec_var.grad.data))
 
-    def test_normal_gp_mll_backward(self):
-        covar = torch.Tensor([
-            [3, -1, 0],
-            [-1, 3, 0],
-            [0, 0, 3],
-        ])
-        y = torch.randn(3)
+    def test_matmul_multiple_vecs(self):
+        # Forward
+        res = NonLazyVariable(self.mat_var).matmul(self.vecs_var)
+        actual = self.mat_var_clone.matmul(self.vecs_var_clone)
+        self.assertTrue(approx_equal(res, actual))
 
-        covarvar = Variable(covar, requires_grad=True)
-        yvar = Variable(y, requires_grad=True)
-        actual_mat_grad = torch.ger(covar.inverse().mv(y), covar.inverse().mv(y))
-        actual_mat_grad -= covar.inverse()
-        actual_mat_grad *= 0.5
-        actual_mat_grad *= 3  # For grad output
+        # Backward
+        grad_output = torch.Tensor(3, 4)
+        res.backward(gradient=grad_output)
+        actual.backward(gradient=grad_output)
+        self.assertTrue(approx_equal(self.mat_var_clone.grad.data, self.mat_var.grad.data))
+        self.assertTrue(approx_equal(self.vecs_var_clone.grad.data, self.vecs_var.grad.data))
 
-        actual_y_grad = -covar.inverse().mv(y)
-        actual_y_grad *= 3  # For grad output
 
-        covarvar = Variable(covar, requires_grad=True)
-        yvar = Variable(y, requires_grad=True)
-        with gpytorch.settings.num_trace_samples(1000):
-            output = _exact_gp_mll_class()(covarvar, yvar) * 3
-            output.backward()
-
-        self.assertLess(torch.norm(actual_mat_grad - covarvar.grad.data), 1e-1)
-        self.assertLess(torch.norm(actual_y_grad - yvar.grad.data), 1e-4)
-
-        with gpytorch.settings.num_trace_samples(0):
-            covarvar = Variable(covar, requires_grad=True)
-            yvar = Variable(y, requires_grad=True)
-            with gpytorch.settings.num_trace_samples(1000):
-                output = _exact_gp_mll_class()(covarvar, yvar) * 3
-                output.backward()
-
-        self.assertLess(torch.norm(actual_mat_grad - covarvar.grad.data), 1e-1)
-        self.assertLess(torch.norm(actual_y_grad - yvar.grad.data), 1e-4)
-
-    def test_normal_trace_log_det_quad_form_forward(self):
-        covar = torch.Tensor([
-            [3, -1, 0],
-            [-1, 3, 0],
-            [0, 0, 3],
-        ])
-        mu_diffs = torch.Tensor([0, -1, 1])
-        chol_covar = torch.Tensor([
-            [1, -2, 0],
-            [0, 1, -2],
-            [0, 0, 1],
-        ])
-
-        actual = mu_diffs.dot(covar.inverse().matmul(mu_diffs))
-        actual += math.log(np.linalg.det(covar.numpy()))
-        actual += (covar.inverse().matmul(chol_covar.t().matmul(chol_covar))).trace()
-
-        covarvar = Variable(covar)
-        chol_covarvar = Variable(chol_covar)
-        mu_diffsvar = Variable(mu_diffs)
-
-        res = gpytorch.trace_logdet_quad_form(mu_diffsvar, chol_covarvar, covarvar)
-        self.assertTrue((torch.abs(actual - res.data).div(res.data) < 0.1).all())
-
-    def test_normal_trace_log_det_quad_form_backward(self):
-        covar = Variable(torch.Tensor([
-            [3, -1, 0],
-            [-1, 3, 0],
-            [0, 0, 3],
-        ]), requires_grad=True)
-        mu_diffs = Variable(torch.Tensor([0, -1, 1]), requires_grad=True)
-        chol_covar = Variable(torch.Tensor([
-            [1, -2, 0],
-            [0, 1, -2],
-            [0, 0, 1],
-        ]), requires_grad=True)
-
-        actual = mu_diffs.dot(covar.inverse().matmul(mu_diffs))
-        actual += (covar.inverse().matmul(chol_covar.t().matmul(chol_covar))).trace()
-        actual.backward()
-
-        actual_covar_grad = covar.grad.data.clone() + covar.data.inverse()
-        actual_mu_diffs_grad = mu_diffs.grad.data.clone()
-        actual_chol_covar_grad = chol_covar.grad.data.clone()
-
-        covar = Variable(torch.Tensor([
-            [3, -1, 0],
-            [-1, 3, 0],
-            [0, 0, 3],
-        ]), requires_grad=True)
-        mu_diffs = Variable(torch.Tensor([0, -1, 1]), requires_grad=True)
-        chol_covar = Variable(torch.Tensor([
-            [1, -2, 0],
-            [0, 1, -2],
-            [0, 0, 1],
-        ]), requires_grad=True)
-
-        with gpytorch.settings.num_trace_samples(1000):
-            res = gpytorch.trace_logdet_quad_form(mu_diffs, chol_covar, covar)
-            res.backward()
-
-        res_covar_grad = covar.grad.data
-        res_mu_diffs_grad = mu_diffs.grad.data
-        res_chol_covar_grad = chol_covar.grad.data
-
-        self.assertLess(
-            torch.norm(actual_covar_grad - res_covar_grad),
-            1e-1,
-        )
-        self.assertLess(
-            torch.norm(actual_mu_diffs_grad - res_mu_diffs_grad),
-            1e-1,
-        )
-        self.assertLess(
-            torch.norm(actual_chol_covar_grad - res_chol_covar_grad),
-            1e-1,
-        )
-
-    def test_batch_trace_log_det_quad_form_forward(self):
-        covar = torch.Tensor([
+class TestMatmulBatch(unittest.TestCase):
+    def setUp(self):
+        mats = torch.Tensor([
             [
                 [3, -1, 0],
                 [-1, 3, 0],
@@ -247,42 +66,74 @@ class TestFunctionFactory(unittest.TestCase):
                 [1, 0, 10],
             ]
         ])
-        mu_diffs = torch.Tensor([
-            [0, -1, 1],
-            [1, 2, 3]
+        vecs = torch.randn(2, 3, 4)
+
+        self.mats_var = Variable(mats, requires_grad=True)
+        self.mats_var_clone = Variable(mats, requires_grad=True)
+        self.vecs_var = Variable(vecs, requires_grad=True)
+        self.vecs_var_clone = Variable(vecs, requires_grad=True)
+
+    def test_matmul_multiple_vecs(self):
+        # Forward
+        res = NonLazyVariable(self.mats_var).matmul(self.vecs_var)
+        actual = self.mats_var_clone.matmul(self.vecs_var_clone)
+        self.assertTrue(approx_equal(res, actual))
+
+        # Backward
+        grad_output = torch.Tensor(2, 3, 4)
+        res.backward(gradient=grad_output)
+        actual.backward(gradient=grad_output)
+        self.assertTrue(approx_equal(self.mats_var_clone.grad.data, self.mats_var.grad.data))
+        self.assertTrue(approx_equal(self.vecs_var_clone.grad.data, self.vecs_var.grad.data))
+
+
+class TestInvMatmulNonBatch(unittest.TestCase):
+    def setUp(self):
+        mat = torch.Tensor([
+            [3, -1, 0],
+            [-1, 3, 0],
+            [0, 0, 3],
         ])
-        chol_covar = torch.Tensor([
-            [
-                [1, -2, 0],
-                [0, 1, -2],
-                [0, 0, 1],
-            ], [
-                [2, -4, 0],
-                [0, 2, -4],
-                [0, 0, 2],
-            ]
-        ])
+        vec = torch.randn(3)
+        vecs = torch.randn(3, 4)
 
-        actual = mu_diffs[0].dot(covar[0].inverse().matmul(mu_diffs[0]))
-        actual += math.log(np.linalg.det(covar[0].numpy()))
-        actual += (
-            covar[0].inverse().matmul(chol_covar[0].t().matmul(chol_covar[0]))
-        ).trace()
-        actual += mu_diffs[1].dot(covar[1].inverse().matmul(mu_diffs[1]))
-        actual += math.log(np.linalg.det(covar[1].numpy()))
-        actual += (
-            covar[1].inverse().matmul(chol_covar[1].t().matmul(chol_covar[1]))
-        ).trace()
+        self.mat_var = Variable(mat, requires_grad=True)
+        self.mat_var_clone = Variable(mat, requires_grad=True)
+        self.vec_var = Variable(vec, requires_grad=True)
+        self.vec_var_clone = Variable(vec, requires_grad=True)
+        self.vecs_var = Variable(vecs, requires_grad=True)
+        self.vecs_var_clone = Variable(vecs, requires_grad=True)
 
-        covarvar = Variable(covar)
-        chol_covarvar = Variable(chol_covar)
-        mu_diffsvar = Variable(mu_diffs)
+    def test_inv_matmul_vec(self):
+        # Forward
+        res = NonLazyVariable(self.mat_var).inv_matmul(self.vec_var)
+        actual = self.mat_var_clone.inverse().matmul(self.vec_var_clone)
+        self.assertTrue(approx_equal(res, actual))
 
-        res = gpytorch.trace_logdet_quad_form(mu_diffsvar, chol_covarvar, covarvar)
-        self.assertTrue((torch.abs(actual - res.data).div(res.data) < 0.1).all())
+        # Backward
+        grad_output = torch.randn(3)
+        res.backward(gradient=grad_output)
+        actual.backward(gradient=grad_output)
+        self.assertTrue(approx_equal(self.mat_var_clone.grad.data, self.mat_var.grad.data))
+        self.assertTrue(approx_equal(self.vec_var_clone.grad.data, self.vec_var.grad.data))
 
-    def test_batch_trace_log_det_quad_form_backward(self):
-        covar = Variable(torch.Tensor([
+    def test_inv_matmul_multiple_vecs(self):
+        # Forward
+        res = NonLazyVariable(self.mat_var).inv_matmul(self.vecs_var)
+        actual = self.mat_var_clone.inverse().matmul(self.vecs_var_clone)
+        self.assertTrue(approx_equal(res, actual))
+
+        # Backward
+        grad_output = torch.randn(3, 4)
+        res.backward(gradient=grad_output)
+        actual.backward(gradient=grad_output)
+        self.assertTrue(approx_equal(self.mat_var_clone.grad.data, self.mat_var.grad.data))
+        self.assertTrue(approx_equal(self.vecs_var_clone.grad.data, self.vecs_var.grad.data))
+
+
+class TestInvMatmulBatch(unittest.TestCase):
+    def setUp(self):
+        mats = torch.Tensor([
             [
                 [3, -1, 0],
                 [-1, 3, 0],
@@ -292,120 +143,275 @@ class TestFunctionFactory(unittest.TestCase):
                 [-2, 10, 0],
                 [1, 0, 10],
             ]
-        ]), requires_grad=True)
-        mu_diffs = Variable(torch.Tensor([
-            [0, -1, 1],
-            [1, 2, 3]
-        ]), requires_grad=True)
-        chol_covar = Variable(torch.Tensor([
-            [
-                [1, -2, 0],
-                [0, 1, -2],
-                [0, 0, 1],
-            ], [
-                [2, -4, 0],
-                [0, 2, -4],
-                [0, 0, 2],
-            ]
-        ]), requires_grad=True)
+        ])
+        vecs = torch.randn(2, 3, 4)
 
-        actual = mu_diffs[0].dot(covar[0].inverse().matmul(mu_diffs[0]))
-        actual += (
-            covar[0].inverse().matmul(chol_covar[0].t().matmul(chol_covar[0]))
-        ).trace()
-        actual += mu_diffs[1].dot(covar[1].inverse().matmul(mu_diffs[1]))
-        actual += (
-            covar[1].inverse().matmul(chol_covar[1].t().matmul(chol_covar[1]))
-        ).trace()
-        actual.backward()
+        self.mats_var = Variable(mats, requires_grad=True)
+        self.mats_var_clone = Variable(mats, requires_grad=True)
+        self.vecs_var = Variable(vecs, requires_grad=True)
+        self.vecs_var_clone = Variable(vecs, requires_grad=True)
 
-        actual_covar_grad = (
-            covar.grad.data.clone() +
-            torch.cat([
-                covar[0].data.inverse().unsqueeze(0),
-                covar[1].data.inverse().unsqueeze(0)]
-            )
-        )
-        actual_mu_diffs_grad = mu_diffs.grad.data.clone()
-        actual_chol_covar_grad = chol_covar.grad.data.clone()
+    def test_inv_matmul_multiple_vecs(self):
+        # Forward
+        res = NonLazyVariable(self.mats_var).inv_matmul(self.vecs_var)
+        actual = torch.cat([
+            self.mats_var_clone[0].inverse().unsqueeze(0),
+            self.mats_var_clone[1].inverse().unsqueeze(0),
+        ]).matmul(self.vecs_var_clone)
+        self.assertTrue(approx_equal(res, actual))
 
-        covar.grad.data.fill_(0)
-        mu_diffs.grad.data.fill_(0)
-        chol_covar.grad.data.fill_(0)
+        # Backward
+        grad_output = torch.randn(2, 3, 4)
+        res.backward(gradient=grad_output)
+        actual.backward(gradient=grad_output)
+        self.assertTrue(approx_equal(self.mats_var_clone.grad.data, self.mats_var.grad.data))
+        self.assertTrue(approx_equal(self.vecs_var_clone.grad.data, self.vecs_var.grad.data))
+
+
+class TestInvQuadLogDetNonBatch(unittest.TestCase):
+    def setUp(self):
+        if os.getenv('UNLOCK_SEED') is None or os.getenv('UNLOCK_SEED').lower() == 'false':
+            self.rng_state = torch.get_rng_state()
+            torch.manual_seed(1)
+
+        mat = torch.Tensor([
+            [3, -1, 0],
+            [-1, 3, 0],
+            [0, 0, 3],
+        ])
+        vec = torch.randn(3)
+        vecs = torch.randn(3, 4)
+
+        self.mat_var = Variable(mat, requires_grad=True)
+        self.vec_var = Variable(vec, requires_grad=True)
+        self.vecs_var = Variable(vecs, requires_grad=True)
+        self.mat_var_clone = Variable(mat, requires_grad=True)
+        self.vec_var_clone = Variable(vec, requires_grad=True)
+        self.vecs_var_clone = Variable(vecs, requires_grad=True)
+        self.log_det = math.log(np.linalg.det(mat.numpy()))
+
+    def tearDown(self):
+        if hasattr(self, 'rng_state'):
+            torch.set_rng_state(self.rng_state)
+
+    def test_inv_quad_log_det_vector(self):
+        # Forward pass
+        actual_inv_quad = self.mat_var_clone.inverse().matmul(self.vec_var_clone).dot(self.vec_var_clone)
         with gpytorch.settings.num_trace_samples(1000):
-            res = gpytorch.trace_logdet_quad_form(mu_diffs, chol_covar, covar)
-            res.backward()
+            nlv = NonLazyVariable(self.mat_var)
+            res_inv_quad, res_log_det = nlv.inv_quad_log_det(inv_quad_rhs=self.vec_var, log_det=True)
+        self.assertAlmostEqual(res_inv_quad.data[0], actual_inv_quad.data[0], places=1)
+        self.assertAlmostEqual(res_log_det.data[0], self.log_det, places=1)
 
-        res_covar_grad = covar.grad.data
-        res_mu_diffs_grad = mu_diffs.grad.data
-        res_chol_covar_grad = chol_covar.grad.data
+        # Backward
+        inv_quad_grad_output = torch.Tensor([3])
+        log_det_grad_output = torch.Tensor([4])
+        actual_inv_quad.backward(gradient=inv_quad_grad_output)
+        self.mat_var_clone.grad.data.add_(self.mat_var_clone.data.inverse() * log_det_grad_output)
+        res_inv_quad.backward(gradient=inv_quad_grad_output, retain_graph=True)
+        res_log_det.backward(gradient=log_det_grad_output)
 
-        self.assertLess(torch.norm(actual_covar_grad - res_covar_grad), 1e-1)
-        self.assertLess(torch.norm(actual_mu_diffs_grad - res_mu_diffs_grad), 1e-1)
-        self.assertLess(torch.norm(actual_chol_covar_grad - res_chol_covar_grad), 1e-1)
+        self.assertTrue(approx_equal(self.mat_var_clone.grad.data, self.mat_var.grad.data, epsilon=1e-1))
+        self.assertTrue(approx_equal(self.vec_var_clone.grad.data, self.vec_var.grad.data))
 
-    def test_root_decomposition_forward(self):
-        a = torch.randn(5, 5)
-        a = torch.matmul(a, a.t())
+    def test_inv_quad_only_vector(self):
+        # Forward pass
+        res = NonLazyVariable(self.mat_var).inv_quad(self.vec_var)
+        actual = self.mat_var_clone.inverse().matmul(self.vec_var_clone).mul(self.vec_var_clone).sum()
+        self.assertAlmostEqual(res.data[0], actual.data[0], places=1)
 
-        a_lv = NonLazyVariable(Variable(a, requires_grad=True))
-        a_root = a_lv.root_decomposition()
+        # Backward
+        inv_quad_grad_output = torch.randn(1)
+        actual.backward(gradient=inv_quad_grad_output)
+        res.backward(gradient=inv_quad_grad_output)
 
-        self.assertLess(
-            torch.max(((a_root.matmul(a_root.transpose(-1, -2)).data - a)).abs()),
-            1e-2,
-        )
+        self.assertTrue(approx_equal(self.mat_var_clone.grad.data, self.mat_var.grad.data, epsilon=1e-1))
+        self.assertTrue(approx_equal(self.vec_var_clone.grad.data, self.vec_var.grad.data))
 
-    def test_root_decomposition_backward(self):
-        a = torch.Tensor([
+    def test_inv_quad_log_det_many_vectors(self):
+        # Forward pass
+        actual_inv_quad = self.mat_var_clone.inverse().matmul(self.vecs_var_clone).dot(self.vecs_var_clone)
+        with gpytorch.settings.num_trace_samples(1000):
+            nlv = NonLazyVariable(self.mat_var)
+            res_inv_quad, res_log_det = nlv.inv_quad_log_det(inv_quad_rhs=self.vecs_var, log_det=True)
+        self.assertAlmostEqual(res_inv_quad.data[0], actual_inv_quad.data[0], places=1)
+        self.assertAlmostEqual(res_log_det.data[0], self.log_det, places=1)
+
+        # Backward
+        inv_quad_grad_output = torch.Tensor([3])
+        log_det_grad_output = torch.Tensor([4])
+        actual_inv_quad.backward(gradient=inv_quad_grad_output)
+        self.mat_var_clone.grad.data.add_(self.mat_var_clone.data.inverse() * log_det_grad_output)
+        res_inv_quad.backward(gradient=inv_quad_grad_output, retain_graph=True)
+        res_log_det.backward(gradient=log_det_grad_output)
+
+        self.assertTrue(approx_equal(self.mat_var_clone.grad.data, self.mat_var.grad.data, epsilon=1e-1))
+        self.assertTrue(approx_equal(self.vecs_var_clone.grad.data, self.vecs_var.grad.data))
+
+    def test_inv_quad_only_many_vectors(self):
+        # Forward pass
+        res = NonLazyVariable(self.mat_var).inv_quad(self.vecs_var)
+        actual = self.mat_var_clone.inverse().matmul(self.vecs_var_clone).mul(self.vecs_var_clone).sum()
+        self.assertAlmostEqual(res.data[0], actual.data[0], places=1)
+
+        # Backward
+        inv_quad_grad_output = torch.randn(1)
+        actual.backward(gradient=inv_quad_grad_output)
+        res.backward(gradient=inv_quad_grad_output)
+
+        self.assertTrue(approx_equal(self.mat_var_clone.grad.data, self.mat_var.grad.data, epsilon=1e-1))
+        self.assertTrue(approx_equal(self.vecs_var_clone.grad.data, self.vecs_var.grad.data))
+
+    def test_log_det_only(self):
+        # Forward pass
+        with gpytorch.settings.num_trace_samples(1000):
+            res = NonLazyVariable(self.mat_var).log_det()
+        self.assertAlmostEqual(res.data[0], self.log_det, places=1)
+
+        # Backward
+        grad_output = torch.Tensor([3])
+        actual_mat_grad = self.mat_var_clone.data.inverse().mul(grad_output)
+        res.backward(gradient=grad_output)
+        self.assertTrue(approx_equal(actual_mat_grad, self.mat_var.grad.data, epsilon=1e-1))
+
+
+class TestInvQuadLogDetBatch(unittest.TestCase):
+    def setUp(self):
+        if os.getenv('UNLOCK_SEED') is None or os.getenv('UNLOCK_SEED').lower() == 'false':
+            self.rng_state = torch.get_rng_state()
+            torch.manual_seed(1)
+
+        mats = torch.Tensor([
+            [
+                [3, -1, 0],
+                [-1, 3, 0],
+                [0, 0, 3],
+            ], [
+                [10, -2, 1],
+                [-2, 10, 0],
+                [1, 0, 10],
+            ]
+        ])
+        vecs = torch.randn(2, 3, 4)
+
+        self.mats_var = Variable(mats, requires_grad=True)
+        self.vecs_var = Variable(vecs, requires_grad=True)
+        self.mats_var_clone = Variable(mats, requires_grad=True)
+        self.vecs_var_clone = Variable(vecs, requires_grad=True)
+        self.log_dets = torch.Tensor([
+            math.log(np.linalg.det(mats[0].numpy())),
+            math.log(np.linalg.det(mats[1].numpy())),
+        ])
+
+    def tearDown(self):
+        if hasattr(self, 'rng_state'):
+            torch.set_rng_state(self.rng_state)
+
+    def test_inv_quad_log_det_many_vectors(self):
+        # Forward pass
+        actual_inv_quad = torch.cat([
+            self.mats_var_clone[0].inverse().unsqueeze(0),
+            self.mats_var_clone[1].inverse().unsqueeze(0),
+        ]).matmul(self.vecs_var_clone).mul(self.vecs_var_clone).sum(2).sum(1)
+        with gpytorch.settings.num_trace_samples(1000):
+            nlv = NonLazyVariable(self.mats_var)
+            res_inv_quad, res_log_det = nlv.inv_quad_log_det(inv_quad_rhs=self.vecs_var, log_det=True)
+        for i in range(self.mats_var.size(0)):
+            self.assertAlmostEqual(res_inv_quad.data[i], actual_inv_quad.data[i], places=1)
+            self.assertAlmostEqual(res_log_det.data[i], self.log_dets[i], places=1)
+
+        # Backward
+        inv_quad_grad_output = torch.Tensor([3, 4])
+        log_det_grad_output = torch.Tensor([4, 2])
+        actual_inv_quad.backward(gradient=inv_quad_grad_output)
+        mat_log_det_grad = torch.cat([
+            self.mats_var_clone[0].data.inverse().mul(log_det_grad_output[0]).unsqueeze(0),
+            self.mats_var_clone[1].data.inverse().mul(log_det_grad_output[1]).unsqueeze(0),
+        ])
+        self.mats_var_clone.grad.data.add_(mat_log_det_grad)
+        res_inv_quad.backward(gradient=inv_quad_grad_output, retain_graph=True)
+        res_log_det.backward(gradient=log_det_grad_output)
+
+        self.assertTrue(approx_equal(self.mats_var_clone.grad.data, self.mats_var.grad.data, epsilon=1e-1))
+        self.assertTrue(approx_equal(self.vecs_var_clone.grad.data, self.vecs_var.grad.data))
+
+    def test_inv_quad_only_many_vectors(self):
+        # Forward pass
+        res = NonLazyVariable(self.mats_var).inv_quad(self.vecs_var)
+        actual = torch.cat([
+            self.mats_var_clone[0].inverse().unsqueeze(0),
+            self.mats_var_clone[1].inverse().unsqueeze(0),
+        ]).matmul(self.vecs_var_clone).mul(self.vecs_var_clone).sum(2).sum(1)
+        for i in range(self.mats_var.size(0)):
+            self.assertAlmostEqual(res.data[i], actual.data[i], places=1)
+
+        # Backward
+        inv_quad_grad_output = torch.randn(2)
+        actual.backward(gradient=inv_quad_grad_output)
+        res.backward(gradient=inv_quad_grad_output)
+
+        self.assertTrue(approx_equal(self.mats_var_clone.grad.data, self.mats_var.grad.data, epsilon=1e-1))
+        self.assertTrue(approx_equal(self.vecs_var_clone.grad.data, self.vecs_var.grad.data))
+
+    def test_log_det_only(self):
+        # Forward pass
+        with gpytorch.settings.num_trace_samples(1000):
+            res = NonLazyVariable(self.mats_var).log_det()
+        for i in range(self.mats_var.size(0)):
+            self.assertAlmostEqual(res.data[i], self.log_dets[i], places=1)
+
+        # Backward
+        grad_output = torch.Tensor([3, 4])
+        actual_mat_grad = torch.cat([
+            self.mats_var_clone[0].data.inverse().mul(grad_output[0]).unsqueeze(0),
+            self.mats_var_clone[1].data.inverse().mul(grad_output[1]).unsqueeze(0),
+        ])
+        res.backward(gradient=grad_output)
+        self.assertTrue(approx_equal(actual_mat_grad, self.mats_var.grad.data, epsilon=1e-1))
+
+
+class TestRootDecomposition(unittest.TestCase):
+    def setUp(self):
+        if os.getenv('UNLOCK_SEED') is None or os.getenv('UNLOCK_SEED').lower() == 'false':
+            self.rng_state = torch.get_rng_state()
+            torch.manual_seed(0)
+
+        mat = torch.Tensor([
             [5.0212, 0.5504, -0.1810, 1.5414, 2.9611],
             [0.5504, 2.8000, 1.9944, 0.6208, -0.8902],
             [-0.1810, 1.9944, 3.0505, 1.0790, -1.1774],
             [1.5414, 0.6208, 1.0790, 2.9430, 0.4170],
             [2.9611, -0.8902, -1.1774, 0.4170, 3.3208],
         ])
+        self.mat_var = Variable(mat, requires_grad=True)
+        self.mat_var_clone = Variable(mat, requires_grad=True)
 
-        a_var = Variable(a, requires_grad=True)
-        a_lv = NonLazyVariable(a_var)
-        a_root = a_lv.root_decomposition()
-        res = a_root.matmul(a_root.transpose(-1, -2))
+    def tearDown(self):
+        if hasattr(self, 'rng_state'):
+            torch.set_rng_state(self.rng_state)
+
+    def test_root_decomposition(self):
+        # Forward
+        root = NonLazyVariable(self.mat_var).root_decomposition()
+        res = root.matmul(root.transpose(-1, -2))
+        self.assertTrue(approx_equal(res.data, self.mat_var.data))
+
+        # Backward
         res.trace().backward()
+        self.mat_var_clone.trace().backward()
+        self.assertTrue(approx_equal(self.mat_var.grad.data, self.mat_var_clone.grad.data))
 
-        a_var_copy = Variable(a, requires_grad=True)
-        a_var_copy.trace().backward()
+    def test_root_inv_decomposition(self):
+        # Forward
+        root = NonLazyVariable(self.mat_var).root_inv_decomposition()
+        res = root.matmul(root.transpose(-1, -2))
+        actual = self.mat_var_clone.inverse()
+        self.assertTrue(approx_equal(res.data, actual.data))
 
-        self.assertTrue(approx_equal(a_var.grad.data, a_var_copy.grad.data))
-
-    def test_root_decomposition_inv_forward(self):
-        a = torch.randn(5, 5)
-        a = torch.matmul(a, a.t())
-
-        a_lv = NonLazyVariable(Variable(a, requires_grad=True))
-        a_root = a_lv.root_inv_decomposition()
-
-        actual = a.inverse()
-        diff = (a_root.matmul(a_root.transpose(-1, -2)).data - actual).abs()
-        self.assertLess(torch.max(diff / actual), 1e-2)
-
-    def test_root_decomposition_inv_backward(self):
-        a = torch.Tensor([
-            [5.0212, 0.5504, -0.1810, 1.5414, 2.9611],
-            [0.5504, 2.8000, 1.9944, 0.6208, -0.8902],
-            [-0.1810, 1.9944, 3.0505, 1.0790, -1.1774],
-            [1.5414, 0.6208, 1.0790, 2.9430, 0.4170],
-            [2.9611, -0.8902, -1.1774, 0.4170, 3.3208],
-        ])
-
-        a_var = Variable(a, requires_grad=True)
-        a_lv = NonLazyVariable(a_var)
-        a_root = a_lv.root_inv_decomposition()
-        res = a_root.matmul(a_root.transpose(-1, -2))
+        # Backward
         res.trace().backward()
-
-        a_var_copy = Variable(a, requires_grad=True)
-        a_var_copy.inverse().trace().backward()
-
-        self.assertTrue(approx_equal(a_var.grad.data, a_var_copy.grad.data))
+        actual.trace().backward()
+        self.assertTrue(approx_equal(self.mat_var.grad.data, self.mat_var_clone.grad.data))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit simplifies the functions in function factory.

## TLDR
- Remove `exact_gp_mll` and `trace_log_det_quad_form`
- MLL computations (exact and variational) now use new function factory function: `inv_quad_log_det`
- Introduce new functions: `inv_quad` and `log_det`.

## Long
This PR removes the two functions that were specific to marginal log likelihood computations (`exact_gp_mll`, `trace_log_det_quad_form`) and adds a more generic function: `inv_quad_log_det`.

`inv_quad_log_det` computes an inverse quadratic form `tr( A^T K^{-1} A)` and a log determinant `K^{-1}`. These two functions are grouped together to minimize the number of calls to LinearCG. Using this function, marginal log likelihood computations for exact and variational inference only require one round of LinearCG for both forward and backward passes.

There are also helper functions `inv_quad` and `log_det`, which utilize `inv_quad_log_det`. This will be useful for variational inference with different covariance parameterizations.