### PR TITLE
Support batch GP predictions (Fixes #134)

### DIFF
--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -46,9 +46,9 @@ class Kernel(Module):
             x2 = x1
 
         # Give x1 and x2 a last dimension, if necessary
-        if x1.data.ndimension() == 1:
+        if x1.ndimension() == 1:
             x1 = x1.unsqueeze(1)
-        if x2.data.ndimension() == 1:
+        if x2.ndimension() == 1:
             x2 = x2.unsqueeze(1)
         if not x1.size(-1) == x2.size(-1):
             raise RuntimeError("x1 and x2 must have the same number of dimensions!")

--- a/gpytorch/means/constant_mean.py
+++ b/gpytorch/means/constant_mean.py
@@ -12,12 +12,9 @@ class ConstantMean(Mean):
         super(ConstantMean, self).__init__()
         self.batch_size = batch_size
         if batch_size is None:
-            self.register_parameter("constant", torch.nn.Parameter(torch.zeros(1)), bounds=constant_bounds)
+            self.register_parameter("constant", torch.nn.Parameter(torch.zeros(1, 1)), bounds=constant_bounds)
         else:
             self.register_parameter("constant", torch.nn.Parameter(torch.zeros(batch_size, 1)), bounds=constant_bounds)
 
     def forward(self, input):
-        if self.batch_size is None:
-            return self.constant.expand(input.size(0))
-        else:
-            return self.constant.expand(input.size(0), input.size(1))
+        return self.constant.expand(input.size(0), input.size(1))

--- a/gpytorch/means/mean.py
+++ b/gpytorch/means/mean.py
@@ -9,3 +9,20 @@ from gpytorch.module import Module
 class Mean(Module):
     def forward(self, x):
         raise NotImplementedError()
+
+    def __call__(self, x):
+        # Add a last dimension
+        if x.ndimension() == 1:
+            x = x.unsqueeze(1)
+
+        is_batch = x.ndimension() == 3
+
+        if not is_batch:
+            x = x.unsqueeze(0)
+
+        res = super(Mean, self).__call__(x)
+
+        if not is_batch:
+            res = res[0]
+
+        return res

--- a/test/examples/test_batch_gp_regression.py
+++ b/test/examples/test_batch_gp_regression.py
@@ -1,0 +1,97 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import math
+import torch
+import unittest
+import gpytorch
+from torch import optim
+from torch.autograd import Variable
+from gpytorch.kernels import RBFKernel
+from gpytorch.means import ConstantMean
+from gpytorch.likelihoods import GaussianLikelihood
+from gpytorch.random_variables import GaussianRandomVariable
+
+
+# Batch training test: Let's learn hyperparameters on a sine dataset, but test on a sine dataset and a cosine dataset
+# in parallel.
+train_x1 = Variable(torch.linspace(0, 1, 11)).unsqueeze(-1)
+train_y1 = Variable(torch.sin(train_x1.data * (2 * math.pi))).squeeze()
+test_x1 = Variable(torch.linspace(0, 1, 51)).unsqueeze(-1)
+test_y1 = Variable(torch.sin(test_x1.data * (2 * math.pi))).squeeze()
+
+train_x2 = Variable(torch.linspace(0, 1, 11)).unsqueeze(-1)
+train_y2 = Variable(torch.cos(train_x2.data * (2 * math.pi))).squeeze()
+test_x2 = Variable(torch.linspace(0, 1, 51)).unsqueeze(-1)
+test_y2 = Variable(torch.cos(test_x2.data * (2 * math.pi))).squeeze()
+
+
+class ExactGPModel(gpytorch.models.ExactGP):
+    def __init__(self, train_inputs, train_targets, likelihood):
+        super(ExactGPModel, self).__init__(train_inputs, train_targets, likelihood)
+        self.mean_module = ConstantMean(constant_bounds=(-1, 1))
+        self.covar_module = RBFKernel(log_lengthscale_bounds=(-3, 3))
+
+    def forward(self, x):
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
+        return GaussianRandomVariable(mean_x, covar_x)
+
+
+class TestBatchGPRegression(unittest.TestCase):
+    def test_posterior_latent_gp_and_likelihood_with_optimization(self):
+        # We're manually going to set the hyperparameters to something they shouldn't be
+        likelihood = GaussianLikelihood(log_noise_bounds=(-3, 3))
+        gp_model = ExactGPModel(train_x1.data, train_y1.data, likelihood)
+        mll = gpytorch.ExactMarginalLogLikelihood(likelihood, gp_model)
+        gp_model.covar_module.initialize(log_lengthscale=1)
+        gp_model.mean_module.initialize(constant=0)
+        likelihood.initialize(log_noise=1)
+
+        # Find optimal model hyperparameters
+        gp_model.train()
+        likelihood.train()
+        optimizer = optim.Adam(list(gp_model.parameters()) + list(likelihood.parameters()), lr=0.1)
+        optimizer.n_iter = 0
+        for _ in range(50):
+            optimizer.zero_grad()
+            output = gp_model(train_x1)
+            loss = -mll(output, train_y1)
+            loss.backward()
+            optimizer.n_iter += 1
+            optimizer.step()
+
+        for param in gp_model.parameters():
+            self.assertTrue(param.grad is not None)
+            self.assertGreater(param.grad.norm().item(), 0)
+        for param in likelihood.parameters():
+            self.assertTrue(param.grad is not None)
+            self.assertGreater(param.grad.norm().item(), 0)
+        optimizer.step()
+
+        # Test the model
+        gp_model.eval()
+        likelihood.eval()
+
+        # Create data batches
+        train_x12 = torch.cat((train_x1.unsqueeze(0), train_x2.unsqueeze(0)), dim=0).contiguous()
+        train_y12 = torch.cat((train_y1.unsqueeze(0), train_y2.unsqueeze(0)), dim=0).contiguous()
+        test_x12 = torch.cat((test_x1.unsqueeze(0), test_x2.unsqueeze(0)), dim=0).contiguous()
+
+        # Update gp model to use both sine and cosine training data as train data
+        gp_model.set_train_data(train_x12, train_y12, strict=False)
+
+        # Make predictions for both sets of test points, and check MAEs.
+        batch_predictions = likelihood(gp_model(test_x12))
+        preds1 = batch_predictions.mean()[0]
+        preds2 = batch_predictions.mean()[1]
+        mean_abs_error1 = torch.mean(torch.abs(test_y1 - preds1))
+        mean_abs_error2 = torch.mean(torch.abs(test_y2 - preds2))
+        self.assertLess(mean_abs_error1.data.squeeze().item(), 0.05)
+        self.assertLess(mean_abs_error2.data.squeeze().item(), 0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Exact GPs support batch predictions, which addresses #134. I'll open up another issue for batch training, which shouldn't be that hard (it looks like someone wanted to support this at some point: the `ConstantMean` class has an optional `batch_mode` argument that reshapes the constant parameter appropriately). Now, you can do something like:

```python
batch_train_x = train_x.repeat(3, 1, 1)
batch_train_y = train_y.repeat(3, 1)
batch_test_x = test_x.repeat(3, 1, 1)
model.set_train_data(batch_train_x, batch_train_y, strict=False)
batch_preds = model(batch_test_x)
```

and you'll get batch predictions on each batch of test data, using the corresponding train input and label batches as the input data for that GP.

## Internal Changes
Basically, this just involved bringing prior and posterior means up to speed with what was already done for kernels.
- `Mean` now reshapes `x` to be 3 dimensional, and therefore all means now operate in batch mode by default.
- Fixed `LazyVariable.exact_predictive_mean` to handle batches.
- Internally, exact GPs reshape all input data to be at least two dimensional (e.g., 11 training examples in 1 dimension is now handled internally as an `11 x 1` tensor, just as 2 dimensional data is a `11 x 2` tensor). This is necessary to avoid ambiguity about whether a `10 x 3` tensor means 10 batches of 3 1D training examples or 10 training examples in 3 dimensions.

## Interface changes
- `set_train_data` now has an optional `strict` argument which defaults to true. When false, the shape of the data is allowed to change.