### PR TITLE
Implement Preconditioning

### DIFF
--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -12,6 +12,7 @@ from .root_lazy_variable import RootLazyVariable
 from .sum_lazy_variable import SumLazyVariable
 from .sum_batch_lazy_variable import SumBatchLazyVariable
 from .toeplitz_lazy_variable import ToeplitzLazyVariable
+from .added_diag_lazy_variable import AddedDiagLazyVariable
 
 
 __all__ = [
@@ -29,4 +30,5 @@ __all__ = [
     SumLazyVariable,
     SumBatchLazyVariable,
     ToeplitzLazyVariable,
+    AddedDiagLazyVariable,
 ]

--- a/gpytorch/lazy/added_diag_lazy_variable.py
+++ b/gpytorch/lazy/added_diag_lazy_variable.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 from .sum_lazy_variable import SumLazyVariable
 from .diag_lazy_variable import DiagLazyVariable
 from ..utils import pivoted_cholesky
+from torch.autograd import Variable
 import gpytorch
 
 
@@ -41,10 +42,24 @@ class AddedDiagLazyVariable(SumLazyVariable):
         if not hasattr(self, '_woodbury_cache'):
             max_iter = gpytorch.settings.max_preconditioner_size.value()
             self._piv_chol_self = pivoted_cholesky.pivoted_cholesky(self._lazy_var, max_iter)
-            diag = self._diag_var.diag().data[0]
-            self._woodbury_cache = pivoted_cholesky.woodbury_factor(self._piv_chol_self, diag)
+            self._woodbury_cache = pivoted_cholesky.woodbury_factor(self._piv_chol_self, self._diag_var.diag().data[0])
 
         def precondition_closure(tensor):
-            return pivoted_cholesky.woodbury_solve(tensor, self._piv_chol_self, self._woodbury_cache, diag)
+            return pivoted_cholesky.woodbury_solve(tensor, self._piv_chol_self,
+                                                   self._woodbury_cache, self._diag_var.diag().data[0])
 
         return precondition_closure
+
+    def inv_quad_log_det(self, inv_quad_rhs=None, log_det=False):
+        inv_quad_term, log_det_term = super(AddedDiagLazyVariable, self).inv_quad_log_det(inv_quad_rhs, log_det)
+
+        if gpytorch.settings.max_preconditioner_size.value() > 0:
+            lr_flipped = self._piv_chol_self.matmul(self._piv_chol_self.transpose(-2, -1))
+            lr_flipped.div_(self._diag_var.diag().data[0])
+            lr_flipped = lr_flipped + lr_flipped.new(lr_flipped.size(0)).fill_(1).diag()
+            ld_one = lr_flipped.potrf().diag().log().sum() * 2
+            ld_two = self._diag_var.diag().data.log().sum()
+            ld_adjustment = log_det_term.data.new(1).fill_(ld_one + ld_two)
+            log_det_term = log_det_term + Variable(ld_adjustment, requires_grad=False)
+
+        return inv_quad_term, log_det_term

--- a/gpytorch/lazy/added_diag_lazy_variable.py
+++ b/gpytorch/lazy/added_diag_lazy_variable.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from .sum_lazy_variable import SumLazyVariable
+from .diag_lazy_variable import DiagLazyVariable
+
+
+class AddedDiagLazyVariable(SumLazyVariable):
+    """
+    A SumLazyVariable, but of only two lazy variables, the second of which must be
+    a DiagLazyVariable.
+    """
+    def __init__(self, *lazy_vars):
+        lazy_vars = list(lazy_vars)
+        super(AddedDiagLazyVariable, self).__init__(*lazy_vars)
+        if len(lazy_vars) > 2:
+            raise RuntimeError('An AddedDiagLazyVariable can only have two components')
+
+        if isinstance(lazy_vars[0], DiagLazyVariable) and isinstance(lazy_vars[1], DiagLazyVariable):
+            raise RuntimeError('Trying to lazily add two DiagLazyVariables. Create a single DiagLazyVariable instead.')
+        elif isinstance(lazy_vars[0], DiagLazyVariable):
+            self._diag_var = lazy_vars[0]
+            self._lazy_var = lazy_vars[1]
+        elif isinstance(lazy_vars[1], DiagLazyVariable):
+            self._diag_var = lazy_vars[1]
+            self._lazy_var = lazy_vars[0]
+        else:
+            raise RuntimeError('One of the LazyVariables input to AddedDiagLazyVariable must be a DiagLazyVariable!')

--- a/gpytorch/lazy/added_diag_lazy_variable.py
+++ b/gpytorch/lazy/added_diag_lazy_variable.py
@@ -31,10 +31,13 @@ class AddedDiagLazyVariable(SumLazyVariable):
         else:
             raise RuntimeError('One of the LazyVariables input to AddedDiagLazyVariable must be a DiagLazyVariable!')
 
-        if not all(self._diag_var.diag().data == self._diag_var.diag().data[0]):
+        if not (self._diag_var.diag().data == self._diag_var.diag().data[0]).all():
             raise RuntimeError('AddedDiagLazyVariable only supports constant shifts (e.g. s in K + s*I)')
 
     def _preconditioner(self):
+        if gpytorch.settings.max_preconditioner_size.value() == 0:
+            return None
+
         if not hasattr(self, '_woodbury_cache'):
             max_iter = gpytorch.settings.max_preconditioner_size.value()
             self._piv_chol_self = pivoted_cholesky.pivoted_cholesky(self._lazy_var, max_iter)

--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -340,7 +340,7 @@ class LazyVariable(object):
         elif self.ndimension() > 3 or tensor.ndimension() > 3:
             raise RuntimeError
 
-        res = lazy_var._inv_matmul_class()(*(list(lazy_var.representation()) + [tensor]))
+        res = lazy_var._inv_matmul_class(preconditioner=self._preconditioner())(*(list(lazy_var.representation()) + [tensor]))
         return res
 
     def inv_quad(self, tensor):

--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -104,12 +104,15 @@ class LazyVariable(object):
             - diag (Scalar Variable)
         """
         from .diag_lazy_variable import DiagLazyVariable
+        from .added_diag_lazy_variable import AddedDiagLazyVariable
         if self.size(-1) != self.size(-2):
             raise RuntimeError('add_diag only defined for square matrices')
         if self.ndimension() == 3:
-            return self + DiagLazyVariable(diag.unsqueeze(0).expand(self.size(0), self.size(1)))
+            diag_lazy_var = DiagLazyVariable(diag.unsqueeze(0).expand(self.size(0), self.size(1)))
+            return AddedDiagLazyVariable(self, diag_lazy_var)
         else:
-            return self + DiagLazyVariable(diag.expand(self.size(0)))
+            diag_lazy_var = DiagLazyVariable(diag.expand(self.size(0)))
+            return AddedDiagLazyVariable(self, diag_lazy_var)
 
     def add_jitter(self):
         """

--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import math
 import torch
 from torch.autograd import Variable
-from ..utils import function_factory
+from ..utils import function_factory, pivoted_cholesky
 from .. import beta_features, settings
 
 
@@ -37,6 +37,9 @@ class LazyVariable(object):
         function(tensor) - closure that performs a matrix multiply
         """
         raise NotImplementedError
+
+    def _preconditioner(self):
+        return None
 
     def _t_matmul_closure_factory(self, *args):
         """
@@ -519,6 +522,13 @@ class LazyVariable(object):
             else:
                 raise RuntimeError('Representation of a LazyVariable should consist only of Variables')
         return tuple(representation)
+
+    def pivoted_cholesky_decomposition(self):
+        """
+        Returns a RootLazyVariable containing a pivoted cholesky decomposition of this
+        LazyVariable. Intended to potentially supercede root_decomposition.
+        """
+        return pivoted_cholesky.pivoted_cholesky(self, gpytorch.settings.max_precond_size.value())
 
     def root_decomposition(self):
         """

--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import math
 import torch
 from torch.autograd import Variable
-from ..utils import function_factory, pivoted_cholesky
+from ..utils import function_factory
 from .. import beta_features, settings
 
 
@@ -340,7 +340,8 @@ class LazyVariable(object):
         elif self.ndimension() > 3 or tensor.ndimension() > 3:
             raise RuntimeError
 
-        res = lazy_var._inv_matmul_class(preconditioner=self._preconditioner())(*(list(lazy_var.representation()) + [tensor]))
+        inv_mm_cls = lazy_var._inv_matmul_class(preconditioner=self._preconditioner())
+        res = inv_mm_cls(*(list(lazy_var.representation()) + [tensor]))
         return res
 
     def inv_quad(self, tensor):
@@ -526,13 +527,6 @@ class LazyVariable(object):
             else:
                 raise RuntimeError('Representation of a LazyVariable should consist only of Variables')
         return tuple(representation)
-
-    def pivoted_cholesky_decomposition(self):
-        """
-        Returns a RootLazyVariable containing a pivoted cholesky decomposition of this
-        LazyVariable. Intended to potentially supercede root_decomposition.
-        """
-        return pivoted_cholesky.pivoted_cholesky(self, gpytorch.settings.max_precond_size.value())
 
     def root_decomposition(self):
         """

--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -400,11 +400,15 @@ class LazyVariable(object):
         if inv_quad_rhs is None:
             return lazy_var._inv_quad_log_det_class(matrix_size=matrix_size, batch_size=batch_size,
                                                     tensor_cls=tensor_cls, inv_quad=False,
-                                                    log_det=log_det)(*args)
+                                                    log_det=log_det,
+                                                    preconditioner=self._preconditioner()
+                                                    )(*args)
         else:
             return lazy_var._inv_quad_log_det_class(matrix_size=matrix_size, batch_size=batch_size,
                                                     tensor_cls=tensor_cls, inv_quad=True,
-                                                    log_det=log_det)(*(list(args) + [inv_quad_rhs]))
+                                                    log_det=log_det,
+                                                    preconditioner=self._preconditioner()
+                                                    )(*(list(args) + [inv_quad_rhs]))
 
     def log_det(self):
         """

--- a/gpytorch/lazy/non_lazy_variable.py
+++ b/gpytorch/lazy/non_lazy_variable.py
@@ -58,7 +58,10 @@ class NonLazyVariable(LazyVariable):
         return NonLazyVariable(gpytorch.add_diag(self.var, diag))
 
     def diag(self):
-        return self.var.diag()
+        if self.var.ndimension() < 3:
+            return self.var.diag()
+        else:
+            return super(NonLazyVariable, self).diag()
 
     def evaluate(self):
         return self.var

--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -3,11 +3,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-
 import math
 from .marginal_log_likelihood import MarginalLogLikelihood
 from ..lazy import LazyVariable, NonLazyVariable
 from ..likelihoods import GaussianLikelihood
+from ..random_variables import GaussianRandomVariable
 
 
 class ExactMarginalLogLikelihood(MarginalLogLikelihood):
@@ -25,10 +25,10 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
         super(ExactMarginalLogLikelihood, self).__init__(likelihood, model)
 
     def forward(self, output, target):
+        if not isinstance(output.covar(), LazyVariable):
+            output = GaussianRandomVariable(output.mean(), NonLazyVariable(output.covar()))
         mean, covar = self.likelihood(output).representation()
         n_data = target.size(-1)
-        if not isinstance(covar, LazyVariable):
-            covar = NonLazyVariable(covar)
 
         # Get log determininat and first part of quadratic form
         inv_quad, log_det = covar.inv_quad_log_det(inv_quad_rhs=target.unsqueeze(-1), log_det=True)

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -72,11 +72,9 @@ class max_lanczos_iterations(_value_context):
 
 class max_preconditioner_size(_value_context):
     """
-    The maximum number of Lanczos iterations to perform
-    This is used when 1) computing variance estiamtes 2) when drawing from MVNs, or
-    3) for kernel multiplication
-    More values results in higher accuracy
-    Default: 100
+    The maximum size of preconditioner to use. 0 corresponds to turning preconditioning off.
+    When enabled, usually a value of around ~10 works fairly well.
+    Default: 0
     """
     _global_value = 0
 

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -69,6 +69,15 @@ class max_lanczos_iterations(_value_context):
     """
     _global_value = 100
 
+class max_preconditioner_size(_value_context):
+    """
+    The maximum number of Lanczos iterations to perform
+    This is used when 1) computing variance estiamtes 2) when drawing from MVNs, or
+    3) for kernel multiplication
+    More values results in higher accuracy
+    Default: 100
+    """
+    _global_value = 10
 
 class max_lanczos_quadrature_iterations(_value_context):
     """

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -77,7 +77,7 @@ class max_preconditioner_size(_value_context):
     More values results in higher accuracy
     Default: 100
     """
-    _global_value = 10
+    _global_value = 0
 
 class max_lanczos_quadrature_iterations(_value_context):
     """

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -69,6 +69,7 @@ class max_lanczos_iterations(_value_context):
     """
     _global_value = 100
 
+
 class max_preconditioner_size(_value_context):
     """
     The maximum number of Lanczos iterations to perform
@@ -78,6 +79,7 @@ class max_preconditioner_size(_value_context):
     Default: 100
     """
     _global_value = 0
+
 
 class max_lanczos_quadrature_iterations(_value_context):
     """

--- a/gpytorch/utils/function_factory.py
+++ b/gpytorch/utils/function_factory.py
@@ -160,7 +160,7 @@ def inv_quad_log_det_factory(matmul_closure_factory=_default_matmul_closure_fact
         - The matrix solves A^{-1} b
         - logdet(A)
         """
-        def __init__(self, matrix_size=0, batch_size=None, tensor_cls=None, inv_quad=False, log_det=False):
+        def __init__(self, matrix_size=0, batch_size=None, tensor_cls=None, inv_quad=False, log_det=False, preconditioner=None):
             if not matrix_size:
                 raise RuntimeError('Matrix size must be set')
             if tensor_cls is None:
@@ -172,6 +172,7 @@ def inv_quad_log_det_factory(matmul_closure_factory=_default_matmul_closure_fact
             self.tensor_cls = tensor_cls
             self.inv_quad = inv_quad
             self.log_det = log_det
+            self.preconditioner = preconditioner
 
         def forward(self, *args):
             """
@@ -226,10 +227,12 @@ def inv_quad_log_det_factory(matmul_closure_factory=_default_matmul_closure_fact
             t_mat = None
             if self.log_det:
                 solves, t_mat = linear_cg(matmul_closure, rhs, n_tridiag=num_random_probes,
-                                          max_iter=settings.max_lanczos_quadrature_iterations.value())
+                                          max_iter=settings.max_lanczos_quadrature_iterations.value(),
+                                          preconditioner=self.preconditioner)
             else:
                 solves = linear_cg(matmul_closure, rhs, n_tridiag=num_random_probes,
-                                   max_iter=settings.max_lanczos_quadrature_iterations.value())
+                                   max_iter=settings.max_lanczos_quadrature_iterations.value(),
+                                   preconditioner=self.preconditioner)
 
             # Final values to return
             log_det_term = self.tensor_cls()

--- a/gpytorch/utils/function_factory.py
+++ b/gpytorch/utils/function_factory.py
@@ -167,7 +167,8 @@ def inv_quad_log_det_factory(matmul_closure_factory=_default_matmul_closure_fact
         - The matrix solves A^{-1} b
         - logdet(A)
         """
-        def __init__(self, matrix_size=0, batch_size=None, tensor_cls=None, inv_quad=False, log_det=False, preconditioner=None):
+        def __init__(self, matrix_size=0, batch_size=None, tensor_cls=None,
+                     inv_quad=False, log_det=False, preconditioner=None):
             if not matrix_size:
                 raise RuntimeError('Matrix size must be set')
             if tensor_cls is None:

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -54,7 +54,7 @@ def pivoted_cholesky(matrix, max_iter, error_tol=1e-3):
         permutation[full_batch_slice, max_diag_indices] = old_pi_m
         pi_m = permutation[:, m]
 
-        L_m = L[:, m] # Will be all zeros -- should we use torch.zeros?
+        L_m = L[:, m]  # Will be all zeros -- should we use torch.zeros?
         L_m[full_batch_slice, pi_m] = torch.sqrt(max_diag_values)
 
         if not batch_mode:
@@ -91,6 +91,7 @@ def pivoted_cholesky(matrix, max_iter, error_tol=1e-3):
     else:
         return L[:, :m, :]
 
+
 def woodbury_factor(low_rank_mat, shift):
     """
     Given a low rank (k x n) matrix V and a shift, returns the
@@ -98,7 +99,6 @@ def woodbury_factor(low_rank_mat, shift):
         R = (I_k + 1/shift VV')^{-1}V
     to be used in solves with (V'V + shift I) via the Woodbury formula
     """
-    n = low_rank_mat.size(-1)
     k = low_rank_mat.size(-2)
     shifted_mat = (1 / shift) * low_rank_mat.matmul(low_rank_mat.t())
     shifted_mat = shifted_mat + shifted_mat.new(k).fill_(1).diag()

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -3,7 +3,7 @@ from torch.autograd import Variable
 from ..lazy import LazyVariable, NonLazyVariable
 
 
-def pivoted_cholesky(matrix, max_iter, error_tol=1e-5):
+def pivoted_cholesky(matrix, max_iter, error_tol=1e-3):
     # matrix is assumed to be batch_size x n x n
     if matrix.ndimension() < 3:
         batch_size = 1

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -1,0 +1,83 @@
+import torch
+
+
+def pivoted_cholesky(matrix, max_iter, error_tol=1e-5):
+    matrix_size = matrix.size(-1)
+    matrix_diag = matrix.diag()
+
+    # TODO: This check won't be necessary in PyTorch 0.4
+    if isinstance(matrix_diag, torch.autograd.Variable):
+        matrix_diag = matrix_diag.data
+
+    error = torch.norm(matrix_diag, 1)
+    permutation = matrix_diag.new(matrix_size).long()
+    torch.arange(0, matrix_size, out=permutation)
+
+    m = 0
+    # TODO: pivoted_cholesky should take tensor_cls and use that here instead
+    L = matrix_diag.new(max_iter, matrix_size).zero_()
+    while m < max_iter and error > error_tol:
+        max_diag_value, max_diag_index = torch.max(matrix_diag[permutation][m:], 0)
+        max_diag_index = max_diag_index + m
+
+        pi_m = permutation[m]
+        permutation[m] = permutation[max_diag_index][0]
+        permutation[max_diag_index] = pi_m
+
+        pi_m = permutation[m]
+
+        L_m = L[m] # Will be all zeros -- should we use torch.zeros?
+        L_m[pi_m] = torch.sqrt(max_diag_value)[0]
+
+        row = matrix[pi_m]
+
+        if isinstance(row, torch.autograd.Variable):
+            row = row.data
+
+        pi_i = permutation[m + 1:]
+        L_m[pi_i] = row[pi_i]
+        if m > 0:
+            L_prev = L[:m].index_select(1, pi_i)
+            L_m[pi_i] -= torch.sum(L[:m, pi_m].unsqueeze(1) * L_prev, dim=0)
+        L_m[pi_i] /= L_m[pi_m]
+
+        matrix_diag[pi_i] = matrix_diag[pi_i] - (L_m[pi_i] ** 2)
+        L[m] = L_m
+
+        error = torch.sum(matrix_diag[permutation[m + 1:]])
+        m = m + 1
+
+    return L[:m, :]
+
+
+def woodbury_factor(low_rank_mat, shift):
+    """
+    Given a low rank (k x n) matrix V and a shift, returns the
+    matrix R so that
+        R = (I_k + 1/shift VV')^{-1}V
+    to be used in solves with (V'V + shift I) via the Woodbury formula
+    """
+    n = low_rank_mat.size(-1)
+    k = low_rank_mat.size(-2)
+    shifted_mat = (1 / shift) * low_rank_mat.matmul(low_rank_mat.t())
+    shifted_mat = shifted_mat + shifted_mat.new(k).fill_(1).diag()
+
+    R = torch.potrs(low_rank_mat, shifted_mat.potrf())
+
+    return R
+
+
+def woodbury_solve(vector, low_rank_mat, woodbury_factor, shift):
+    """
+    Solves the system of equations:
+        (sigma*I + VV')x = b
+    Using the Woodbury formula.
+
+    Input:
+        - vector (size n) - right hand side vector b to solve with.
+        - woodbury_factor (k x n) - The result of calling woodbury_factor on V
+          and the shift, \sigma
+        - shift (scalar) - shift value sigma
+    """
+    right = (1 / shift) * low_rank_mat.t().matmul(woodbury_factor.matmul(vector))
+    return (1 / shift) * (vector - right)

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -1,6 +1,6 @@
 import torch
 from torch.autograd import Variable
-from gpytorch.lazy import LazyVariable, NonLazyVariable
+from ..lazy import LazyVariable, NonLazyVariable
 
 
 def pivoted_cholesky(matrix, max_iter, error_tol=1e-5):

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -1,54 +1,95 @@
 import torch
+from torch.autograd import Variable
+from gpytorch.lazy import LazyVariable, NonLazyVariable
 
 
 def pivoted_cholesky(matrix, max_iter, error_tol=1e-5):
+    # matrix is assumed to be batch_size x n x n
+    if matrix.ndimension() < 3:
+        batch_size = 1
+        batch_mode = False
+    else:
+        batch_size = matrix.size(0)
+        batch_mode = True
     matrix_size = matrix.size(-1)
-    matrix_diag = matrix.diag()
+
+    # Need to get diagonals. This is easy if it's a LazyVariable, since
+    # LazyVariable.diag() operates in batch mode.
+    if isinstance(matrix, LazyVariable):
+        matrix_diag = matrix.diag()
+    elif isinstance(matrix, Variable):
+        matrix_diag = NonLazyVariable(matrix).diag()
+    elif torch.is_tensor(matrix):
+        matrix_diag = NonLazyVariable(Variable(matrix)).diag()
 
     # TODO: This check won't be necessary in PyTorch 0.4
     if isinstance(matrix_diag, torch.autograd.Variable):
         matrix_diag = matrix_diag.data
 
-    error = torch.norm(matrix_diag, 1)
+    if not batch_mode:
+        matrix_diag.unsqueeze_(0)
+    # matrix_diag is now batch_size x n
+
+    errors = torch.norm(matrix_diag, 1, dim=1)
     permutation = matrix_diag.new(matrix_size).long()
     torch.arange(0, matrix_size, out=permutation)
+    permutation = permutation.repeat(batch_size, 1)
 
     m = 0
     # TODO: pivoted_cholesky should take tensor_cls and use that here instead
-    L = matrix_diag.new(max_iter, matrix_size).zero_()
-    while m < max_iter and error > error_tol:
-        max_diag_value, max_diag_index = torch.max(matrix_diag[permutation][m:], 0)
-        max_diag_index = max_diag_index + m
+    L = matrix_diag.new(batch_size, max_iter, matrix_size).zero_()
+    full_batch_slice = permutation.new(batch_size)
+    torch.arange(batch_size, out=full_batch_slice)
+    while m < max_iter and torch.max(errors) > error_tol:
+        permuted_diags = torch.gather(matrix_diag, 1, permutation)[:, m:]
+        max_diag_values, max_diag_indices = torch.max(permuted_diags, 1)
 
-        pi_m = permutation[m]
-        permutation[m] = permutation[max_diag_index][0]
-        permutation[max_diag_index] = pi_m
+        max_diag_indices = max_diag_indices + m
 
-        pi_m = permutation[m]
+        # Swap pi_m and pi_i in each row, where pi_i is the element of the permutation
+        # corresponding to the max diagonal element
+        old_pi_m = permutation[:, m].clone()
+        new_pi_m = permutation[full_batch_slice, max_diag_indices].clone()
+        permutation[:, m] = new_pi_m
+        permutation[full_batch_slice, max_diag_indices] = old_pi_m
+        pi_m = permutation[:, m]
 
-        L_m = L[m] # Will be all zeros -- should we use torch.zeros?
-        L_m[pi_m] = torch.sqrt(max_diag_value)[0]
+        L_m = L[:, m] # Will be all zeros -- should we use torch.zeros?
+        L_m[full_batch_slice, pi_m] = torch.sqrt(max_diag_values)
 
-        row = matrix[pi_m]
+        if not batch_mode:
+            row = matrix[pi_m, :]
+            if row.ndimension() < 2:
+                row.unsqueeze_(0)
+        else:
+            row = matrix[full_batch_slice, pi_m, :]
 
+        if isinstance(row, LazyVariable):
+            row = row.evaluate()
         if isinstance(row, torch.autograd.Variable):
             row = row.data
 
-        pi_i = permutation[m + 1:]
-        L_m[pi_i] = row[pi_i]
+        pi_i = permutation[:, m + 1:]
+        L_m_new = row.gather(1, pi_i)
         if m > 0:
-            L_prev = L[:m].index_select(1, pi_i)
-            L_m[pi_i] -= torch.sum(L[:m, pi_m].unsqueeze(1) * L_prev, dim=0)
-        L_m[pi_i] /= L_m[pi_m]
+            L_prev = L[:, :m].gather(2, pi_i.unsqueeze(1).repeat(1, m, 1))
+            update = L[:, :m].gather(2, pi_m.unsqueeze(1).unsqueeze(1).repeat(1, m, 1))
+            L_m_new -= torch.sum(update * L_prev, dim=1)
 
-        matrix_diag[pi_i] = matrix_diag[pi_i] - (L_m[pi_i] ** 2)
-        L[m] = L_m
+        L_m_new /= L_m.gather(1, pi_m.unsqueeze(1))
+        L_m.scatter_(1, pi_i, L_m_new)
 
-        error = torch.sum(matrix_diag[permutation[m + 1:]])
+        matrix_diag_current = matrix_diag.gather(1, pi_i)
+        matrix_diag.scatter_(1, pi_i, matrix_diag_current - L_m_new ** 2)
+        L[:, m] = L_m
+
+        errors = torch.norm(matrix_diag.gather(1, pi_i), 1, dim=1)
         m = m + 1
 
-    return L[:m, :]
-
+    if not batch_mode:
+        return L[0, :m, :]
+    else:
+        return L[:, :m, :]
 
 def woodbury_factor(low_rank_mat, shift):
     """

--- a/test/util/test_pivoted_cholesky.py
+++ b/test/util/test_pivoted_cholesky.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import torch
+import unittest
+from torch.autograd import Variable
+from gpytorch.utils import pivoted_cholesky, approx_equal
+from gpytorch.kernels import RBFKernel
+
+
+class TestPivotedCholesky(unittest.TestCase):
+
+    def test_pivoted_cholesky(self):
+        size = 100
+        train_x = Variable(torch.linspace(0, 1, size))
+        covar_matrix = RBFKernel()(train_x, train_x).data
+        piv_chol = pivoted_cholesky.pivoted_cholesky(covar_matrix, 10)
+        covar_approx = piv_chol.t().matmul(piv_chol)
+
+        self.assertTrue(approx_equal(covar_approx, covar_matrix))
+
+    def test_solve(self):
+        size = 100
+        train_x = Variable(torch.linspace(0, 1, size))
+        covar_matrix = RBFKernel()(train_x, train_x).data
+        piv_chol = pivoted_cholesky.pivoted_cholesky(covar_matrix, 10)
+        woodbury_factor = pivoted_cholesky.woodbury_factor(piv_chol, 1)
+
+        rhs_vector = torch.randn(100)
+        shifted_covar_matrix = covar_matrix + torch.eye(size)
+        real_solve = shifted_covar_matrix.inverse().matmul(rhs_vector)
+        approx_solve = pivoted_cholesky.woodbury_solve(rhs_vector, piv_chol, woodbury_factor, 1)
+
+        self.assertTrue(approx_equal(approx_solve, real_solve))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request implements a (currently optional) preconditioning feature for linear solves, using a pivoted Cholesky decomposition as a preconditioner. 

Preconditioning can significantly reduce the number of CG iterations required to get accurate solves. While this may not substantially affect training (other than a potential speed improvement), this can significantly improve test accuracy / speed where previously a significant number of CG iterations were required.

## Interface Changes
Preconditioning can now be enabled for linear solves by using the context
```python
with gpytorch.settings.max_preconditioner_size(value)
```
with value > 0 (default is 0, which disables preconditioning). 

## Internal Changes
- `LazyVariable` now defines a `_preconditioner()` method, which by default returns `None`. For certain `LazyVariables`, this can return a closure that takes a tensor and returns `P^{-1}v`, where `P` is a preconditioner for `self`.
- `LazyVariable.inv_matmul()` and `LazyVariable.inv_quad_log_det()` now pass the result of `self._preconditioner()` to their respective `Functions`.
- `add_diag` now creates a new `AddedDiagLazyVariable`, which extends `SumLazyVariable` but allows us to define the `_preconditioner()` method.
- The marginal likelihood calculations now always convert the prior covariance to a `NonLazyVariable`. This allows preconditioning to be applied when not using KISS-GP.
- When using preconditioning, the log determinant calculation in `inv_quad_log_det()` for an `AddedDiagLazyVariable` is adjusted to account for this. As a result, the loss calculations may be slightly less accurate when using preconditioning. However, the loss __gradient__ calculations are likely __more__ accurate, so convergence may be improved.
- `NonLazyVariable` now uses `super`'s `diag()` function if it is in batch mode.