### PR TITLE
Allow to change training targets for exact GP after fitting

### DIFF
--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -43,6 +43,17 @@ class ExactGP(Module):
             self._has_warned = True
         return ExactMarginalLogLikelihood(likelihood, self)(output, target)
 
+    def set_train_targets(self, train_targets):
+        """Set training targets (does not re-fit model parameters)"""
+        for attr in {'shape', 'dtype', 'device'}:
+            if getattr(train_targets, attr) != getattr(self.train_targets, attr):
+                raise RuntimeError(
+                    'Cannot modify {attr} of train_targets'.format(attr=attr)
+              )
+        self.train_targets = train_targets
+        self.mean_cache = None
+        self.covar_cache = None
+
     def train(self, mode=True):
         if mode:
             self.mean_cache = None

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -49,7 +49,7 @@ class ExactGP(Module):
             if getattr(train_targets, attr) != getattr(self.train_targets, attr):
                 raise RuntimeError(
                     'Cannot modify {attr} of train_targets'.format(attr=attr)
-              )
+                )
         self.train_targets = train_targets
         self.mean_cache = None
         self.covar_cache = None


### PR DESCRIPTION
This is useful e.g. for "fantasizing", i.e. performing posterior prediction under different realizations of the training target, without re-fitting the model parameters (see example below).

Note that this is written under pytorch 0.4+ and may not work under pytorch 0.3.1 (feel free to make that compatible)

```
def posterior_mean(gp, X):
    return gp(X).mean()

def fantasize(gp, fun, X, Ydist, nsamp):
    Ybase = gp.train_targets.clone()
    for i in range(nsamp):
        gp.set_train_targets(Ydist.sample())
        yield fun(gp, X)
    gp.set_train_targets(Ybase)

Ydist = Normal(
    loc=training_data.Y[metric],
    scale=training_data.Y_sem[metric],
)

gp.train_targets[:2]

0.1653
 0.3505
[torch.FloatTensor of size (2,)]

for m in evaluate_fantasies(gp, posterior_mean, training_data.X[metric], Ydist, 2):
    print(m[:2])

-0.4004
 0.6623
[torch.FloatTensor of size (2,)]

-0.0739
 0.4799
[torch.FloatTensor of size (2,)]

gp.train_targets[:2]

 0.1653
 0.3505
[torch.FloatTensor of size (2,)]
```

