### PR TITLE
Remove custom __getattr__ and __setattr__ from gpytorch.Module (addresses #180)

### DIFF
--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -227,23 +227,3 @@ class Module(nn.Module):
         if len(outputs) == 1:
             outputs = outputs[0]
         return outputs
-
-    def __getattr__(self, name):
-        if "_parameters" in self.__dict__:
-            _parameters = self.__dict__["_parameters"]
-            if name in _parameters:
-                return _parameters[name]
-        if "_buffers" in self.__dict__:
-            _buffers = self.__dict__["_buffers"]
-            if name in _buffers:
-                return _buffers[name]
-        if "_modules" in self.__dict__:
-            modules = self.__dict__["_modules"]
-            if name in modules:
-                return modules[name]
-        raise AttributeError("'{}' object has no attribute '{}'".format(type(self).__name__, name))
-
-    def __setattr__(self, name, value):
-        if isinstance(value, nn.Parameter):
-            raise RuntimeError("Please assign torch.nn.Parameters using" "gpytorch.module.register_parameters()")
-        super(Module, self).__setattr__(name, value)

--- a/test/examples/test_kissgp_gp_classification.py
+++ b/test/examples/test_kissgp_gp_classification.py
@@ -28,11 +28,7 @@ class GPClassificationModel(gpytorch.models.GridInducingVariationalGP):
         self.covar_module = RBFKernel(
             log_lengthscale_prior=SmoothedBoxPrior(exp(-5), exp(6), sigma=0.1, log_transform=True)
         )
-        self.register_parameter(
-            name="log_outputscale",
-            parameter=torch.nn.Parameter(torch.Tensor([0])),
-            prior=SmoothedBoxPrior(exp(-5), exp(6), sigma=0.1, log_transform=True),
-        )
+        self.log_outputscale = torch.nn.Parameter(torch.Tensor([0]))
 
     def forward(self, x):
         mean_x = self.mean_module(x)

--- a/test/examples/test_kissgp_gp_classification.py
+++ b/test/examples/test_kissgp_gp_classification.py
@@ -58,6 +58,7 @@ class TestKISSGPClassification(unittest.TestCase):
             optimizer.n_iter += 1
             optimizer.step()
 
+        self.assertTrue(model.log_outputscale.grad is not None)
         for param in model.parameters():
             self.assertTrue(param.grad is not None)
             self.assertGreater(param.grad.norm().item(), 0)


### PR DESCRIPTION
It seems like this was easy enough -- I think these really only existed to stop people from creating parameters without bounds. Since bounds are now handled exclusively as priors, none of the functionality in those methods accomplished anything necessary.

Travis, what do you think?

#180 