### PR TITLE
Update test_interpolated_lazy_variable to PyTorch 0.4, 0.5

### DIFF
--- a/test/lazy/test_interpolated_lazy_variable.py
+++ b/test/lazy/test_interpolated_lazy_variable.py
@@ -6,24 +6,28 @@ from __future__ import unicode_literals
 import gpytorch
 import torch
 import unittest
-from torch.autograd import Variable
 from gpytorch.lazy import NonLazyVariable, InterpolatedLazyVariable
 from gpytorch.utils import approx_equal
 
 
 class TestInterpolatedLazyVariable(unittest.TestCase):
     def test_matmul(self):
-        left_interp_indices = Variable(torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(3, 1))
-        left_interp_values = Variable(torch.Tensor([[1, 2], [0.5, 1], [1, 3]]).repeat(3, 1), requires_grad=True)
-        left_interp_values_copy = Variable(left_interp_values.data, requires_grad=True)
-        right_interp_indices = Variable(torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(3, 1))
-        right_interp_values = Variable(torch.Tensor([[1, 2], [2, 0.5], [1, 3]]).repeat(3, 1), requires_grad=True)
-        right_interp_values_copy = Variable(right_interp_values.data, requires_grad=True)
+        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(3, 1)
+        left_interp_values = torch.Tensor([[1, 2], [0.5, 1], [1, 3]]).repeat(3, 1)
+        left_interp_values_copy = left_interp_values.clone()
+        left_interp_values.requires_grad = True
+        left_interp_values_copy.requires_grad = True
+        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(3, 1)
+        right_interp_values = torch.Tensor([[1, 2], [2, 0.5], [1, 3]]).repeat(3, 1)
+        right_interp_values_copy = right_interp_values.clone()
+        right_interp_values.requires_grad = True
+        right_interp_values_copy.requires_grad = True
 
         base_lazy_variable_mat = torch.randn(6, 6)
         base_lazy_variable_mat = base_lazy_variable_mat.t().matmul(base_lazy_variable_mat)
-        base_variable = Variable(base_lazy_variable_mat, requires_grad=True)
-        base_variable_copy = Variable(base_lazy_variable_mat, requires_grad=True)
+        base_variable = base_lazy_variable_mat
+        base_variable.requires_grad = True
+        base_variable_copy = base_lazy_variable_mat
         base_lazy_variable = NonLazyVariable(base_variable)
 
         test_matrix = torch.randn(9, 4)
@@ -31,14 +35,14 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         interp_lazy_var = InterpolatedLazyVariable(
             base_lazy_variable, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
         )
-        res = interp_lazy_var.matmul(Variable(test_matrix))
+        res = interp_lazy_var.matmul(test_matrix)
 
-        left_matrix = Variable(torch.zeros(9, 6))
-        right_matrix = Variable(torch.zeros(9, 6))
+        left_matrix = torch.zeros(9, 6)
+        right_matrix = torch.zeros(9, 6)
         left_matrix.scatter_(1, left_interp_indices, left_interp_values_copy)
         right_matrix.scatter_(1, right_interp_indices, right_interp_values_copy)
 
-        actual = left_matrix.matmul(base_variable_copy).matmul(right_matrix.t()).matmul(Variable(test_matrix))
+        actual = left_matrix.matmul(base_variable_copy).matmul(right_matrix.t()).matmul(test_matrix)
         self.assertTrue(approx_equal(res.data, actual.data))
 
         res.sum().backward()
@@ -48,17 +52,23 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         self.assertTrue(approx_equal(left_interp_values.grad.data, left_interp_values_copy.grad.data))
 
     def test_batch_matmul(self):
-        left_interp_indices = Variable(torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 3, 1))
-        left_interp_values = Variable(torch.Tensor([[1, 2], [0.5, 1], [1, 3]]).repeat(5, 3, 1), requires_grad=True)
-        left_interp_values_copy = Variable(left_interp_values.data, requires_grad=True)
-        right_interp_indices = Variable(torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(5, 3, 1))
-        right_interp_values = Variable(torch.Tensor([[1, 2], [2, 0.5], [1, 3]]).repeat(5, 3, 1), requires_grad=True)
-        right_interp_values_copy = Variable(right_interp_values.data, requires_grad=True)
+        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 3, 1)
+        left_interp_values = torch.Tensor([[1, 2], [0.5, 1], [1, 3]]).repeat(5, 3, 1)
+        left_interp_values_copy = left_interp_values.clone()
+        left_interp_values.requires_grad = True
+        left_interp_values_copy.requires_grad = True
+        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(5, 3, 1)
+        right_interp_values = torch.Tensor([[1, 2], [2, 0.5], [1, 3]]).repeat(5, 3, 1)
+        right_interp_values_copy = right_interp_values.clone()
+        right_interp_values.requires_grad = True
+        right_interp_values_copy.requires_grad = True
 
         base_lazy_variable_mat = torch.randn(5, 6, 6)
         base_lazy_variable_mat = base_lazy_variable_mat.transpose(-1, -2).matmul(base_lazy_variable_mat)
-        base_variable = Variable(base_lazy_variable_mat, requires_grad=True)
-        base_variable_copy = Variable(base_lazy_variable_mat, requires_grad=True)
+        base_variable = base_lazy_variable_mat
+        base_variable_copy = base_variable.clone()
+        base_variable.requires_grad = True
+        base_variable_copy.requires_grad = True
         base_lazy_variable = NonLazyVariable(base_variable)
 
         test_matrix = torch.randn(5, 9, 4)
@@ -66,13 +76,13 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         interp_lazy_var = InterpolatedLazyVariable(
             base_lazy_variable, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
         )
-        res = interp_lazy_var.matmul(Variable(test_matrix))
+        res = interp_lazy_var.matmul(test_matrix)
 
         left_matrix_comps = []
         right_matrix_comps = []
         for i in range(5):
-            left_matrix_comp = Variable(torch.zeros(9, 6))
-            right_matrix_comp = Variable(torch.zeros(9, 6))
+            left_matrix_comp = torch.zeros(9, 6)
+            right_matrix_comp = torch.zeros(9, 6)
             left_matrix_comp.scatter_(1, left_interp_indices[i], left_interp_values_copy[i])
             right_matrix_comp.scatter_(1, right_interp_indices[i], right_interp_values_copy[i])
             left_matrix_comps.append(left_matrix_comp.unsqueeze(0))
@@ -81,7 +91,7 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         right_matrix = torch.cat(right_matrix_comps)
 
         actual = left_matrix.matmul(base_variable_copy).matmul(right_matrix.transpose(-1, -2))
-        actual = actual.matmul(Variable(test_matrix))
+        actual = actual.matmul(test_matrix)
         self.assertTrue(approx_equal(res.data, actual.data))
 
         res.sum().backward()
@@ -95,17 +105,24 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         base_lazy_variable_mat = base_lazy_variable_mat.t().matmul(base_lazy_variable_mat)
         test_matrix = torch.randn(3, 4)
 
-        left_interp_indices = Variable(torch.LongTensor([[2, 3], [3, 4], [4, 5]]), requires_grad=True)
-        left_interp_values = Variable(torch.Tensor([[1, 2], [0.5, 1], [1, 3]]), requires_grad=True)
-        right_interp_indices = Variable(torch.LongTensor([[2, 3], [3, 4], [4, 5]]), requires_grad=True)
-        right_interp_values = Variable(torch.Tensor([[1, 2], [0.5, 1], [1, 3]]), requires_grad=True)
-        left_interp_values_copy = Variable(left_interp_values.data, requires_grad=True)
-        right_interp_values_copy = Variable(right_interp_values.data, requires_grad=True)
+        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]])
+        left_interp_values = torch.Tensor([[1, 2], [0.5, 1], [1, 3]])
+        left_interp_values_copy = left_interp_values.clone()
+        left_interp_values.requires_grad = True
+        left_interp_values_copy.requires_grad = True
 
-        base_lazy_variable = Variable(base_lazy_variable_mat, requires_grad=True)
-        base_lazy_variable_copy = Variable(base_lazy_variable_mat, requires_grad=True)
-        test_matrix_var = Variable(test_matrix, requires_grad=True)
-        test_matrix_var_copy = Variable(test_matrix, requires_grad=True)
+        right_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]])
+        right_interp_values = torch.Tensor([[1, 2], [0.5, 1], [1, 3]])
+        right_interp_values_copy = right_interp_values.clone()
+        right_interp_values.requires_grad = True
+        right_interp_values_copy.requires_grad = True
+
+        base_lazy_variable = base_lazy_variable_mat
+        base_lazy_variable.requires_grad = True
+        base_lazy_variable_copy = base_lazy_variable_mat
+        test_matrix_var = test_matrix
+        test_matrix_var.requires_grad = True
+        test_matrix_var_copy = test_matrix
 
         interp_lazy_var = InterpolatedLazyVariable(
             NonLazyVariable(base_lazy_variable),
@@ -116,8 +133,8 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         )
         res = interp_lazy_var.inv_matmul(test_matrix_var)
 
-        left_matrix = Variable(torch.zeros(3, 6))
-        right_matrix = Variable(torch.zeros(3, 6))
+        left_matrix = torch.zeros(3, 6)
+        right_matrix = torch.zeros(3, 6)
         left_matrix.scatter_(1, left_interp_indices, left_interp_values_copy)
         right_matrix.scatter_(1, right_interp_indices, right_interp_values_copy)
         actual_mat = left_matrix.matmul(base_lazy_variable_copy).matmul(right_matrix.transpose(-1, -2))
@@ -133,31 +150,30 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         self.assertTrue(approx_equal(left_interp_values.grad.data, left_interp_values_copy.grad.data))
 
     def test_inv_matmul_batch(self):
-        base_lazy_variable_mat = torch.randn(6, 6)
-        base_lazy_variable_mat = (
-            (base_lazy_variable_mat.t().matmul(base_lazy_variable_mat)).unsqueeze(0).repeat(5, 1, 1)
+        base_lazy_variable = torch.randn(6, 6)
+        base_lazy_variable = (
+            (base_lazy_variable.t().matmul(base_lazy_variable)).unsqueeze(0).repeat(5, 1, 1)
         )
-        test_matrix = torch.randn(5, 3, 4)
+        base_lazy_variable_copy = base_lazy_variable.clone()
+        base_lazy_variable.requires_grad = True
+        base_lazy_variable_copy.requires_grad = True
 
-        left_interp_indices = Variable(
-            torch.LongTensor([[2, 3], [3, 4], [4, 5]]).unsqueeze(0).repeat(5, 1, 1), requires_grad=True
-        )
-        left_interp_values = Variable(
-            torch.Tensor([[1, 2], [0.5, 1], [1, 3]]).unsqueeze(0).repeat(5, 1, 1), requires_grad=True
-        )
-        right_interp_indices = Variable(
-            torch.LongTensor([[2, 3], [3, 4], [4, 5]]).unsqueeze(0).repeat(5, 1, 1), requires_grad=True
-        )
-        right_interp_values = Variable(
-            torch.Tensor([[1, 2], [0.5, 1], [1, 3]]).unsqueeze(0).repeat(5, 1, 1), requires_grad=True
-        )
-        left_interp_values_copy = Variable(left_interp_values.data, requires_grad=True)
-        right_interp_values_copy = Variable(right_interp_values.data, requires_grad=True)
+        test_matrix_var = torch.randn(5, 3, 4)
+        test_matrix_var_copy = test_matrix_var.clone()
+        test_matrix_var.requires_grad = True
+        test_matrix_var_copy.requires_grad = True
 
-        base_lazy_variable = Variable(base_lazy_variable_mat, requires_grad=True)
-        base_lazy_variable_copy = Variable(base_lazy_variable_mat, requires_grad=True)
-        test_matrix_var = Variable(test_matrix, requires_grad=True)
-        test_matrix_var_copy = Variable(test_matrix, requires_grad=True)
+        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).unsqueeze(0).repeat(5, 1, 1)
+        left_interp_values = torch.Tensor([[1, 2], [0.5, 1], [1, 3]]).unsqueeze(0).repeat(5, 1, 1)
+        left_interp_values_copy = left_interp_values.clone()
+        left_interp_values.requires_grad = True
+        left_interp_values_copy.requires_grad = True
+
+        right_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).unsqueeze(0).repeat(5, 1, 1)
+        right_interp_values = torch.Tensor([[1, 2], [0.5, 1], [1, 3]]).unsqueeze(0).repeat(5, 1, 1)
+        right_interp_values_copy = right_interp_values.clone()
+        right_interp_values.requires_grad = True
+        right_interp_values_copy.requires_grad = True
 
         interp_lazy_var = InterpolatedLazyVariable(
             NonLazyVariable(base_lazy_variable),
@@ -171,8 +187,8 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         left_matrix_comps = []
         right_matrix_comps = []
         for i in range(5):
-            left_matrix_comp = Variable(torch.zeros(3, 6))
-            right_matrix_comp = Variable(torch.zeros(3, 6))
+            left_matrix_comp = torch.zeros(3, 6)
+            right_matrix_comp = torch.zeros(3, 6)
             left_matrix_comp.scatter_(1, left_interp_indices[i], left_interp_values_copy[i])
             right_matrix_comp.scatter_(1, right_interp_indices[i], right_interp_values_copy[i])
             left_matrix_comps.append(left_matrix_comp.unsqueeze(0))
@@ -192,16 +208,17 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         self.assertTrue(approx_equal(left_interp_values.grad.data, left_interp_values_copy.grad.data))
 
     def test_matmul_batch(self):
-        left_interp_indices = Variable(torch.LongTensor([[2, 3], [3, 4], [4, 5]])).repeat(5, 3, 1)
-        left_interp_values = Variable(torch.Tensor([[1, 2], [0.5, 1], [1, 3]])).repeat(5, 3, 1)
-        right_interp_indices = Variable(torch.LongTensor([[0, 1], [1, 2], [2, 3]])).repeat(5, 3, 1)
-        right_interp_values = Variable(torch.Tensor([[1, 2], [2, 0.5], [1, 3]])).repeat(5, 3, 1)
+        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 3, 1)
+        left_interp_values = torch.Tensor([[1, 2], [0.5, 1], [1, 3]]).repeat(5, 3, 1)
+        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(5, 3, 1)
+        right_interp_values = torch.Tensor([[1, 2], [2, 0.5], [1, 3]]).repeat(5, 3, 1)
 
         base_lazy_variable_mat = torch.randn(5, 6, 6)
         base_lazy_variable_mat = base_lazy_variable_mat.transpose(1, 2).matmul(base_lazy_variable_mat)
-        test_matrix = Variable(torch.randn(1, 9, 4))
+        base_lazy_variable_mat.requires_grad = True
+        test_matrix = torch.randn(1, 9, 4)
 
-        base_lazy_variable = NonLazyVariable(Variable(base_lazy_variable_mat, requires_grad=True))
+        base_lazy_variable = NonLazyVariable(base_lazy_variable_mat)
         interp_lazy_var = InterpolatedLazyVariable(
             base_lazy_variable, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
         )
@@ -241,15 +258,16 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         self.assertTrue(approx_equal(res.data, actual))
 
     def test_getitem_batch(self):
-        left_interp_indices = Variable(torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 1, 1))
-        left_interp_values = Variable(torch.Tensor([[1, 1], [1, 1], [1, 1]]).repeat(5, 1, 1))
-        right_interp_indices = Variable(torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(5, 1, 1))
-        right_interp_values = Variable(torch.Tensor([[1, 1], [1, 1], [1, 1]]).repeat(5, 1, 1))
+        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 1, 1)
+        left_interp_values = torch.Tensor([[1, 1], [1, 1], [1, 1]]).repeat(5, 1, 1)
+        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(5, 1, 1)
+        right_interp_values = torch.Tensor([[1, 1], [1, 1], [1, 1]]).repeat(5, 1, 1)
 
         base_lazy_variable_mat = torch.randn(5, 6, 6)
         base_lazy_variable_mat = base_lazy_variable_mat.transpose(1, 2).matmul(base_lazy_variable_mat)
+        base_lazy_variable_mat.requires_grad = True
 
-        base_lazy_variable = NonLazyVariable(Variable(base_lazy_variable_mat, requires_grad=True))
+        base_lazy_variable = NonLazyVariable(base_lazy_variable_mat)
         interp_lazy_var = InterpolatedLazyVariable(
             base_lazy_variable, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
         )
@@ -270,15 +288,16 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         self.assertTrue(approx_equal(interp_lazy_var[1, :1, 2].data, actual[1, :1, 2].data))
 
     def test_diag(self):
-        left_interp_indices = Variable(torch.LongTensor([[2, 3], [3, 4], [4, 5]]))
-        left_interp_values = Variable(torch.Tensor([[1, 1], [1, 1], [1, 1]]))
-        right_interp_indices = Variable(torch.LongTensor([[0, 1], [1, 2], [2, 3]]))
-        right_interp_values = Variable(torch.Tensor([[1, 1], [1, 1], [1, 1]]))
+        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]])
+        left_interp_values = torch.Tensor([[1, 1], [1, 1], [1, 1]])
+        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]])
+        right_interp_values = torch.Tensor([[1, 1], [1, 1], [1, 1]])
 
         base_lazy_variable_mat = torch.randn(6, 6)
         base_lazy_variable_mat = base_lazy_variable_mat.t().matmul(base_lazy_variable_mat)
+        base_lazy_variable_mat.requires_grad = True
 
-        base_lazy_variable = NonLazyVariable(Variable(base_lazy_variable_mat, requires_grad=True))
+        base_lazy_variable = NonLazyVariable(base_lazy_variable_mat)
         interp_lazy_var = InterpolatedLazyVariable(
             base_lazy_variable, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
         )
@@ -287,15 +306,16 @@ class TestInterpolatedLazyVariable(unittest.TestCase):
         self.assertTrue(approx_equal(actual.diag().data, interp_lazy_var.diag().data))
 
     def test_batch_diag(self):
-        left_interp_indices = Variable(torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 1, 1))
-        left_interp_values = Variable(torch.Tensor([[1, 1], [1, 1], [1, 1]]).repeat(5, 1, 1))
-        right_interp_indices = Variable(torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(5, 1, 1))
-        right_interp_values = Variable(torch.Tensor([[1, 1], [1, 1], [1, 1]]).repeat(5, 1, 1))
+        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 1, 1)
+        left_interp_values = torch.Tensor([[1, 1], [1, 1], [1, 1]]).repeat(5, 1, 1)
+        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(5, 1, 1)
+        right_interp_values = torch.Tensor([[1, 1], [1, 1], [1, 1]]).repeat(5, 1, 1)
 
         base_lazy_variable_mat = torch.randn(5, 6, 6)
         base_lazy_variable_mat = base_lazy_variable_mat.transpose(1, 2).matmul(base_lazy_variable_mat)
+        base_lazy_variable_mat.requires_grad = True
 
-        base_lazy_variable = NonLazyVariable(Variable(base_lazy_variable_mat, requires_grad=True))
+        base_lazy_variable = NonLazyVariable(base_lazy_variable_mat)
         interp_lazy_var = InterpolatedLazyVariable(
             base_lazy_variable, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
         )


### PR DESCRIPTION
Fixes #169, as well as removes `Variable` from the test entirely.