### PR TITLE
Register eta paramerter in LKJ prior as float

### DIFF
--- a/gpytorch/priors/lkj_prior.py
+++ b/gpytorch/priors/lkj_prior.py
@@ -18,14 +18,14 @@ class LKJPrior(Prior):
     correlation matrix.
     """
 
-    def __init__(self, n, eta=1):
+    def __init__(self, n, eta=1.0):
         if eta <= 0:
             raise ValueError("Shape parameter of LKJ prior must be positive")
 
         if n < 1:
             raise ValueError("Dimension n must be a positive integer")
         super(LKJPrior, self).__init__()
-        self.register_buffer("eta", torch.tensor(eta))
+        self.register_buffer("eta", torch.tensor(float(eta)))
         self.register_buffer("n", torch.tensor(n))
         # Normalization constant
         # Reference: Bayesian Data Analysis, 3rd ed., Gelman et al., p. 576


### PR DESCRIPTION
This fixes the issue reported by @rajkumarkarthik offline. Not sure why this behavior before this change was different between CPU and GPU. I tried to dig a little to see whether the `torch.tensor` constructor works differently for the two, or if there are weird interactions between the device and registering buffers, but didn't find anything. 