### PR TITLE
Initialize low rank noise covar to nonzero values

### DIFF
--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -50,7 +50,7 @@ class MultitaskGaussianLikelihood(GaussianLikelihood):
         else:
             self.register_parameter(
                 name="task_noise_covar_factor",
-                parameter=torch.nn.Parameter(torch.zeros([n_tasks, rank])),
+                parameter=torch.nn.Parameter(torch.randn([n_tasks, rank])),
             )
             if task_prior is not None:
                 self.register_derived_prior(

--- a/test/likelihoods/test_general_multitask_gaussian_likelihood.py
+++ b/test/likelihoods/test_general_multitask_gaussian_likelihood.py
@@ -63,7 +63,7 @@ class TestMultiTaskGPRegression(unittest.TestCase):
         if hasattr(self, "rng_state"):
             torch.set_rng_state(self.rng_state)
 
-    def test_multitask_gp_mean_abs_error(self):
+    def test_multitask_low_rank_noise_covar(self):
         likelihood = MultitaskGaussianLikelihood(n_tasks=2, rank=1)
         model = MultitaskGPModel(train_x, train_y, likelihood)
         # Find optimal model hyperparameters


### PR DESCRIPTION
This implements the lessons learned by `IndexKernel`: `task_noise_covar_factor` can't be initialized with zeros and get gradients.

I also renamed the actual unit test function to describe the test.

@Balandat @rajkumarkarthik 