### PR TITLE
fix conditional in gpytorch.kernels.Kernel.__call__ when active_dims is set

### DIFF
--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -101,15 +101,12 @@ class Kernel(Module):
         raise NotImplementedError()
 
     def __call__(self, x1_, x2_=None, **params):
+        x1, x2 = x1_, x2_
+
         if self.active_dims is not None:
             x1 = x1_.index_select(-1, self.active_dims)
             if x2_ is not None:
                 x2 = x2_.index_select(-1, self.active_dims)
-            else:
-                x2 = None
-        else:
-            x1 = x1_
-            x2 = x2_
 
         if x2 is None:
             x2 = x1

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -105,6 +105,8 @@ class Kernel(Module):
             x1 = x1_.index_select(-1, self.active_dims)
             if x2_ is not None:
                 x2 = x2_.index_select(-1, self.active_dims)
+            else:
+                x2 = None
         else:
             x1 = x1_
             x2 = x2_


### PR DESCRIPTION
I think the requested changes are relatively straightforward. I ran into this when trying to evaluate individual components of an `AdditiveKernel` instance.

In the current master branch, if `x2_` is `None` when `active_dims` is set, `x2` never gets set, so the conditional at [line 112](https://github.com/cornellius-gp/gpytorch/blob/master/gpytorch/kernels/kernel.py#L112) gets skipped over.

`AdditiveKernel` doesn't trigger this behavior because it passes `x1` and `x2` explicitly.

My proposed solution is to move the default case up to the front of the method, before the `active_dims` check.
