### PR TITLE
Speed up eval of log_prob for InverseWishartPrior

### DIFF
--- a/gpytorch/priors/wishart_prior.py
+++ b/gpytorch/priors/wishart_prior.py
@@ -73,7 +73,7 @@ class InverseWishartPrior(Prior):
             raise ValueError("parameter must be positive definite for Inverse Wishart prior")
         return self.C - 0.5 * (
             (self.nu + 2 * self.shape[0]) * torch.log(torch.det(parameter))
-            + torch.trace(self.K.matmul(torch.inverse(parameter)))
+            + torch.trace(torch.gesv(self.K, parameter)[0])
         )
 
     def is_in_support(self, parameter):


### PR DESCRIPTION
With `A`, `B` positive definite we have `trace(AB^-1) = trace(B^-1A)`.

For 3x3 matrices:
```
%timeit torch.trace(A.matmul(B.inverse()))
35.5 µs ± 1.03 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

%timeit torch.trace(torch.gesv(A, B)[0])
24.9 µs ± 436 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```