### PR TITLE
Added device-agnostic .to method to specify LazyTensor device

### DIFF
--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -93,8 +93,11 @@ class RBFKernel(Kernel):
 
     def forward(self, x1, x2):
         x1_, x2_ = self._create_input_grid(x1, x2)
-        x1_ = x1_.div(self.lengthscale)
-        x2_ = x2_.div(self.lengthscale)
+        ls = self.lengthscale
+        if self.batch_size > 1:
+            ls = self.lengthscale.unsqueeze(1)
+        x1_ = x1_.div(ls)
+        x2_ = x2_.div(ls)
 
         diff = (x1_ - x2_).norm(2, dim=-1)
         return diff.pow(2).div_(-2).exp_()

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -93,11 +93,8 @@ class RBFKernel(Kernel):
 
     def forward(self, x1, x2):
         x1_, x2_ = self._create_input_grid(x1, x2)
-        ls = self.lengthscale
-        if self.batch_size > 1:
-            ls = self.lengthscale.unsqueeze(1)
-        x1_ = x1_.div(ls)
-        x2_ = x2_.div(ls)
+        x1_ = x1_.div(self.lengthscale)
+        x2_ = x2_.div(self.lengthscale)
 
         diff = (x1_ - x2_).norm(2, dim=-1)
         return diff.pow(2).div_(-2).exp_()

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -304,29 +304,6 @@ class LazyTensor(object):
                 new_kwargs[name] = val
         return self.__class__(*new_args, **new_kwargs)
 
-    def to(self, device_id):
-        """
-        A device-agnostic method of moving the lazy_tensor to the specified device.
-
-        Args:
-            device_id (:obj: `torch.device`): Which device to use (GPU or CPU).
-        Returns:
-            :obj:`~gpytorch.lazy.LazyTensor`: New LazyTensor identical to self on specified device
-        """
-        new_args = []
-        new_kwargs = {}
-        for arg in self._args:
-            if hasattr(arg, "to"):
-                new_args.append(arg.to(device_id))
-            else:
-                new_args.append(arg)
-        for name, val in self._kwargs.items():
-            if hasattr(val, "to"):
-                new_kwargs[name] = val.to(device_id)
-            else:
-                new_kwargs[name] = val
-        return self.__class__(*new_args, **new_kwargs)
-
     @property
     def device(self):
         device = None

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -304,6 +304,29 @@ class LazyTensor(object):
                 new_kwargs[name] = val
         return self.__class__(*new_args, **new_kwargs)
 
+    def to(self, device_id):
+        """
+        A device-agnostic method of moving the lazy_tensor to the specified device.
+
+        Args:
+            device_id (:obj: `torch.device`): Which device to use (GPU or CPU).
+        Returns:
+            :obj:`~gpytorch.lazy.LazyTensor`: New LazyTensor identical to self on specified device
+        """
+        new_args = []
+        new_kwargs = {}
+        for arg in self._args:
+            if hasattr(arg, "to"):
+                new_args.append(arg.to(device_id))
+            else:
+                new_args.append(arg)
+        for name, val in self._kwargs.items():
+            if hasattr(val, "to"):
+                new_kwargs[name] = val.to(device_id)
+            else:
+                new_kwargs[name] = val
+        return self.__class__(*new_args, **new_kwargs)
+
     @property
     def device(self):
         device = None


### PR DESCRIPTION
Pytorch 0.4.0 made some positive changes towards making writing device-agnostic code more convenient, as discussed in their migration guide. `LazyTensor.to` is intended to mirror `torch.Tensor.to`.