### PR TITLE
[Codemod] Future imports to improve py2/py3 compatibility

### DIFF
--- a/gpytorch/beta_features.py
+++ b/gpytorch/beta_features.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from .settings import _feature_flag
 
 

--- a/gpytorch/functions/add_diag.py
+++ b/gpytorch/functions/add_diag.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Function
 

--- a/gpytorch/functions/dsmm.py
+++ b/gpytorch/functions/dsmm.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Function, Variable
 from ..utils import bdsmm

--- a/gpytorch/functions/log_normal_cdf.py
+++ b/gpytorch/functions/log_normal_cdf.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import math
 from . import NormalCDF
 from torch.autograd import Function

--- a/gpytorch/functions/normal_cdf.py
+++ b/gpytorch/functions/normal_cdf.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Function
 import math

--- a/gpytorch/kernels/__init__.py
+++ b/gpytorch/kernels/__init__.py
@@ -1,24 +1,24 @@
-from .additive_grid_interpolation_kernel import AdditiveGridInterpolationKernel
-from .grid_interpolation_kernel import GridInterpolationKernel
-from .index_kernel import IndexKernel
 from .kernel import Kernel
-from .linear_kernel import LinearKernel
-from .matern_kernel import MaternKernel
-from .multiplicative_grid_interpolation_kernel import MultiplicativeGridInterpolationKernel
-from .periodic_kernel import PeriodicKernel
 from .rbf_kernel import RBFKernel
+from .matern_kernel import MaternKernel
+from .periodic_kernel import PeriodicKernel
 from .spectral_mixture_kernel import SpectralMixtureKernel
+from .index_kernel import IndexKernel
+from .grid_interpolation_kernel import GridInterpolationKernel
+from .additive_grid_interpolation_kernel import AdditiveGridInterpolationKernel
+from .linear_kernel import LinearKernel
+from .multiplicative_grid_interpolation_kernel import MultiplicativeGridInterpolationKernel
 
 
 __all__ = [
-    AdditiveGridInterpolationKernel,
-    GridInterpolationKernel,
-    IndexKernel,
     Kernel,
     LinearKernel,
-    MaternKernel,
-    MultiplicativeGridInterpolationKernel,
-    PeriodicKernel,
     RBFKernel,
+    MaternKernel,
+    PeriodicKernel,
     SpectralMixtureKernel,
+    IndexKernel,
+    GridInterpolationKernel,
+    AdditiveGridInterpolationKernel,
+    MultiplicativeGridInterpolationKernel,
 ]

--- a/gpytorch/kernels/additive_grid_interpolation_kernel.py
+++ b/gpytorch/kernels/additive_grid_interpolation_kernel.py
@@ -9,6 +9,7 @@ from ..utils import Interpolation
 
 
 class AdditiveGridInterpolationKernel(GridInterpolationKernel):
+
     def __init__(
         self,
         base_kernel_module,

--- a/gpytorch/lazy/block_diagonal_lazy_variable.py
+++ b/gpytorch/lazy/block_diagonal_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from .lazy_variable import LazyVariable

--- a/gpytorch/lazy/constant_mul_lazy_variable.py
+++ b/gpytorch/lazy/constant_mul_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from .lazy_variable import LazyVariable

--- a/gpytorch/lazy/diag_lazy_variable.py
+++ b/gpytorch/lazy/diag_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from torch.autograd import Variable
 from .lazy_variable import LazyVariable
 

--- a/gpytorch/lazy/interpolated_lazy_variable.py
+++ b/gpytorch/lazy/interpolated_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from .block_diagonal_lazy_variable import BlockDiagonalLazyVariable

--- a/gpytorch/lazy/kronecker_product_lazy_variable.py
+++ b/gpytorch/lazy/kronecker_product_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 import operator
 from torch.autograd import Variable

--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import math
 import torch
 from torch.autograd import Variable

--- a/gpytorch/lazy/matmul_lazy_variable.py
+++ b/gpytorch/lazy/matmul_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from .lazy_variable import LazyVariable

--- a/gpytorch/lazy/mul_lazy_variable.py
+++ b/gpytorch/lazy/mul_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from torch.autograd import Variable
 from .lazy_variable import LazyVariable
 from .non_lazy_variable import NonLazyVariable

--- a/gpytorch/lazy/non_lazy_variable.py
+++ b/gpytorch/lazy/non_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 import gpytorch
 from gpytorch.lazy import LazyVariable

--- a/gpytorch/lazy/psd_sum_lazy_variable.py
+++ b/gpytorch/lazy/psd_sum_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from .sum_lazy_variable import SumLazyVariable
 
 

--- a/gpytorch/lazy/root_lazy_variable.py
+++ b/gpytorch/lazy/root_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from .lazy_variable import LazyVariable

--- a/gpytorch/lazy/sum_batch_lazy_variable.py
+++ b/gpytorch/lazy/sum_batch_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from .lazy_variable import LazyVariable

--- a/gpytorch/lazy/sum_lazy_variable.py
+++ b/gpytorch/lazy/sum_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from .lazy_variable import LazyVariable
 from .non_lazy_variable import NonLazyVariable
 from torch.autograd import Variable

--- a/gpytorch/lazy/toeplitz_lazy_variable.py
+++ b/gpytorch/lazy/toeplitz_lazy_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from .lazy_variable import LazyVariable

--- a/gpytorch/likelihoods/bernoulli_likelihood.py
+++ b/gpytorch/likelihoods/bernoulli_likelihood.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from ..random_variables import GaussianRandomVariable, BernoulliRandomVariable
 from .likelihood import Likelihood

--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 import math
 import gpytorch

--- a/gpytorch/likelihoods/likelihood.py
+++ b/gpytorch/likelihoods/likelihood.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import gpytorch
 
 

--- a/gpytorch/likelihoods/softmax_likelihood.py
+++ b/gpytorch/likelihoods/softmax_likelihood.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch import nn
 from ..random_variables import GaussianRandomVariable, CategoricalRandomVariable

--- a/gpytorch/means/constant_mean.py
+++ b/gpytorch/means/constant_mean.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch import nn
 from .mean import Mean

--- a/gpytorch/means/mean.py
+++ b/gpytorch/means/mean.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from ..module import Module
 

--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from .marginal_log_likelihood import MarginalLogLikelihood
 from ..lazy import LazyVariable
 from ..likelihoods import GaussianLikelihood

--- a/gpytorch/mlls/marginal_log_likelihood.py
+++ b/gpytorch/mlls/marginal_log_likelihood.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from .. import Module
 
 

--- a/gpytorch/mlls/variational_marginal_log_likelihood.py
+++ b/gpytorch/mlls/variational_marginal_log_likelihood.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from .marginal_log_likelihood import MarginalLogLikelihood
 
 

--- a/gpytorch/models/abstract_variational_gp.py
+++ b/gpytorch/models/abstract_variational_gp.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch import nn
 from torch.autograd import Variable

--- a/gpytorch/models/additive_grid_inducing_variational_gp.py
+++ b/gpytorch/models/additive_grid_inducing_variational_gp.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch import nn
 from ..random_variables import GaussianRandomVariable

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import logging
 import gpytorch
 import torch

--- a/gpytorch/models/gp.py
+++ b/gpytorch/models/gp.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from ..module import Module
 
 

--- a/gpytorch/models/grid_inducing_variational_gp.py
+++ b/gpytorch/models/grid_inducing_variational_gp.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from ..random_variables import GaussianRandomVariable

--- a/gpytorch/models/variational_gp.py
+++ b/gpytorch/models/variational_gp.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import gpytorch
 import torch
 from torch.autograd import Variable

--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from collections import OrderedDict
 from torch import nn

--- a/gpytorch/random_variables/bernoulli_random_variable.py
+++ b/gpytorch/random_variables/bernoulli_random_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from .random_variable import RandomVariable

--- a/gpytorch/random_variables/categorical_random_variable.py
+++ b/gpytorch/random_variables/categorical_random_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from .random_variable import RandomVariable

--- a/gpytorch/random_variables/dirichlet_random_variable.py
+++ b/gpytorch/random_variables/dirichlet_random_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 import numpy as np
 from torch.autograd import Variable

--- a/gpytorch/random_variables/gaussian_random_variable.py
+++ b/gpytorch/random_variables/gaussian_random_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from torch.autograd import Variable
 from .random_variable import RandomVariable
 from ..lazy import LazyVariable, NonLazyVariable

--- a/gpytorch/random_variables/mixture_random_variable.py
+++ b/gpytorch/random_variables/mixture_random_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import math
 import torch
 from .random_variable import RandomVariable

--- a/gpytorch/random_variables/random_variable.py
+++ b/gpytorch/random_variables/random_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 from ..lazy import LazyVariable

--- a/gpytorch/random_variables/samples_random_variable.py
+++ b/gpytorch/random_variables/samples_random_variable.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from torch.autograd import Variable
 from .random_variable import RandomVariable
 import random

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 class _feature_flag(object):
     _state = False
 

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+
 class _feature_flag(object):
     _state = False
 

--- a/gpytorch/utils/circulant.py
+++ b/gpytorch/utils/circulant.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from gpytorch import utils
 from gpytorch.utils import fft

--- a/gpytorch/utils/fft.py
+++ b/gpytorch/utils/fft.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from .. import libfft
 
 

--- a/gpytorch/utils/function_factory.py
+++ b/gpytorch/utils/function_factory.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import math
 import torch
 from torch.autograd import Function, Variable

--- a/gpytorch/utils/interpolation.py
+++ b/gpytorch/utils/interpolation.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from torch.autograd import Variable
 

--- a/gpytorch/utils/lanczos.py
+++ b/gpytorch/utils/lanczos.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 
 

--- a/gpytorch/utils/linear_cg.py
+++ b/gpytorch/utils/linear_cg.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from .. import settings
 

--- a/gpytorch/utils/sparse.py
+++ b/gpytorch/utils/sparse.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 
 

--- a/gpytorch/utils/stochastic_lq.py
+++ b/gpytorch/utils/stochastic_lq.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 from .lanczos import lanczos_tridiag
 

--- a/gpytorch/utils/toeplitz.py
+++ b/gpytorch/utils/toeplitz.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 import gpytorch.utils.fft as fft
 import gpytorch.utils as utils

--- a/gpytorch/variational/mvn_variational_strategy.py
+++ b/gpytorch/variational/mvn_variational_strategy.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import torch
 import gpytorch
 from .variational_strategy import VariationalStrategy

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+
 class VariationalStrategy(object):
     def __init__(self, variational_dist, prior_dist):
         self.variational_dist = variational_dist

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 class VariationalStrategy(object):
     def __init__(self, variational_dist, prior_dist):
         self.variational_dist = variational_dist


### PR DESCRIPTION
Ran a script to add the following future imports to each file:
```
from __future__ import absolute_import
from __future__ import division
from __future__ import print_function
from __future__ import unicode_literals
```

Also fix some windows-style line breaks (e.g. in bernoulli_likelihood.py)