### PR TITLE
Rename SpectralMixtureKernel's initialize to initialize_from_data

### DIFF
--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -40,7 +40,7 @@ class SpectralMixtureKernel(Kernel):
             bounds=log_mixture_scale_bounds,
         )
 
-    def initialize(self, train_x, train_y, **kwargs):
+    def initialize_from_data(self, train_x, train_y, **kwargs):
         _, n_dims = train_x.size()
 
         if not n_dims == self.n_dims:


### PR DESCRIPTION
SpectralMixtureKernel has an .initialize() function that overrides the function fo the same name of the superclass Module, but these functions have different purposes. This is confusing and has created hard to debug issues.

Since this function is used nowhere in the code, this simply renames it to initialize_from_data as suggested in #149.