### PR TITLE
Prior mode for exact GPs

### DIFF
--- a/gpytorch/functions/__init__.py
+++ b/gpytorch/functions/__init__.py
@@ -81,6 +81,9 @@ def exact_predictive_mean(full_covar, full_mean, train_labels, n_train, likeliho
     Returns:
     - (t) - the predictive posterior mean of the test points
     """
+    if not n_train:
+        return full_mean, None
+
     if not hasattr(full_covar, "exact_predictive_mean"):
         from ..lazy.non_lazy_variable import NonLazyVariable
 
@@ -102,6 +105,9 @@ def exact_predictive_covar(full_covar, n_train, likelihood, precomputed_cache=No
     Returns:
     - LazyVariable (t x t) - the predictive posterior covariance of the test points
     """
+    if not n_train:
+        return full_covar, None
+
     if not hasattr(full_covar, "exact_predictive_covar"):
         from ..lazy.non_lazy_variable import NonLazyVariable
 

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -53,6 +53,17 @@ class _value_context(object):
         return False
 
 
+class debug(_feature_flag):
+    """
+    Whether or not to perform "safety" checks on the supplied data.
+    (For example, that the correct training data is supplied in Exact GP training mode)
+    Pros: fewer data checks, fewer warning messages
+    Cons: possibility of supplying incorrect data, model accidentially in wrong mode
+    """
+
+    _state = True
+
+
 class max_cg_iterations(_value_context):
     """
     The maximum number of conjugate gradient iterations to perform (when computing
@@ -78,9 +89,8 @@ class max_root_decomposition_size(_value_context):
 class max_lanczos_iterations(max_root_decomposition_size):
     """
     The maximum number of Lanczos iterations to perform
-    This is used when 1) computing variance estiamtes 2) when drawing from MVNs,
-    or 3) for kernel multiplication
-    More values results in higher accuracy
+    This is used when 1) computing variance estiamtes 2) when drawing from
+    MVNs, or 3) for kernel multiplication More values results in higher accuracy
     Default: 100
 
     DEPRECATED: Use max_root_decomposition_size instead
@@ -113,6 +123,16 @@ class max_lanczos_quadrature_iterations(_value_context):
     _global_value = 15
 
 
+class memory_efficient(_feature_flag):
+    """
+    Whether or not to use Toeplitz math with gridded data, grid inducing point modules
+    Pros: memory efficient, faster on CPU
+    Cons: slower on GPUs with < 10000 inducing points
+    """
+
+    _state = False
+
+
 class num_likelihood_samples(_value_context):
     """
     The number of samples to draw from a latent GP when computing a likelihood
@@ -142,13 +162,3 @@ class use_toeplitz(_feature_flag):
     """
 
     _state = True
-
-
-class memory_efficient(_feature_flag):
-    """
-    Whether or not to use Toeplitz math with gridded data, grid inducing point modules
-    Pros: memory efficient, faster on CPU
-    Cons: slower on GPUs with < 10000 inducing points
-    """
-
-    _state = False

--- a/test/examples/test_multitask_gp_regression.py
+++ b/test/examples/test_multitask_gp_regression.py
@@ -11,7 +11,6 @@ import torch
 import unittest
 import gpytorch
 from torch import optim
-from torch.autograd import Variable
 from gpytorch.kernels import RBFKernel, IndexKernel
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.means import ConstantMean
@@ -19,17 +18,17 @@ from gpytorch.priors import InverseWishartPrior, SmoothedBoxPrior
 from gpytorch.random_variables import GaussianRandomVariable
 
 # Simple training data: let's try to learn a sine function
-train_x = Variable(torch.linspace(0, 1, 100))
-y1_inds = Variable(torch.zeros(100).long())
-y2_inds = Variable(torch.ones(100).long())
-train_y1 = Variable(torch.sin(train_x.data * (2 * pi)))
-train_y2 = Variable(torch.cos(train_x.data * (2 * pi)))
+train_x = torch.linspace(0, 1, 100)
+y1_inds = torch.zeros(100).long()
+y2_inds = torch.ones(100).long()
+train_y1 = torch.sin(train_x * (2 * pi))
+train_y2 = torch.cos(train_x * (2 * pi))
 
-test_x = Variable(torch.linspace(0, 1, 51))
-y1_inds_test = Variable(torch.zeros(51).long())
-y2_inds_test = Variable(torch.ones(51).long())
-test_y1 = Variable(torch.sin(test_x.data * (2 * pi)))
-test_y2 = Variable(torch.cos(test_x.data * (2 * pi)))
+test_x = torch.linspace(0, 1, 51)
+y1_inds_test = torch.zeros(51).long()
+y2_inds_test = torch.ones(51).long()
+test_y1 = torch.sin(test_x * (2 * pi))
+test_y2 = torch.cos(test_x * (2 * pi))
 
 
 class MultitaskGPModel(gpytorch.models.ExactGP):
@@ -65,9 +64,7 @@ class TestMultiTaskGPRegression(unittest.TestCase):
     def test_multitask_gp_mean_abs_error(self):
         likelihood = GaussianLikelihood(log_noise_prior=SmoothedBoxPrior(-6, 6))
         gp_model = MultitaskGPModel(
-            (torch.cat([train_x.data, train_x.data]), torch.cat([y1_inds.data, y2_inds.data])),
-            torch.cat([train_y1.data, train_y2.data]),
-            likelihood,
+            (torch.cat([train_x, train_x]), torch.cat([y1_inds, y2_inds])), torch.cat([train_y1, train_y2]), likelihood
         )
         mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, gp_model)
 
@@ -98,12 +95,12 @@ class TestMultiTaskGPRegression(unittest.TestCase):
         test_preds_task_1 = likelihood(gp_model(test_x, y1_inds_test)).mean()
         mean_abs_error_task_1 = torch.mean(torch.abs(test_y1 - test_preds_task_1))
 
-        self.assertLess(mean_abs_error_task_1.data.squeeze().item(), 0.05)
+        self.assertLess(mean_abs_error_task_1.item(), 0.05)
 
         test_preds_task_2 = likelihood(gp_model(test_x, y2_inds_test)).mean()
         mean_abs_error_task_2 = torch.mean(torch.abs(test_y2 - test_preds_task_2))
 
-        self.assertLess(mean_abs_error_task_2.data.squeeze().item(), 0.05)
+        self.assertLess(mean_abs_error_task_2.item(), 0.05)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Can now construct an exact GP with `train_inputs=None, train_targets=None`.
That GP in `eval()` mode will return the prior
That GP in `train()` mode will return an error

Also introduces a debug mode, which suppresses warnings in exact GPs.
Cleans up some old pytorch 0.3 references in tests as well

Closes #173