### PR TITLE
Generalized MultitaskGaussianLikelihood to include off-diagonal covariances for task noise

### DIFF
--- a/gpytorch/lazy/root_lazy_variable.py
+++ b/gpytorch/lazy/root_lazy_variable.py
@@ -65,7 +65,7 @@ class RootLazyVariable(LazyVariable):
     def _batch_get_indices(self, batch_indices, left_indices, right_indices):
         n_indices = left_indices.numel()
         if n_indices > self.size(-1) * self.size(-2) * self.size(-3):
-            return self._evaluated[batch_indices, left_indices, right_indices]
+            return self.evaluate()[batch_indices, left_indices, right_indices]
 
         else:
             outer_size = batch_indices.size(0)
@@ -93,7 +93,7 @@ class RootLazyVariable(LazyVariable):
     def _get_indices(self, left_indices, right_indices):
         n_indices = left_indices.numel()
         if n_indices > self.size(-1) * self.size(-2):
-            return self._evaluated[left_indices, right_indices]
+            return self.evaluate()[left_indices, right_indices]
 
         else:
             outer_size = left_indices.size(0)

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -1,53 +1,75 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import torch
 from gpytorch.functions import add_diag
+from gpytorch.lazy import (
+    DiagLazyVariable,
+    KroneckerProductLazyVariable,
+    RootLazyVariable,
+)
 from gpytorch.likelihoods import GaussianLikelihood
-from gpytorch.lazy import DiagLazyVariable, KroneckerProductLazyVariable, RootLazyVariable
 
 
 def _eval_covar_matrix(task_noise_covar_factor, log_noise):
     n_tasks = task_noise_covar_factor.size(0)
-    return task_noise_covar_factor.matmul(task_noise_covar_factor.transpose(-1, -2)) + log_noise.exp() * torch.eye(n_tasks)
+    return task_noise_covar_factor.matmul(
+        task_noise_covar_factor.transpose(-1, -2)
+    ) + log_noise.exp() * torch.eye(n_tasks)
 
 
 class MultitaskGaussianLikelihood(GaussianLikelihood):
     """
     A convenient extension of the :class:`gpytorch.likelihoods.GaussianLikelihood` to the multitask setting that allows
-    for a full cross-task covariance structure for the noise. The fitted covariance matrix has rank `rank`. Like the Gaussian 
-    likelihood, this object can be used with exact inference.
+    for a full cross-task covariance structure for the noise. The fitted covariance matrix has rank `rank`. If a strictly
+    diagonal task noise covariance matrix is desired, then rank=0 should be set. (This option still allows for a different
+    `log_noise` parameter for each task.)
+
+    Like the Gaussian likelihood, this object can be used with exact inference.
     """
 
-    def __init__(self, n_tasks, rank=1, task_covar_prior=None):
+    def __init__(self, n_tasks, rank=1, task_prior=None):
         """
         Args:
-            n_tasks (int): Number of tasks. This likelihood will create a rank `rank` covariance matrix for task noises.
-            log_task_noises_prior (:obj:`gpytorch.priors.Prior`): Prior to use over the task noise covariance matrix.
+            n_tasks (int): Number of tasks.
+
+            rank (int): The rank of the task noise covariance matrix to fit. If `rank` is set to 0,
+            then a diagonal covariance matrix is fit.
+
+            task_prior (:obj:`gpytorch.priors.Prior`): Prior to use over the task noise covariance matrix if
+            `rank` > 0, or a prior over the log of just the diagonal elements, if `rank` == 0.
+
         """
         super(MultitaskGaussianLikelihood, self).__init__()
-        self.register_parameter(
-            name="task_noise_covar_factor", parameter=torch.nn.Parameter(torch.zeros([n_tasks, rank]))
-        )
-        if task_covar_prior is not None:
-            self.register_derived_prior(
-                name="MultitaskErrorCovariancePrior",
-                prior=task_covar_prior,
-                parameter_names=("task_noise_covar_factor", "log_noise"),
-                transform=_eval_covar_matrix,
-            ) 
+
+        if rank == 0:
+            self.register_parameter(
+                name="log_task_noises",
+                parameter=torch.nn.Parameter(torch.zeros(n_tasks)),
+                prior=task_prior,
+            )
+        else:
+            self.register_parameter(
+                name="task_noise_covar_factor",
+                parameter=torch.nn.Parameter(torch.zeros([n_tasks, rank])),
+            )
+            if task_prior is not None:
+                self.register_derived_prior(
+                    name="MultitaskErrorCovariancePrior",
+                    prior=task_prior,
+                    parameter_names=("task_noise_covar_factor", "log_noise"),
+                    transform=_eval_covar_matrix,
+                )
         self.n_tasks = n_tasks
 
     def forward(self, input):
         """
         Adds the log task noises to the diagonal of the covariance matrix of the supplied
         :obj:`gpytorch.random_variables.GaussianRandomVariable` or
-        :obj:`gpytorch.random_variables.MultitaskGaussianRandomVariable`.
+        :obj:`gpytorch.random_variables.MultitaskGaussianRandomVariable`, in case of
+        `rank` == 0. Otherwise, adds a rank `rank` covariance matrix to it.
 
         To accomplish this, we form a new :obj:`gpytorch.lazy.KroneckerProductLazyVariable` between :math:`I_{n}`,
-        an identity matrix with size equal to the data and a (not necessarily diagonal) matrix containing the task 
+        an identity matrix with size equal to the data and a (not necessarily diagonal) matrix containing the task
         noises :math:`D_{t}`.
 
         We also incorporate a shared `log_noise` parameter from the base
@@ -64,12 +86,19 @@ class MultitaskGaussianLikelihood(GaussianLikelihood):
             added.
         """
         mean, covar = input.representation()
-        eye_lv = DiagLazyVariable(torch.ones(covar.size(-1) // self.n_tasks, device=self.log_noise.device))
-        task_var_lv = RootLazyVariable(self.task_noise_covar_factor)
+        eye_lv = DiagLazyVariable(
+            torch.ones(covar.size(-1) // self.n_tasks, device=self.log_noise.device)
+        )
+        if hasattr(self, "log_task_noises"):
+            task_var_lv = DiagLazyVariable(self.log_task_noises.exp())
+        else:
+            task_var_lv = RootLazyVariable(self.task_noise_covar_factor)
         diag_kron_lv = KroneckerProductLazyVariable(task_var_lv, eye_lv)
         noise = covar + diag_kron_lv
         noise = add_diag(noise, self.log_noise.exp())
         return input.__class__(mean, noise)
 
     def log_probability(self, input, target):
-        raise NotImplementedError("Variational inference with Multitask Gaussian likelihood is not yet supported")
+        raise NotImplementedError(
+            "Variational inference with Multitask Gaussian likelihood is not yet supported"
+        )

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -27,7 +27,7 @@ class MultitaskGaussianLikelihood(GaussianLikelihood):
     Like the Gaussian likelihood, this object can be used with exact inference.
     """
 
-    def __init__(self, n_tasks, rank=1, task_prior=None):
+    def __init__(self, n_tasks, rank=0, task_prior=None):
         """
         Args:
             n_tasks (int): Number of tasks.
@@ -93,8 +93,8 @@ class MultitaskGaussianLikelihood(GaussianLikelihood):
             task_var_lv = DiagLazyVariable(self.log_task_noises.exp())
         else:
             task_var_lv = RootLazyVariable(self.task_noise_covar_factor)
-        diag_kron_lv = KroneckerProductLazyVariable(task_var_lv, eye_lv)
-        noise = covar + diag_kron_lv
+        covar_kron_lv = KroneckerProductLazyVariable(task_var_lv, eye_lv)
+        noise = covar + covar_kron_lv
         noise = add_diag(noise, self.log_noise.exp())
         return input.__class__(mean, noise)
 

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -20,9 +20,9 @@ def _eval_covar_matrix(task_noise_covar_factor, log_noise):
 class MultitaskGaussianLikelihood(GaussianLikelihood):
     """
     A convenient extension of the :class:`gpytorch.likelihoods.GaussianLikelihood` to the multitask setting that allows
-    for a full cross-task covariance structure for the noise. The fitted covariance matrix has rank `rank`. If a strictly
-    diagonal task noise covariance matrix is desired, then rank=0 should be set. (This option still allows for a different
-    `log_noise` parameter for each task.)
+    for a full cross-task covariance structure for the noise. The fitted covariance matrix has rank `rank`.
+    If a strictly diagonal task noise covariance matrix is desired, then rank=0 should be set. (This option still
+    allows for a different `log_noise` parameter for each task.)
 
     Like the Gaussian likelihood, this object can be used with exact inference.
     """

--- a/test/likelihoods/test_general_multitask_gaussian_likelihood.py
+++ b/test/likelihoods/test_general_multitask_gaussian_likelihood.py
@@ -1,0 +1,99 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from math import pi
+
+import os
+import random
+import torch
+import unittest
+import gpytorch
+from gpytorch.kernels import RBFKernel, MultitaskKernel
+from gpytorch.means import ConstantMean, MultitaskMean
+from gpytorch.likelihoods import MultitaskGaussianLikelihood
+from gpytorch.random_variables import MultitaskGaussianRandomVariable
+
+
+# Simple training data: let's try to learn a sine function
+train_x = torch.linspace(0, 1, 100)
+latent_error = torch.rand(train_x.size()) * 0.5
+
+# y1 function is sin(2*pi*x) with noise N(0, 0.04)
+train_y1 = torch.sin(train_x.data * (2 * pi)) + latent_error + torch.randn(train_x.size()) * 0.1
+# y2 function is cos(2*pi*x) with noise N(0, 0.04)
+train_y2 = torch.cos(train_x.data * (2 * pi)) + latent_error + torch.randn(train_x.size()) * 0.1
+
+# Create a train_y which interleaves the two
+train_y = torch.stack([train_y1, train_y2], -1)
+
+
+class MultitaskGPModel(gpytorch.models.ExactGP):
+    def __init__(self, train_x, train_y, likelihood):
+        super(MultitaskGPModel, self).__init__(train_x, train_y, likelihood)
+        self.mean_module = MultitaskMean(ConstantMean(), n_tasks=2)
+        self.data_covar_module = RBFKernel()
+        self.covar_module = MultitaskKernel(self.data_covar_module, n_tasks=2, rank=1)
+
+    def forward(self, x):
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
+        return MultitaskGaussianRandomVariable(mean_x, covar_x)
+
+
+class TestMultiTaskGPRegression(unittest.TestCase):
+    def setUp(self):
+        if os.getenv("UNLOCK_SEED") is None or os.getenv("UNLOCK_SEED").lower() == "false":
+            self.rng_state = torch.get_rng_state()
+            torch.manual_seed(0)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(0)
+            random.seed(0)
+
+    def tearDown(self):
+        if hasattr(self, "rng_state"):
+            torch.set_rng_state(self.rng_state)
+
+    def test_multitask_gp_mean_abs_error(self):
+        likelihood = MultitaskGaussianLikelihood(n_tasks=2, rank=1)
+        model = MultitaskGPModel(train_x, train_y, likelihood)
+        # Find optimal model hyperparameters
+        model.train()
+        likelihood.train()
+
+        # Use the adam optimizer
+        optimizer = torch.optim.Adam([
+            {'params': model.parameters()},  # Includes GaussianLikelihood parameters
+        ], lr=0.1)
+
+        # "Loss" for GPs - the marginal log likelihood
+        mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, model)
+
+        n_iter = 50
+        for i in range(n_iter):
+            # Zero prev backpropped gradients
+            optimizer.zero_grad()
+            # Make predictions from training data
+            # Again, note feeding duplicated x_data and indices indicating which task
+            output = model(train_x)
+            # TODO: Fix this view call!!
+            loss = -mll(output, train_y)
+            loss.backward()
+            optimizer.step()
+
+        # Test the model
+        model.eval()
+        likelihood.eval()
+
+        task_noise_covar_factor = likelihood.task_noise_covar_factor
+        log_noise = likelihood.log_noise
+        task_noise_covar = task_noise_covar_factor.matmul(
+        task_noise_covar_factor.transpose(-1, -2)
+        ) + log_noise.exp() * torch.eye(n_tasks)
+        
+        self.assertGreater(task_noise_covar[0, 1].data.squeeze().item(), 0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/likelihoods/test_general_multitask_gaussian_likelihood.py
+++ b/test/likelihoods/test_general_multitask_gaussian_likelihood.py
@@ -18,7 +18,7 @@ from gpytorch.random_variables import MultitaskGaussianRandomVariable
 
 # Simple training data: let's try to learn a sine function
 train_x = torch.linspace(0, 1, 100)
-latent_error = torch.rand(train_x.size()) * 0.5
+latent_error = torch.randn(train_x.size()) * 0.5
 
 # y1 function is sin(2*pi*x) with noise N(0, 0.04)
 train_y1 = torch.sin(train_x.data * (2 * pi)) + latent_error + torch.randn(train_x.size()) * 0.1


### PR DESCRIPTION
Updates:

- Changed parameter of MultitaskGaussianLikelihood to include a rank = `rank` noise covariance matrix, parameterized by its covariance factor `task_noise_covar_factor`. 
- The full covariance matrix is the `v v' + e`, where `v` is `task_noise_covar_factor` and `e` is the diagonal matrix whose elements are `log_noise.exp()`. This is computed in `_eval_covar_matrix`.

The purpose of these updates is to make the cross-task noise covariance matrix general, and not just diagonal. 