### PR TITLE
Small fixes

### DIFF
--- a/gpytorch/mlls/variational_marginal_log_likelihood.py
+++ b/gpytorch/mlls/variational_marginal_log_likelihood.py
@@ -19,10 +19,10 @@ class VariationalMarginalLogLikelihood(MarginalLogLikelihood):
         super(VariationalMarginalLogLikelihood, self).__init__(likelihood, model)
         self.n_data = n_data
 
-    def forward(self, output, target):
+    def forward(self, output, target, **kwargs):
         n_batch = target.size(0)
 
-        log_likelihood = self.likelihood.log_probability(output, target).div(n_batch)
+        log_likelihood = self.likelihood.log_probability(output, target, **kwargs).div(n_batch)
         kl_divergence = sum(variational_strategy.kl_divergence().sum()
                             for variational_strategy in self.model.variational_strategies()).div(self.n_data)
 

--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -158,10 +158,6 @@ class Module(nn.Module):
         self._variational_strategies[name] = variational_strategy
 
     def __call__(self, *inputs, **kwargs):
-        for input in inputs:
-            if not(isinstance(input, RandomVariable) or isinstance(input, Variable)):
-                raise RuntimeError('Input must be a RandomVariable or Variable, was a %s' %
-                                   input.__class__.__name__)
         outputs = self.forward(*inputs, **kwargs)
         if isinstance(outputs, Variable) or isinstance(outputs, RandomVariable) or isinstance(outputs, LazyVariable):
             return outputs

--- a/gpytorch/random_variables/categorical_random_variable.py
+++ b/gpytorch/random_variables/categorical_random_variable.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import torch
 from torch.autograd import Variable
 from .random_variable import RandomVariable
+from torch.nn import functional as F
 
 
 class CategoricalRandomVariable(RandomVariable):
@@ -45,31 +46,38 @@ class CategoricalRandomVariable(RandomVariable):
     def representation(self):
         return self.mass_function
 
-    def sample(self, n_samples=1):
+    def sample(self, n_samples=1, gumbel_softmax_temp=None):
         """
         This function is written as a reparameterization
         This way we can differentiate through the mass function
         """
         mass_function = self.mass_function
+
         if mass_function.ndimension() == 1:
             mass_function = mass_function.unsqueeze(0)
 
-        upper_mass_function = mass_function.cumsum(1)
-        lower_mass_function = upper_mass_function - mass_function
-
         # Generate uniform samples
-        samples = Variable(mass_function.data.new(n_samples, 1, 1).uniform_())
-        samples = samples.clamp(1e-5, 1)  # Make sure that everything is strictly greater than zero
 
-        lower_mask = samples.gt(lower_mass_function.unsqueeze(0))
-        upper_mask = samples.le(upper_mass_function.unsqueeze(0))
-        res = (lower_mask * upper_mask)
+        if gumbel_softmax_temp is None:
+            upper_mass_function = mass_function.cumsum(1)
+            lower_mass_function = upper_mass_function - mass_function
+
+            samples = Variable(mass_function.data.new(1, 1, n_samples).uniform_())
+            samples = samples.clamp(1e-5, 1)  # Make sure that everything is strictly greater than zero
+            lower_mask = samples.gt(lower_mass_function.unsqueeze(-1))
+            upper_mask = samples.le(upper_mass_function.unsqueeze(-1))
+            res = (lower_mask * upper_mask)
+        else:
+            samples = Variable(mass_function.data.new(1, mass_function.size(-1), n_samples).uniform_())
+            gumbel_samples = samples.log().mul_(-1).log_().mul_(-1)
+            softmax_weights = (mass_function.log().unsqueeze(-1) + gumbel_samples).div(gumbel_softmax_temp)
+            res = F.softmax(softmax_weights, 1)
 
         # Sample dimension is first
         if self.mass_function.ndimension() == 1:
-            res = res.squeeze(1)
-        if n_samples == 1:
             res = res.squeeze(0)
+        if n_samples == 1:
+            res = res.squeeze(-1)
         return res
 
     def __len__(self):

--- a/gpytorch/random_variables/samples_random_variable.py
+++ b/gpytorch/random_variables/samples_random_variable.py
@@ -29,3 +29,11 @@ class SamplesRandomVariable(RandomVariable):
 
     def representation(self):
         return self._samples
+
+    def mean(self):
+        return self._samples.mean(-1)
+
+    def var(self):
+        if self._samples.size(-1) == 1:
+            return Variable(self._samples.data.new(self._samples.squeeze(-1).size()).zero_())
+        return self._samples.var(-1)


### PR DESCRIPTION
This branch has a number of small fixes

## Variational MLL can take kwargs
This allows the use of more complicated likelihoods. Imagine a likelihood that requires additional inputs, besides the gp output and target: `def log_likelihood(gp_output, target, extra_input_1, extra_input_2)`. This PR modifies the variational MLL to allow for the extra inputs as kwargs:

```python
mll(gp_output, target, extra_input_1=extra_input_1, extra_input_2=extra_input_2)
```

## Back-propable sampling for `CategoricalRandomVariables`
As currently implemented, samples of categorical random variables do not produce a gradient. Now, these variables can produce "soft" back-propable samples using the [gumbel-softmax estimator](https://arxiv.org/abs/1611.01144).

If you call `random_variable.sample(n_samples=10, gumbel_softmax_temp=1.5)`, this produces gumbel-softmax estimated samples, with temperature of 1.5. If you call `random_variable.sample(n_samples=10)`, this produces the standard "hard" samples (which are not back-propable).

## Other tiny changes
- `SampleRandomVariable` now has a `mean` and `var` method.
- `gpytorch.Module` no longer type-checks inputs. This makes it so that models can accept tuples as inputs, or `None` as an input.