### PR TITLE
Fixes to variational inference

### DIFF
--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -1,5 +1,6 @@
 from .lazy_variable import LazyVariable
 from .block_diagonal_lazy_variable import BlockDiagonalLazyVariable
+from .chol_lazy_variable import CholLazyVariable
 from .constant_mul_lazy_variable import ConstantMulLazyVariable
 from .diag_lazy_variable import DiagLazyVariable
 from .interpolated_lazy_variable import InterpolatedLazyVariable
@@ -18,6 +19,7 @@ from .added_diag_lazy_variable import AddedDiagLazyVariable
 __all__ = [
     LazyVariable,
     BlockDiagonalLazyVariable,
+    CholLazyVariable,
     ConstantMulLazyVariable,
     DiagLazyVariable,
     InterpolatedLazyVariable,

--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -1,4 +1,5 @@
 from .lazy_variable import LazyVariable
+from .added_diag_lazy_variable import AddedDiagLazyVariable
 from .block_diagonal_lazy_variable import BlockDiagonalLazyVariable
 from .chol_lazy_variable import CholLazyVariable
 from .constant_mul_lazy_variable import ConstantMulLazyVariable
@@ -13,11 +14,11 @@ from .root_lazy_variable import RootLazyVariable
 from .sum_lazy_variable import SumLazyVariable
 from .sum_batch_lazy_variable import SumBatchLazyVariable
 from .toeplitz_lazy_variable import ToeplitzLazyVariable
-from .added_diag_lazy_variable import AddedDiagLazyVariable
 
 
 __all__ = [
     LazyVariable,
+    AddedDiagLazyVariable,
     BlockDiagonalLazyVariable,
     CholLazyVariable,
     ConstantMulLazyVariable,
@@ -32,5 +33,4 @@ __all__ = [
     SumLazyVariable,
     SumBatchLazyVariable,
     ToeplitzLazyVariable,
-    AddedDiagLazyVariable,
 ]

--- a/gpytorch/lazy/chol_lazy_variable.py
+++ b/gpytorch/lazy/chol_lazy_variable.py
@@ -1,0 +1,88 @@
+import torch
+from torch.autograd import Variable
+from .lazy_variable import LazyVariable
+from .root_lazy_variable import RootLazyVariable
+
+
+class CholLazyVariable(RootLazyVariable):
+    def __init__(self, chol):
+        if isinstance(chol, LazyVariable):  # Probably is an instance of NonLazyVariable
+            chol = chol.evaluate()
+
+        # Check that we have a lower triangular matrix
+        mask = Variable(
+            chol.data.new(chol.size(-2), chol.size(-2)).
+            fill_(1).
+            tril_()
+        )
+        if chol.ndimension() == 3:
+            mask.data.unsqueeze_(0)
+        if not torch.equal(chol, chol.mul(mask)):
+            raise RuntimeError('CholLazyVaraiable should take a lower-triangular matrix in the constructor.')
+
+        # Run super constructor
+        super(CholLazyVariable, self).__init__(chol)
+
+        # Check that the diagonal is
+        if not torch.equal(self._chol_diag.abs(), self._chol_diag):
+            raise RuntimeError('The diagonal of the cholesky decomposition should be positive.')
+
+    @property
+    def _chol(self):
+        if not hasattr(self, '_chol_memo'):
+            self._chol_memo = self.root.evaluate()
+        return self._chol_memo
+
+    @property
+    def _chol_diag(self):
+        if not hasattr(self, '_chol_diag_memo'):
+            if self._chol.ndimension() == 3:
+                batch_size, diag_size, _ = self._chol.size()
+                batch_index = self._chol.data.new(batch_size).long()
+                torch.arange(0, batch_size, out=batch_index)
+                batch_index = (
+                    batch_index.unsqueeze(1).
+                    repeat(1, diag_size).
+                    view(-1)
+                )
+                diag_index = self._chol.data.new(diag_size).long()
+                torch.arange(0, diag_size, out=diag_index)
+                diag_index = (
+                    diag_index.unsqueeze(1).
+                    repeat(batch_size, 1).
+                    view(-1)
+                )
+                self._chol_diag_memo = self._chol[batch_index, diag_index, diag_index].view(batch_size, diag_size)
+            else:
+                self._chol_diag_memo = self._chol.diag()
+        return self._chol_diag_memo
+
+    def inv_matmul(self, rhs):
+        if self.ndimension() == 2:
+            res = torch.potrs(rhs, self._chol, upper=False)
+        else:
+            res = super(CholLazyVariable, self).inv_matmul(rhs)
+        return res
+
+    def inv_quad_log_det(self, inv_quad_rhs=None, log_det=False):
+        inv_quad_term = None
+        log_det_term = None
+        is_batch = (self.ndimension() == 3)
+
+        if inv_quad_rhs is not None:
+            inv_quad_term = (
+                self.inv_matmul(inv_quad_rhs).
+                mul(inv_quad_rhs).
+                sum(-1).
+                sum(-1, keepdim=(not is_batch))
+            )
+
+        if log_det:
+            log_det_term = (
+                self._chol_diag.
+                log().
+                sum(-1).
+                mul(2)
+            )
+
+        return inv_quad_term, log_det_term

--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -199,23 +199,6 @@ class LazyVariable(object):
                 eye = eye.unsqueeze(0).expand(batch_size, n_cols, n_cols)
             return self.matmul(eye)
 
-    def exact_gp_marginal_log_likelihood(self, target):
-        """
-        Computes the marginal log likelihood of a Gaussian process whose covariance matrix
-        plus the diagonal noise term (added using add_diag above) is stored as this lazy variable
-
-        Args:
-            - target (vector n) - training label vector to be used in the marginal log likelihood calculation.
-        Returns:
-            - scalar - The GP marginal log likelihood where (K+\sigma^{2}I) is represented by this LazyVariable.
-        """
-        if not hasattr(self, '_gp_mll_class'):
-            dqff = self._derivative_quadratic_form_factory
-            self._gp_mll_class = function_factory.exact_gp_mll_factory(self._matmul_closure_factory,
-                                                                       dqff)
-        args = list(self.representation()) + [target]
-        return self._gp_mll_class()(*args)
-
     def exact_predictive_mean(self, full_mean, train_labels, noise, precomputed_cache=None):
         """
         Computes the posterior predictive covariance of a GP
@@ -659,14 +642,6 @@ class LazyVariable(object):
         if not hasattr(self, '_tensor_cls'):
             self._tensor_cls = _import_dotted_name(self.representation()[0].data.type())
         return self._tensor_cls
-
-    def trace_log_det_quad_form(self, mu_diffs, chol_covar_1):
-        if not hasattr(self, '_trace_log_det_quad_form_class'):
-            tlqf_function_factory = function_factory.trace_logdet_quad_form_factory
-            self._trace_log_det_quad_form_class = tlqf_function_factory(self._matmul_closure_factory,
-                                                                        self._derivative_quadratic_form_factory)
-        covar2_args = self.representation()
-        return self._trace_log_det_quad_form_class()(mu_diffs, chol_covar_1, *covar2_args)
 
     def zero_mean_mvn_samples(self, n_samples):
         """

--- a/gpytorch/lazy/sum_lazy_variable.py
+++ b/gpytorch/lazy/sum_lazy_variable.py
@@ -51,7 +51,7 @@ class SumLazyVariable(LazyVariable):
         return self.lazy_vars[0].size()
 
     def _transpose_nonbatch(self):
-        lazy_vars_t = list(lazy_var.t() for lazy_var in self.lazy_var)
+        lazy_vars_t = list(lazy_var.transpose(-1, -2) for lazy_var in self.lazy_vars)
         return SumLazyVariable(*lazy_vars_t)
 
     def _batch_get_indices(self, batch_indices, left_indices, right_indices):

--- a/gpytorch/models/abstract_variational_gp.py
+++ b/gpytorch/models/abstract_variational_gp.py
@@ -8,7 +8,7 @@ from torch import nn
 from torch.autograd import Variable
 from ..module import Module
 from ..random_variables import GaussianRandomVariable
-from ..lazy import LazyVariable, RootLazyVariable
+from ..lazy import LazyVariable, CholLazyVariable
 
 
 class AbstractVariationalGP(Module):
@@ -88,4 +88,5 @@ class AbstractVariationalGP(Module):
             raise RuntimeError('Invalid number of variational covar dimensions')
 
         chol_variational_covar = inside.mul(chol_variational_covar)
-        return GaussianRandomVariable(self.variational_mean, RootLazyVariable(chol_variational_covar))
+        variational_covar = CholLazyVariable(chol_variational_covar.transpose(-1, -2))
+        return GaussianRandomVariable(self.variational_mean, variational_covar)

--- a/gpytorch/models/grid_inducing_variational_gp.py
+++ b/gpytorch/models/grid_inducing_variational_gp.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import torch
 from torch.autograd import Variable
 from ..random_variables import GaussianRandomVariable
-from ..lazy import DiagLazyVariable, InterpolatedLazyVariable, PsdSumLazyVariable
+from ..lazy import DiagLazyVariable, InterpolatedLazyVariable
 from ..variational import MVNVariationalStrategy
 from ..kernels.kernel import Kernel
 from ..kernels.grid_kernel import GridKernel
@@ -92,10 +92,11 @@ class GridInducingVariationalGP(AbstractVariationalGP):
 
         # Diagonal correction
         if beta_features.diagonal_correction.on():
+            from ..lazy import AddedDiagLazyVariable
             prior_covar = InterpolatedLazyVariable(prior_output.covar(), interp_indices, interp_values,
                                                    interp_indices, interp_values)
             diagonal_correction = DiagLazyVariable((self.covar_diag(inputs) - prior_covar.diag()) * 0)
-            test_covar = PsdSumLazyVariable(test_covar, diagonal_correction)
+            test_covar = AddedDiagLazyVariable(test_covar, diagonal_correction)
 
         output = GaussianRandomVariable(test_mean, test_covar)
         return output

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -1,9 +1,10 @@
 import torch
 from torch.autograd import Variable
-from ..lazy import LazyVariable, NonLazyVariable
 
 
 def pivoted_cholesky(matrix, max_iter, error_tol=1e-3):
+    from ..lazy import LazyVariable, NonLazyVariable
+
     # matrix is assumed to be batch_size x n x n
     if matrix.ndimension() < 3:
         batch_size = 1

--- a/gpytorch/utils/toeplitz.py
+++ b/gpytorch/utils/toeplitz.py
@@ -4,8 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import torch
-import gpytorch.utils.fft as fft
-import gpytorch.utils as utils
+from ..utils import fft, reverse
 
 
 def toeplitz(toeplitz_column, toeplitz_row):
@@ -140,7 +139,7 @@ def toeplitz_matmul(toeplitz_column, toeplitz_row, tensor):
 
     else:
         batch_size, orig_size, num_rhs = tensor.size()
-        r_reverse = utils.reverse(toeplitz_row[:, 1:], dim=1)
+        r_reverse = reverse(toeplitz_row[:, 1:], dim=1)
 
         c_r_rev = toeplitz_column.new(batch_size, orig_size + r_reverse.size(1)).zero_()
         c_r_rev[:, :orig_size] = toeplitz_column
@@ -220,9 +219,9 @@ def sym_toeplitz_derivative_quadratic_form(left_vectors, right_vectors):
     columns = left_vectors.new(s, m).fill_(0)
     columns[:, 0] = left_vectors[:, 0]
     res = toeplitz_matmul(columns, left_vectors, right_vectors)
-    rows = utils.reverse(left_vectors, dim=1)
+    rows = reverse(left_vectors, dim=1)
     columns[:, 0] = rows[:, 0]
-    res += toeplitz_matmul(columns, rows, utils.reverse(right_vectors, dim=1))
+    res += toeplitz_matmul(columns, rows, reverse(right_vectors, dim=1))
 
     if not batch:
         res = res.sum(0)

--- a/gpytorch/variational/mvn_variational_strategy.py
+++ b/gpytorch/variational/mvn_variational_strategy.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import torch
 from .variational_strategy import VariationalStrategy
-from ..lazy import LazyVariable, NonLazyVariable, RootLazyVariable
+from ..lazy import LazyVariable, NonLazyVariable
 
 
 class MVNVariationalStrategy(VariationalStrategy):
@@ -18,35 +18,18 @@ class MVNVariationalStrategy(VariationalStrategy):
 
         variational_mean = self.variational_dist.mean()
         variational_covar = self.variational_dist.covar()
-        if not isinstance(variational_covar, RootLazyVariable):
-            raise RuntimeError('The variational covar for an MVN distribution should be a RootLazyVariable')
-        chol_variational_covar = variational_covar.root.evaluate()
+        root_variational_covar = variational_covar.root_decomposition()
 
         mean_diffs = prior_mean - variational_mean
-        inv_quad_rhs = torch.cat([chol_variational_covar.transpose(-1, -2), mean_diffs.unsqueeze(-1)], -1)
-
-        if chol_variational_covar.ndimension() == 2:
-            matrix_diag = chol_variational_covar.diag()
-        elif chol_variational_covar.ndimension() == 3:
-            batch_size, diag_size, _ = chol_variational_covar.size()
-            batch_index = chol_variational_covar.data.new(batch_size).long()
-            torch.arange(0, batch_size, out=batch_index)
-            batch_index = batch_index.unsqueeze(1).repeat(1, diag_size).view(-1)
-            diag_index = chol_variational_covar.data.new(diag_size).long()
-            torch.arange(0, diag_size, out=diag_index)
-            diag_index = diag_index.unsqueeze(1).repeat(batch_size, 1).view(-1)
-            matrix_diag = chol_variational_covar[batch_index, diag_index, diag_index].view(batch_size, diag_size)
-        else:
-            raise RuntimeError('Invalid number of variational covar dimensions')
-
-        logdet_variational_covar = matrix_diag.log().sum() * 2
-        trace_plus_inv_quad_form, logdet_prior_covar = prior_covar.inv_quad_log_det(inv_quad_rhs=inv_quad_rhs,
-                                                                                    log_det=True)
+        inv_quad_rhs = torch.cat([root_variational_covar, mean_diffs.unsqueeze(-1)], -1)
+        log_det_variational_covar = variational_covar.log_det()
+        trace_plus_inv_quad_form, log_det_prior_covar = prior_covar.inv_quad_log_det(inv_quad_rhs=inv_quad_rhs,
+                                                                                     log_det=True)
 
         # Compute the KL Divergence.
         res = 0.5 * sum([
-            logdet_prior_covar,
-            logdet_variational_covar.mul(-1),
+            log_det_prior_covar,
+            log_det_variational_covar.mul(-1),
             trace_plus_inv_quad_form,
             -float(mean_diffs.size(-1)),
         ])

--- a/test/lazy/test_chol_lazy_variable.py
+++ b/test/lazy/test_chol_lazy_variable.py
@@ -1,0 +1,158 @@
+import math
+import numpy as np
+import torch
+import unittest
+from torch.autograd import Variable
+from gpytorch.lazy import CholLazyVariable
+from gpytorch.utils import approx_equal
+
+
+class TestCholLazyVariable(unittest.TestCase):
+    def setUp(self):
+        chol = torch.Tensor([
+            [3, 0, 0, 0, 0],
+            [-1, 2, 0, 0, 0],
+            [1, 4, 1, 0, 0],
+            [0, 2, 3, 2, 0],
+            [-4, -2, 1, 3, 4],
+        ])
+        vecs = torch.randn(5, 2)
+
+        self.chol_var = Variable(chol, requires_grad=True)
+        self.chol_var_copy = Variable(chol, requires_grad=True)
+        self.actual_mat = self.chol_var_copy.matmul(self.chol_var_copy.transpose(-1, -2))
+        self.vecs = Variable(vecs, requires_grad=True)
+        self.vecs_copy = Variable(vecs, requires_grad=True)
+
+    def test_matmul(self):
+        # Forward
+        res = CholLazyVariable(self.chol_var).matmul(self.vecs)
+        actual = self.actual_mat.matmul(self.vecs_copy)
+        self.assertTrue(approx_equal(res, actual))
+
+        # Backward
+        grad_output = torch.randn(*self.vecs.size())
+        res.backward(gradient=grad_output)
+        actual.backward(gradient=grad_output)
+        self.assertTrue(approx_equal(self.chol_var.grad.data, self.chol_var_copy.grad.data))
+        self.assertTrue(approx_equal(self.vecs.grad.data, self.vecs_copy.grad.data))
+
+    def test_inv_matmul(self):
+        # Forward
+        res = CholLazyVariable(self.chol_var).inv_matmul(self.vecs)
+        actual = self.actual_mat.inverse().matmul(self.vecs_copy)
+        self.assertLess(torch.max((res.data - actual.data).abs() / actual.data.norm()), 1e-2)
+
+    def test_inv_quad_log_det(self):
+        # Forward
+        res_inv_quad, res_log_det = CholLazyVariable(self.chol_var).inv_quad_log_det(inv_quad_rhs=self.vecs,
+                                                                                     log_det=True)
+        res = res_inv_quad + res_log_det
+        actual_inv_quad = self.actual_mat.inverse().matmul(self.vecs_copy).mul(self.vecs_copy).sum()
+        actual = actual_inv_quad + math.log(np.linalg.det(self.actual_mat.data))
+        self.assertLess(((res.data - actual.data) / actual.data).abs()[0], 1e-2)
+
+    def test_diag(self):
+        res = CholLazyVariable(self.chol_var).diag()
+        actual = self.actual_mat.diag()
+        self.assertTrue(approx_equal(res.data, actual.data))
+
+    def test_getitem(self):
+        res = CholLazyVariable(self.chol_var)[2:4, -2]
+        actual = self.actual_mat[2:4, -2]
+        self.assertTrue(approx_equal(res.data, actual.data))
+
+    def test_evaluate(self):
+        res = CholLazyVariable(self.chol_var).evaluate()
+        actual = self.actual_mat
+        self.assertTrue(approx_equal(res.data, actual.data))
+
+
+class TestCholLazyVariableBatch(unittest.TestCase):
+    def setUp(self):
+        chol = torch.Tensor([
+            [
+                [3, 0, 0, 0, 0],
+                [-1, 2, 0, 0, 0],
+                [1, 4, 1, 0, 0],
+                [0, 2, 3, 2, 0],
+                [-4, -2, 1, 3, 4],
+            ], [
+                [2, 0, 0, 0, 0],
+                [3, 1, 0, 0, 0],
+                [-2, 3, 2, 0, 0],
+                [-2, 1, -1, 3, 0],
+                [-4, -4, 5, 2, 3],
+            ],
+        ])
+        vecs = torch.randn(2, 5, 3)
+
+        self.chol_var = Variable(chol, requires_grad=True)
+        self.chol_var_copy = Variable(chol, requires_grad=True)
+        self.actual_mat = self.chol_var_copy.matmul(self.chol_var_copy.transpose(-1, -2))
+        self.actual_mat_inv = torch.cat([
+            self.actual_mat[0].inverse().unsqueeze(0),
+            self.actual_mat[1].inverse().unsqueeze(0),
+        ], 0)
+
+        self.vecs = Variable(vecs, requires_grad=True)
+        self.vecs_copy = Variable(vecs, requires_grad=True)
+
+    def test_matmul(self):
+        # Forward
+        res = CholLazyVariable(self.chol_var).matmul(self.vecs)
+        actual = self.actual_mat.matmul(self.vecs_copy)
+        self.assertTrue(approx_equal(res, actual))
+
+        # Backward
+        grad_output = torch.randn(*self.vecs.size())
+        res.backward(gradient=grad_output)
+        actual.backward(gradient=grad_output)
+        self.assertTrue(approx_equal(self.chol_var.grad.data, self.chol_var_copy.grad.data))
+        self.assertTrue(approx_equal(self.vecs.grad.data, self.vecs_copy.grad.data))
+
+    def test_inv_matmul(self):
+        # Forward
+        res = CholLazyVariable(self.chol_var).inv_matmul(self.vecs)
+        actual = self.actual_mat_inv.matmul(self.vecs_copy)
+        self.assertLess(torch.max((res.data - actual.data).abs() / actual.data.norm()), 1e-2)
+
+    def test_inv_quad_log_det(self):
+        # Forward
+        res_inv_quad, res_log_det = CholLazyVariable(self.chol_var).inv_quad_log_det(inv_quad_rhs=self.vecs,
+                                                                                     log_det=True)
+        res = res_inv_quad + res_log_det
+        actual_inv_quad = (
+            self.actual_mat_inv.
+            matmul(self.vecs_copy).
+            mul(self.vecs_copy).
+            sum(-1).sum(-1)
+        )
+        actual_log_det = Variable(torch.Tensor([
+            math.log(np.linalg.det(self.actual_mat[0].data)),
+            math.log(np.linalg.det(self.actual_mat[1].data)),
+        ]))
+        actual = actual_inv_quad + actual_log_det
+        self.assertLess(torch.max((res.data - actual.data).abs() / actual.data.norm()), 1e-2)
+
+    def test_diag(self):
+        res = CholLazyVariable(self.chol_var).diag()
+        actual = torch.cat([
+            self.actual_mat[0].diag().unsqueeze(0),
+            self.actual_mat[1].diag().unsqueeze(0),
+        ], 0)
+        self.assertTrue(approx_equal(res.data, actual.data))
+
+    def test_getitem(self):
+        res = CholLazyVariable(self.chol_var)[1, 2:4, -2]
+        actual = self.actual_mat[1, 2:4, -2]
+        self.assertTrue(approx_equal(res.data, actual.data))
+
+    def test_evaluate(self):
+        res = CholLazyVariable(self.chol_var).evaluate()
+        actual = self.actual_mat
+        self.assertTrue(approx_equal(res.data, actual.data))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Some small fixes/refactors to variational inference:

## Features
- The Variational MLL object has an optional `combine_terms` attribute (default true). If you set it to false, the loss returns the two terms (the expected NLL and the KL term) separately.

## Refactors
- MVN KL divergence can now take a lazy variable for the variational covariance. (For now, we're always using a cholesky lazy variable, but it allows for other LV options in the future).
- The AddedDiagLazyVariable is used for the variational diagonal correction

## Minor fixes and tweaks
- Remove the old MLL functions from lazy variables
- Fix a transpose issue in SumLazyVariable