### PR TITLE
Function factory tests work on pytorch 0.3 and 0.4

### DIFF
--- a/test/util/test_function_factory.py
+++ b/test/util/test_function_factory.py
@@ -15,7 +15,7 @@ from gpytorch.lazy import NonLazyVariable
 
 
 class PyTorchCompatibleTestCase(unittest.TestCase):
-    # Writing a separate function for compatability with PyTorch 0.3 and PyTorch 0.4
+    # Writing a separate function for compatibility with PyTorch 0.3 and PyTorch 0.4
     def assert_scalar_almost_equal(self, scalar1, scalar2, **kwargs):
         # PyTorch 0.3 - make everything tensors
         if isinstance(scalar1, Variable):


### PR DESCRIPTION
On PyTorch master (0.4-alpha), Indexing a zero-dimensional tensor does not return a numeric value anymore, but a tensor. This caused test failures with assertAlmostEqual of the kind TypeError: type Variable doesn't define __round__ method.

This PR fixes these assertion errors, so they work on stable PyTorch (0.3) and PyTorch master.