### PR TITLE
ConstantMulLazyVariable now uses a scalar when appropriate

### DIFF
--- a/gpytorch/lazy/constant_mul_lazy_variable.py
+++ b/gpytorch/lazy/constant_mul_lazy_variable.py
@@ -10,9 +10,12 @@ from .lazy_variable import LazyVariable
 class ConstantMulLazyVariable(LazyVariable):
     def __init__(self, lazy_var, constant):
         if torch.is_tensor(constant):
+            if constant.numel() == 1:
+                constant = constant.squeeze()
             constant = constant
         else:
-            constant = torch.tensor([constant], device=lazy_var.device, dtype=torch.float32)
+            constant = torch.tensor(constant, device=lazy_var.device, dtype=torch.float32)
+
         super(ConstantMulLazyVariable, self).__init__(lazy_var, constant)
         self.lazy_var = lazy_var
         self.constant = constant

--- a/gpytorch/lazy/constant_mul_lazy_variable.py
+++ b/gpytorch/lazy/constant_mul_lazy_variable.py
@@ -12,7 +12,6 @@ class ConstantMulLazyVariable(LazyVariable):
         if torch.is_tensor(constant):
             if constant.numel() == 1:
                 constant = constant.squeeze()
-            constant = constant
         else:
             constant = torch.tensor(constant, device=lazy_var.device, dtype=torch.float32)
 


### PR DESCRIPTION
`ConstantMulLazyVariable` now uses a torch scalar for its constant if there is only one element in the constant (e.g., not batch mode).

This fixes some bugs when back-propagating through samples on pytorch master. 

cc @Balandat 