### PR TITLE
Use InterpolatedLazyVariable prediction methods

### DIFF
--- a/gpytorch/functions/__init__.py
+++ b/gpytorch/functions/__init__.py
@@ -106,6 +106,7 @@ def exact_predictive_covar(full_covar, n_train, noise, precomputed_cache=None):
         from ..lazy.non_lazy_variable import NonLazyVariable
 
         full_covar = NonLazyVariable(full_covar)
+
     return full_covar.exact_predictive_covar(n_train, noise, precomputed_cache)
 
 

--- a/gpytorch/kernels/grid_interpolation_kernel.py
+++ b/gpytorch/kernels/grid_interpolation_kernel.py
@@ -30,6 +30,10 @@ class GridInterpolationKernel(GridKernel):
             base_kernel_module=base_kernel_module, inducing_points=inducing_points, grid=grid, active_dims=active_dims
         )
 
+    @property
+    def has_custom_exact_predictions(self):
+        return True
+
     def _compute_grid(self, inputs):
         batch_size, n_data, n_dimensions = inputs.size()
         inputs = inputs.view(batch_size * n_data, n_dimensions)

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -81,6 +81,10 @@ class Kernel(Module):
         else:
             return None
 
+    @property
+    def has_custom_exact_predictions(self):
+        return False
+
     @abstractmethod
     def forward(self, x1, x2, **params):
         raise NotImplementedError()

--- a/gpytorch/lazy/lazy_evaluated_kernel_variable.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_variable.py
@@ -109,6 +109,21 @@ class LazyEvaluatedKernelVariable(LazyVariable):
     def evaluate(self):
         return self.evaluate_kernel().evaluate()
 
+    def exact_predictive_mean(self, full_mean, train_labels, noise, precomputed_cache=None):
+        if self.kernel.has_custom_exact_predictions:
+            return self.evaluate_kernel().exact_predictive_mean(full_mean, train_labels, noise, precomputed_cache)
+        else:
+            return super(LazyEvaluatedKernelVariable, self).exact_predictive_mean(full_mean,
+                                                                                  train_labels,
+                                                                                  noise,
+                                                                                  precomputed_cache)
+
+    def exact_predictive_covar(self, n_train, noise, precomputed_cache=None):
+        if self.kernel.has_custom_exact_predictions:
+            return self.evaluate_kernel().exact_predictive_covar(n_train, noise, precomputed_cache)
+        else:
+            return super(LazyEvaluatedKernelVariable, self).exact_predictive_covar(n_train, noise, precomputed_cache)
+
     def __getitem__(self, index):
         index = list(index) if isinstance(index, tuple) else [index]
         ndimension = self.ndimension()


### PR DESCRIPTION
Since introducing `LazyEvaluatedKernelVariables`, it turns out we've always used the default `LazyVariable.exact_predictive_mean` and covar method. 

This made predictions a bit slower for SKI since we weren't taking full advantage of the caching abilities, and it also made LOVE predictions and sampling slower for SKI than it should have been / was in the paper.

This PR patches this by allowing kernels to specify that whatever they return has custom prediction code (which at the moment only applies to SKI). If we write another kernel with this property, then perhaps we can come up with a better solution then; for the moment, I'm going to merge this if everything passes, however, since it's a pretty serious performance bug for SKI.

@gpleiss 