### PR TITLE
modify expand_as  to expand for 0.4

### DIFF
--- a/gpytorch/kernels/linear_kernel.py
+++ b/gpytorch/kernels/linear_kernel.py
@@ -42,4 +42,4 @@ class LinearKernel(Kernel):
                 (x2 - self.offset).transpose(2, 1)
             )
 
-        return prod + self.variance.expand_as(prod)
+        return prod + self.variance.expand(prod.size())


### PR DESCRIPTION
expand_as(prod) errors out now, because it checks that the input is a Tensor, and the check fails because it's of type MatmulLazyVariable. So instead move to expand(size)