### PR TITLE
Detach mean and covar caches at test time

### DIFF
--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -427,7 +427,7 @@ class LazyVariable(object):
         if res.ndimension() == 3:
             res = res.squeeze(-1)
         res = res + test_mean
-        return res, precomputed_cache
+        return res, precomputed_cache.detach()
 
     def _exact_predictive_covar_inv_quad_form_cache(self, train_train_covar_inv_root, test_train_covar):
         """
@@ -505,7 +505,7 @@ class LazyVariable(object):
 
         covar_inv_quad_form_root = self._exact_predictive_covar_inv_quad_form_root(precomputed_cache, test_train_covar)
         res = test_test_covar + RootLazyVariable(covar_inv_quad_form_root).mul(-1)
-        return res, precomputed_cache
+        return res, precomputed_cache.detach()
 
     def inv_matmul(self, tensor):
         """


### PR DESCRIPTION
This PR detaches the mean and covariance caches computed at test time. This has two effects:

First and most importantly, backpropagating through GP predictions is bugged on master for things like BayesOpt. Specifically, a pattern like:

```python
from batch_acquisition import batch_expected_improvement
x = torch.tensor([0.25], requires_grad=True)
optimizer = torch.optim.Adam([x], lr=0.1)
for i in range(50):
    optimizer.zero_grad()
    loss = -batch_expected_improvement(x, model, 0)
    print('Iter {}, loss = {}'.format(i, loss))
    loss.backward()
    optimizer.step()
```

throws a runtime error on master (technically the gpytorchopt branch), because the caches require grad due to the model parameters but aren't created by the call to the acquisition function. Therefore, when `backward()` is called, intermediate things are deleted that aren't ever recreated in this loop, so calling `backward()` a second time is not possible without specifying `retain_graph=True`.

Second, this should be a performance improvement for derivatives through predictions, as we no longer enter backwards calls of expensive functions like `InvMatmul`.

Fixes #175 