### PR TITLE
Implement ARD, simplify RBF Kernel

### DIFF
--- a/gpytorch/kernels/grid_interpolation_kernel.py
+++ b/gpytorch/kernels/grid_interpolation_kernel.py
@@ -11,41 +11,63 @@ from ..utils import Interpolation
 
 
 class GridInterpolationKernel(GridKernel):
-    def __init__(self, base_kernel_module, grid_size, grid_bounds, active_dims=None):
+
+    def __init__(
+        self,
+        base_kernel_module,
+        grid_size,
+        grid_bounds,
+        active_dims=None,
+    ):
         grid = torch.zeros(len(grid_bounds), grid_size)
         for i in range(len(grid_bounds)):
             grid_diff = float(grid_bounds[i][1] - grid_bounds[i][0]) / (grid_size - 2)
-            grid[i] = torch.linspace(grid_bounds[i][0] - grid_diff,
-                                     grid_bounds[i][1] + grid_diff,
-                                     grid_size)
+            grid[i] = torch.linspace(
+                grid_bounds[i][0] - grid_diff,
+                grid_bounds[i][1] + grid_diff,
+                grid_size,
+            )
 
-        inducing_points = torch.zeros(int(pow(grid_size, len(grid_bounds))), len(grid_bounds))
+        inducing_points = torch.zeros(
+            int(pow(grid_size, len(grid_bounds))),
+            len(grid_bounds),
+        )
         prev_points = None
         for i in range(len(grid_bounds)):
             for j in range(grid_size):
-                inducing_points[j * grid_size ** i:(j + 1) * grid_size ** i, i].fill_(grid[i, j])
+                inducing_points[
+                    j * grid_size ** i:(j + 1) * grid_size ** i, i
+                ].fill_(grid[i, j])
                 if prev_points is not None:
-                    inducing_points[j * grid_size ** i:(j + 1) * grid_size ** i, :i].copy_(prev_points)
+                    inducing_points[
+                        j * grid_size ** i:(j + 1) * grid_size ** i, :i
+                    ].copy_(prev_points)
             prev_points = inducing_points[:grid_size ** (i + 1), :(i + 1)]
 
         super(GridInterpolationKernel, self).__init__(
-            base_kernel_module,
-            inducing_points,
-            grid,
+            base_kernel_module=base_kernel_module,
+            inducing_points=inducing_points,
+            grid=grid,
             active_dims=active_dims,
         )
 
     def _compute_grid(self, inputs):
         batch_size, n_data, n_dimensions = inputs.size()
         inputs = inputs.view(batch_size * n_data, n_dimensions)
-        interp_indices, interp_values = Interpolation().interpolate(Variable(self.grid), inputs)
+        interp_indices, interp_values = Interpolation().interpolate(
+            Variable(self.grid),
+            inputs,
+        )
         interp_indices = interp_indices.view(batch_size, n_data, -1)
         interp_values = interp_values.view(batch_size, n_data, -1)
         return interp_indices, interp_values
 
     def _inducing_forward(self):
         inducing_points_var = Variable(self.inducing_points)
-        return super(GridInterpolationKernel, self).forward(inducing_points_var, inducing_points_var)
+        return super(GridInterpolationKernel, self).forward(
+            inducing_points_var,
+            inducing_points_var,
+        )
 
     def forward(self, x1, x2, **kwargs):
         base_lazy_var = self._inducing_forward()
@@ -58,5 +80,10 @@ class GridInterpolationKernel(GridKernel):
             right_interp_values = left_interp_values
         else:
             right_interp_indices, right_interp_values = self._compute_grid(x2)
-        return InterpolatedLazyVariable(base_lazy_var, left_interp_indices, left_interp_values,
-                                        right_interp_indices, right_interp_values)
+        return InterpolatedLazyVariable(
+            base_lazy_var,
+            left_interp_indices,
+            left_interp_values,
+            right_interp_indices,
+            right_interp_values,
+        )

--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -11,7 +11,14 @@ from .. import settings
 
 
 class GridKernel(Kernel):
-    def __init__(self, base_kernel_module, inducing_points, grid, active_dims=None):
+
+    def __init__(
+        self,
+        base_kernel_module,
+        inducing_points,
+        grid,
+        active_dims=None,
+    ):
         super(GridKernel, self).__init__(active_dims=active_dims)
         self.base_kernel_module = base_kernel_module
         if inducing_points.ndimension() != 2:
@@ -25,8 +32,13 @@ class GridKernel(Kernel):
         return super(GridKernel, self).train(mode)
 
     def forward(self, x1, x2, **kwargs):
-        if not torch.equal(x1.data, self.inducing_points) or not torch.equal(x2.data, self.inducing_points):
-            raise RuntimeError('The kernel should only receive the inducing points as input')
+        if (
+            not torch.equal(x1.data, self.inducing_points)
+            or not torch.equal(x2.data, self.inducing_points)
+        ):
+            raise RuntimeError(
+                'The kernel should only receive the inducing points as input'
+            )
 
         if not self.training and hasattr(self, '_cached_kernel_mat'):
             return self._cached_kernel_mat
@@ -38,7 +50,10 @@ class GridKernel(Kernel):
             if settings.use_toeplitz.on():
                 first_item = grid_var[:, 0:1].contiguous()
                 covar_columns = self.base_kernel_module(first_item, grid_var, **kwargs)
-                covars = [ToeplitzLazyVariable(covar_columns[i:i + 1].squeeze(-2)) for i in range(n_dim)]
+                covars = [
+                    ToeplitzLazyVariable(covar_columns[i:i + 1].squeeze(-2))
+                    for i in range(n_dim)
+                ]
             else:
                 grid_var = grid_var.view(n_dim, -1, 1)
                 covars = self.base_kernel_module(grid_var, grid_var, **kwargs)

--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -33,8 +33,8 @@ class GridKernel(Kernel):
 
     def forward(self, x1, x2, **kwargs):
         if (
-            not torch.equal(x1.data, self.inducing_points)
-            or not torch.equal(x2.data, self.inducing_points)
+            not torch.equal(x1.data, self.inducing_points) or
+            not torch.equal(x2.data, self.inducing_points)
         ):
             raise RuntimeError(
                 'The kernel should only receive the inducing points as input'

--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -9,6 +9,7 @@ from .kernel import Kernel
 
 
 class IndexKernel(Kernel):
+
     def __init__(
         self,
         n_tasks,

--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -38,9 +38,9 @@ class MaternKernel(Kernel):
         x1_t_x_2 = torch.matmul(x1_normed, x2_normed.transpose(-1, -2))
 
         distance_over_rho = (
-            x1_squared.unsqueeze(-1)
-            + x2_squared.unsqueeze(-2)
-            - x1_t_x_2.mul(2)
+            x1_squared.unsqueeze(-1) +
+            x2_squared.unsqueeze(-2) -
+            x1_t_x_2.mul(2)
         )
         distance_over_rho = distance_over_rho.clamp(0, 1e10).sqrt()
         exp_component = torch.exp(-math.sqrt(self.nu * 2) * distance_over_rho)

--- a/gpytorch/kernels/multiplicative_grid_interpolation_kernel.py
+++ b/gpytorch/kernels/multiplicative_grid_interpolation_kernel.py
@@ -9,6 +9,7 @@ from ..utils import Interpolation
 
 
 class MultiplicativeGridInterpolationKernel(GridInterpolationKernel):
+
     def __init__(
         self,
         base_kernel_module,
@@ -18,9 +19,9 @@ class MultiplicativeGridInterpolationKernel(GridInterpolationKernel):
         active_dims=None,
     ):
         super(MultiplicativeGridInterpolationKernel, self).__init__(
-            base_kernel_module,
-            grid_size,
-            grid_bounds,
+            base_kernel_module=base_kernel_module,
+            grid_size=grid_size,
+            grid_bounds=grid_bounds,
             active_dims=active_dims
         )
         self.n_components = n_components

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -27,7 +27,7 @@ class PeriodicKernel(Kernel):
         self.eps = eps
         self.register_parameter(
             'log_period_length',
-            nn.Parameter(torch.zeros(1, 1)),
+            nn.Parameter(torch.zeros(1, 1, 1)),
             bounds=log_period_length_bounds,
         )
 
@@ -36,4 +36,4 @@ class PeriodicKernel(Kernel):
         period_length = (self.log_period_length.exp() + self.eps).sqrt_()
         diff = torch.sum((x1.unsqueeze(2) - x2.unsqueeze(1)).abs(), -1)
         res = - 2 * torch.sin(math.pi * diff / period_length).pow(2) / lengthscale
-        return res.exp().unsqueeze(1)
+        return res.exp()

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -19,16 +19,15 @@ class PeriodicKernel(Kernel):
         eps=1e-5,
         active_dims=None,
     ):
-        super(PeriodicKernel, self).__init__(active_dims=active_dims)
+        super(PeriodicKernel, self).__init__(
+            has_lengthscale=True,
+            log_lengthscale_bounds=log_lengthscale_bounds,
+            active_dims=active_dims,
+        )
         self.eps = eps
         self.register_parameter(
-            'log_lengthscale',
-            nn.Parameter(torch.zeros(1, 1, 1)),
-            bounds=log_lengthscale_bounds,
-        )
-        self.register_parameter(
             'log_period_length',
-            nn.Parameter(torch.zeros(1, 1, 1)),
+            nn.Parameter(torch.zeros(1, 1)),
             bounds=log_period_length_bounds,
         )
 
@@ -37,4 +36,4 @@ class PeriodicKernel(Kernel):
         period_length = (self.log_period_length.exp() + self.eps).sqrt_()
         diff = torch.sum((x1.unsqueeze(2) - x2.unsqueeze(1)).abs(), -1)
         res = - 2 * torch.sin(math.pi * diff / period_length).pow(2) / lengthscale
-        return res.exp()
+        return res.exp().unsqueeze(1)

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -3,32 +3,27 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import torch
-from torch import nn
 from .kernel import Kernel
 
 
 class RBFKernel(Kernel):
+
     def __init__(
         self,
+        ard_num_dims=None,
         log_lengthscale_bounds=(-10000, 10000),
         eps=1e-5,
         active_dims=None,
     ):
-        super(RBFKernel, self).__init__(active_dims=active_dims)
+        super(RBFKernel, self).__init__(
+            has_lengthscale=True,
+            ard_num_dims=ard_num_dims,
+            log_lengthscale_bounds=log_lengthscale_bounds,
+            active_dims=active_dims,
+        )
         self.eps = eps
-        self.register_parameter('log_lengthscale', nn.Parameter(torch.zeros(1, 1)),
-                                bounds=log_lengthscale_bounds)
 
     def forward(self, x1, x2):
-        lengthscale = (self.log_lengthscale.exp() + self.eps).sqrt_()
-        mean = x1.mean(1).mean(0)
-        x1_normed = (x1 - mean.unsqueeze(0).unsqueeze(1)).div_(lengthscale)
-        x2_normed = (x2 - mean.unsqueeze(0).unsqueeze(1)).div_(lengthscale)
-
-        x1_squared = x1_normed.norm(2, -1).pow(2)
-        x2_squared = x2_normed.norm(2, -1).pow(2)
-        x1_t_x_2 = torch.matmul(x1_normed, x2_normed.transpose(-1, -2))
-        res = (x1_squared.unsqueeze(-1) - x1_t_x_2.mul_(2) + x2_squared.unsqueeze(-2)).mul_(-1)
-        res = res.exp()
-        return res
+        lengthscales = self.log_lengthscale.exp() + self.eps
+        diff = (x1.unsqueeze(2) - x2.unsqueeze(1)).div_(lengthscales.sqrt())
+        return diff.pow_(2).sum(-1).mul_(-1).exp_()

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -10,6 +10,7 @@ from .kernel import Kernel
 
 
 class SpectralMixtureKernel(Kernel):
+
     def __init__(
         self,
         n_mixtures,
@@ -23,12 +24,21 @@ class SpectralMixtureKernel(Kernel):
         self.n_dims = n_dims
 
         super(SpectralMixtureKernel, self).__init__(active_dims=active_dims)
-        self.register_parameter('log_mixture_weights', nn.Parameter(torch.zeros(self.n_mixtures)),
-                                bounds=log_mixture_weight_bounds)
-        self.register_parameter('log_mixture_means', nn.Parameter(torch.zeros(self.n_mixtures, self.n_dims)),
-                                bounds=log_mixture_mean_bounds)
-        self.register_parameter('log_mixture_scales', nn.Parameter(torch.zeros(self.n_mixtures, self.n_dims)),
-                                bounds=log_mixture_scale_bounds)
+        self.register_parameter(
+            'log_mixture_weights',
+            nn.Parameter(torch.zeros(self.n_mixtures)),
+            bounds=log_mixture_weight_bounds,
+        )
+        self.register_parameter(
+            'log_mixture_means',
+            nn.Parameter(torch.zeros(self.n_mixtures, self.n_dims)),
+            bounds=log_mixture_mean_bounds,
+        )
+        self.register_parameter(
+            'log_mixture_scales',
+            nn.Parameter(torch.zeros(self.n_mixtures, self.n_dims)),
+            bounds=log_mixture_scale_bounds,
+        )
 
     def initialize(self, train_x, train_y, **kwargs):
         if not torch.is_tensor(train_x) or not torch.is_tensor(train_y):
@@ -53,7 +63,9 @@ class SpectralMixtureKernel(Kernel):
         batch_size, n, n_dims = x1.size()
         _, m, _ = x2.size()
         if not n_dims == self.n_dims:
-            raise RuntimeError('The number of dimensions doesn\'t match what was supplied!')
+            raise RuntimeError(
+                "The number of dimensions doesn't match what was supplied!"
+            )
 
         mixture_weights = self.log_mixture_weights.view(self.n_mixtures, 1, 1, 1).exp()
         mixture_means = self.log_mixture_means.view(self.n_mixtures, 1, 1, 1, self.n_dims).exp()

--- a/test/kernels/test_rbf_kernel.py
+++ b/test/kernels/test_rbf_kernel.py
@@ -11,6 +11,20 @@ from gpytorch.kernels import RBFKernel
 
 
 class TestRBFKernel(unittest.TestCase):
+
+    def test_ard(self):
+        a = torch.Tensor([[1, 2], [2, 4]])
+        b = torch.Tensor([1, 3]).view(1, 1, 2)
+        lengthscales = torch.Tensor([1, 2]).view(1, 1, 2)
+
+        kernel = RBFKernel(ard_num_dims=2)
+        kernel.initialize(log_lengthscale=lengthscales.log())
+        kernel.eval()
+        actual = (a - b).pow(2).div_(lengthscales).sum(dim=-1).mul_(-1).exp()
+
+        res = kernel(Variable(a), Variable(b)).data
+        self.assertLess(torch.norm(res - actual.unsqueeze(-1)), 1e-5)
+
     def test_subset_active_compute_radial_basis_function(self):
         a = torch.Tensor([4, 2, 8]).view(3, 1)
         a_p = torch.Tensor([1, 2, 3]).view(3, 1)
@@ -18,7 +32,8 @@ class TestRBFKernel(unittest.TestCase):
         b = torch.Tensor([0, 2]).view(2, 1)
         lengthscale = 2
 
-        kernel = RBFKernel(active_dims=[0]).initialize(log_lengthscale=math.log(lengthscale))
+        kernel = RBFKernel(active_dims=[0])
+        kernel.initialize(log_lengthscale=math.log(lengthscale))
         kernel.eval()
         actual = torch.Tensor([
             [16, 4],
@@ -73,7 +88,8 @@ class TestRBFKernel(unittest.TestCase):
         b = torch.Tensor([0, 2, 2]).view(3, 1)
         lengthscale = 2
 
-        kernel = RBFKernel(active_dims=[0]).initialize(log_lengthscale=math.log(lengthscale))
+        kernel = RBFKernel(active_dims=[0])
+        kernel.initialize(log_lengthscale=math.log(lengthscale))
         kernel.eval()
         param = Variable(
             torch.Tensor(3, 3).fill_(math.log(lengthscale)),


### PR DESCRIPTION
Implements ARD on the level of the Kernel class. See https://github.com/cornellius-gp/gpytorch/issues/82 for details. 

In the process, simplify computation of RBFKernel. Previous computation was somewhat messy to get to work for different length scales. Turns out there isn't really a perf hit from doing this (see below).










# Simplify RBF Kernel


```python
import math
import torch
from gpytorch.kernels import RBFKernel
from torch.autograd import Variable
from gpytorch.kernels import Kernel, RBFKernel
```


```python
class RBFKernel_NEW(Kernel):

    def __init__(
        self,
        ard_num_dims=None,
        log_lengthscale_bounds=(-10000, 10000),
        eps=1e-5,
        active_dims=None,
    ):
        super(RBFKernel_NEW, self).__init__(
            has_lengthscale=True,
            ard_num_dims=ard_num_dims,
            log_lengthscale_bounds=log_lengthscale_bounds,
            active_dims=active_dims,
        )
        self.eps = eps

    def forward(self, x1, x2):
        lengthscales = self.log_lengthscale.exp() + self.eps
        diff = (x1.unsqueeze(2) - x2.unsqueeze(1)).div_(lengthscales.sqrt())
        return diff.pow_(2).sum(-1).mul_(-1).exp_()
```

# Basic w/ single lengthscale


```python
a = torch.Tensor([[[1, 2], [2, 4]], [[3, 4], [5, 1]]])
b = torch.Tensor([1, 3]).view(1, 1, 2)
lengthscales = torch.Tensor([1]).view(1, 1, 1)
```


```python
kernel = RBFKernel()
kernel.initialize(log_lengthscale=lengthscales.log())
kernel.eval()
kernel(a, b)
```




    
    (0 ,.,.) = 
      3.6788e-01
      1.3534e-01
    
    (1 ,.,.) = 
      6.7383e-03
      2.0616e-09
    [torch.FloatTensor of size (2,2,1)]




```python
kernel_NEW = RBFKernel_NEW()
kernel_NEW.initialize(log_lengthscale=lengthscales.log())
kernel_NEW.eval()
kernel_NEW(a, b)
```




    
    (0 ,.,.) = 
      3.6788e-01
      1.3534e-01
    
    (1 ,.,.) = 
      6.7383e-03
      2.0616e-09
    [torch.FloatTensor of size (2,2,1)]



# With ARD


```python
lengthscales = torch.Tensor([1, 2]).view(1, 1, 2)
```


```python
kernel = RBFKernel(ard_num_dims=2)
kernel.initialize(log_lengthscale=lengthscales.log())
kernel.eval()
kernel(a, b)
```




    
    (0 ,.,.) = 
      6.0653e-01
      2.2313e-01
    
    (1 ,.,.) = 
      1.1109e-02
      1.5233e-08
    [torch.FloatTensor of size (2,2,1)]




```python
kernel_NEW = RBFKernel_NEW(ard_num_dims=2)
kernel_NEW.initialize(log_lengthscale=lengthscales.log())
kernel_NEW.eval()
kernel_NEW(a, b)
```




    
    (0 ,.,.) = 
      6.0653e-01
      2.2313e-01
    
    (1 ,.,.) = 
      1.1109e-02
      1.5233e-08
    [torch.FloatTensor of size (2,2,1)]



# Make sure things work with auto-batching


```python
a = torch.Tensor([[1, 2], [2, 4]])
b = torch.Tensor([1, 3]).view(1, 1, 2)
lengthscales = torch.Tensor([1, 2]).view(1, 1, 2)
```


```python
kernel = RBFKernel(ard_num_dims=2)
kernel.initialize(log_lengthscale=lengthscales.log())
kernel.eval()
kernel(a, b)
```




    
    (0 ,.,.) = 
      0.6065
      0.2231
    [torch.FloatTensor of size (1,2,1)]




```python
kernel_NEW = RBFKernel_NEW(ard_num_dims=2)
kernel_NEW.initialize(log_lengthscale=lengthscales.log())
kernel_NEW.eval()
kernel_NEW(a, b)
```




    
    (0 ,.,.) = 
      0.6065
      0.2231
    [torch.FloatTensor of size (1,2,1)]



# Benchmarking


```python
a = torch.rand(1, 100, 3)
b = torch.rand(1, 500, 3)

lengthscales = torch.Tensor([1, 2, 0.5]).view(1, 1, 3)
```


```python
kernel = RBFKernel(ard_num_dims=3)
kernel.initialize(log_lengthscale=lengthscales.log())
kernel.eval()
```




    RBFKernel(
    )




```python
%timeit kernel(a, b)
```

    7.74 ms ± 119 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)



```python
kernel_NEW = RBFKernel_NEW(ard_num_dims=3)
kernel_NEW.initialize(log_lengthscale=lengthscales.log())
kernel_NEW.eval()
```




    RBFKernel_NEW(
    )




```python
%timeit kernel_NEW(a, b)
```

    7.62 ms ± 189 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)


# GPU tests

## GPU ARD


```python
lengthscales = torch.Tensor([1, 2]).view(1, 1, 2)
```


```python
kernel = RBFKernel(ard_num_dims=2)
kernel.initialize(log_lengthscale=lengthscales.log())
kernel.cuda()
kernel.eval()
kernel(a, b)
```




    
    (0 ,.,.) = 
      6.0653e-01
      2.2313e-01
    
    (1 ,.,.) = 
      1.1109e-02
      1.5233e-08
    [torch.cuda.FloatTensor of size (2,2,1) (GPU 0)]




```python
kernel_NEW = RBFKernel_NEW(ard_num_dims=2)
kernel_NEW.initialize(log_lengthscale=lengthscales.log())
kernel_NEW.cuda()
kernel_NEW.eval()
kernel_NEW(a, b)
```




    
    (0 ,.,.) = 
      6.0653e-01
      2.2313e-01
    
    (1 ,.,.) = 
      1.1109e-02
      1.5233e-08
    [torch.cuda.FloatTensor of size (2,2,1) (GPU 0)]



## GPU Benchmarking


```python
a = torch.rand(1, 100, 3).cuda()
b = torch.rand(1, 500, 3).cuda()

lengthscales = torch.Tensor([1, 2, 0.5]).view(1, 1, 3)
```


```python
kernel = RBFKernel(ard_num_dims=3)
kernel.initialize(log_lengthscale=lengthscales.log())
kernel.cuda()
kernel.eval()
```




    RBFKernel(
    )




```python
%timeit kernel(a, b)
```

    554 µs ± 22.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)



```python
kernel_NEW = RBFKernel_NEW(ard_num_dims=3)
kernel_NEW.initialize(log_lengthscale=lengthscales.log())
kernel_NEW.cuda()
kernel_NEW.eval()
```




    RBFKernel_NEW(
    )




```python
%timeit kernel_NEW(a, b)
```

    544 µs ± 25.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

