### PR TITLE
AdditiveKernel and ProductKernel now accept several kernels to compose

### DIFF
--- a/gpytorch/kernels/__init__.py
+++ b/gpytorch/kernels/__init__.py
@@ -1,4 +1,4 @@
-from .kernel import Kernel
+from .kernel import Kernel, AdditiveKernel, ProductKernel
 from .rbf_kernel import RBFKernel
 from .matern_kernel import MaternKernel
 from .periodic_kernel import PeriodicKernel
@@ -12,11 +12,13 @@ from .multiplicative_grid_interpolation_kernel import MultiplicativeGridInterpol
 from .white_noise_kernel import WhiteNoiseKernel
 
 __all__ = [
+    AdditiveKernel,
     Kernel,
     LinearKernel,
     RBFKernel,
     MaternKernel,
     PeriodicKernel,
+    ProductKernel,
     SpectralMixtureKernel,
     IndexKernel,
     GridInterpolationKernel,

--- a/test/kernels/test_additive_kernel.py
+++ b/test/kernels/test_additive_kernel.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import math
 import torch
 import unittest
-from gpytorch.kernels import RBFKernel
+from gpytorch.kernels import RBFKernel, AdditiveKernel, ProductKernel
 
 
 class TestAdditiveKernel(unittest.TestCase):
@@ -40,6 +40,38 @@ class TestAdditiveKernel(unittest.TestCase):
         res = kernel(a, b).evaluate()
         self.assertLess(torch.norm(res - actual), 2e-5)
 
+    def test_computes_product_of_three_radial_basis_function(self):
+        a = torch.Tensor([4, 2, 8]).view(3, 1)
+        b = torch.Tensor([0, 2]).view(2, 1)
+        lengthscale = 2
+
+        kernel_1 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel_2 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel_3 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel = ProductKernel(kernel_1, kernel_2, kernel_3)
+
+        actual = torch.Tensor([[16, 4], [4, 0], [64, 36]]).mul_(-0.5).div_(lengthscale ** 2).exp() ** 3
+
+        kernel.eval()
+        res = kernel(a, b).evaluate()
+        self.assertLess(torch.norm(res - actual), 2e-5)
+
+    def test_computes_sum_of_three_radial_basis_function(self):
+        a = torch.Tensor([4, 2, 8]).view(3, 1)
+        b = torch.Tensor([0, 2]).view(2, 1)
+        lengthscale = 2
+
+        kernel_1 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel_2 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel_3 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel = AdditiveKernel(kernel_1, kernel_2, kernel_3)
+
+        actual = torch.Tensor([[16, 4], [4, 0], [64, 36]]).mul_(-0.5).div_(lengthscale ** 2).exp() * 3
+
+        kernel.eval()
+        res = kernel(a, b).evaluate()
+        self.assertLess(torch.norm(res - actual), 2e-5)
+
     def test_computes_sum_radial_basis_function_gradient(self):
         a = torch.Tensor([4, 2, 8]).view(3, 1)
         b = torch.Tensor([0, 2, 2]).view(3, 1)
@@ -60,6 +92,33 @@ class TestAdditiveKernel(unittest.TestCase):
         output = kernel(a, b).evaluate()
         output.backward(gradient=torch.eye(3))
         res = kernel.kernels[0].log_lengthscale.grad + kernel.kernels[1].log_lengthscale.grad
+        self.assertLess(torch.norm(res - actual_param_grad), 2e-5)
+
+    def test_computes_sum_three_radial_basis_function_gradient(self):
+        a = torch.Tensor([4, 2, 8]).view(3, 1)
+        b = torch.Tensor([0, 2, 2]).view(3, 1)
+        lengthscale = 2
+
+        param = math.log(lengthscale) * torch.ones(3, 3)
+        param.requires_grad_()
+        diffs = a.expand(3, 3) - b.expand(3, 3).transpose(0, 1)
+        actual_output = (-0.5 * (diffs / param.exp()) ** 2).exp()
+        actual_output.backward(torch.eye(3))
+        actual_param_grad = param.grad.sum() * 3
+
+        kernel_1 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel_2 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel_3 = RBFKernel().initialize(log_lengthscale=math.log(lengthscale))
+        kernel = AdditiveKernel(kernel_1, kernel_2, kernel_3)
+        kernel.eval()
+
+        output = kernel(a, b).evaluate()
+        output.backward(gradient=torch.eye(3))
+        res = (
+            kernel.kernels[0].log_lengthscale.grad
+            + kernel.kernels[1].log_lengthscale.grad
+            + kernel.kernels[2].log_lengthscale.grad
+        )
         self.assertLess(torch.norm(res - actual_param_grad), 2e-5)
 
 

--- a/test/kernels/test_additive_kernel.py
+++ b/test/kernels/test_additive_kernel.py
@@ -59,7 +59,7 @@ class TestAdditiveKernel(unittest.TestCase):
 
         output = kernel(a, b).evaluate()
         output.backward(gradient=torch.eye(3))
-        res = kernel.kernel_1.log_lengthscale.grad + kernel.kernel_2.log_lengthscale.grad
+        res = kernel.kernels[0].log_lengthscale.grad + kernel.kernels[1].log_lengthscale.grad
         self.assertLess(torch.norm(res - actual_param_grad), 2e-5)
 
 


### PR DESCRIPTION
This was blocking some implementation a student was working on here. 

`AdditiveKernel` and `ProductKernel` now operate on a list of kernels, and accept several kernels in their constructors.