### PR TITLE
Fix cache detach for sum lazy variables

### DIFF
--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -444,7 +444,7 @@ class LazyVariable(object):
         Returns
             - A precomputed cache
         """
-        return train_train_covar_inv_root
+        return train_train_covar_inv_root.detach()
 
     def _exact_predictive_covar_inv_quad_form_root(self, precomputed_cache, test_train_covar):
         """
@@ -508,7 +508,7 @@ class LazyVariable(object):
 
         covar_inv_quad_form_root = self._exact_predictive_covar_inv_quad_form_root(precomputed_cache, test_train_covar)
         res = test_test_covar + RootLazyVariable(covar_inv_quad_form_root).mul(-1)
-        return res, precomputed_cache.detach()
+        return res, precomputed_cache
 
     def inv_matmul(self, tensor):
         """

--- a/gpytorch/lazy/sum_lazy_variable.py
+++ b/gpytorch/lazy/sum_lazy_variable.py
@@ -55,7 +55,9 @@ class SumLazyVariable(LazyVariable):
 
     def _exact_predictive_covar_inv_quad_form_cache(self, train_train_covar_inv_root, test_train_covar):
         return tuple(
-            lazy_var._exact_predictive_covar_inv_quad_form_cache(train_train_covar_inv_root, test_train_covar_comp)
+            lazy_var._exact_predictive_covar_inv_quad_form_cache(
+                train_train_covar_inv_root, test_train_covar_comp
+            ).detach()
             for lazy_var, test_train_covar_comp in zip(self.lazy_vars, test_train_covar.lazy_vars)
         )
 


### PR DESCRIPTION
Fixes a small issue where detaching the LOVE cache for sum lazy variables needed to be special cased. We now detach in the correct method rather than in `exact_predictive_covar` directly.