### PR TITLE
RBF stability improvements

### DIFF
--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import math
 from .kernel import Kernel
 
 
@@ -12,7 +13,7 @@ class RBFKernel(Kernel):
         self,
         ard_num_dims=None,
         log_lengthscale_bounds=(-10000, 10000),
-        eps=1e-5,
+        eps=1e-6,
         active_dims=None,
     ):
         super(RBFKernel, self).__init__(
@@ -24,6 +25,6 @@ class RBFKernel(Kernel):
         self.eps = eps
 
     def forward(self, x1, x2):
-        lengthscales = self.log_lengthscale.exp() + self.eps
+        lengthscales = self.log_lengthscale.exp().mul(math.sqrt(2)).clamp(self.eps, 1e5)
         diff = (x1.unsqueeze(2) - x2.unsqueeze(1)).div_(lengthscales)
-        return diff.pow_(2).sum(-1).mul_(-0.5).exp_()
+        return diff.pow_(2).sum(-1).mul_(-1).exp_()


### PR DESCRIPTION
A few changes:

1. We divide the lengthscale by 2 before summing the squared dimension-wise distances. This seems to be more numerically stable than dividing by 2 afterwards.

1. Rather than adding 1e-5 to the lengthscale (to prevent division by zero errors), we're instead using a clamp operation.

Fixes #119 