### PR TITLE
Automatically determine grid bounds for SKI regression

### DIFF
--- a/docs/source/kernels.rst
+++ b/docs/source/kernels.rst
@@ -133,5 +133,5 @@ Kernels for Scalable GP Regression Methods
 :hidden:`MultiplicativeGridInterpolationKernel`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: AdditiveGridInterpolationKernel
+.. autoclass:: MultiplicativeGridInterpolationKernel
    :members:

--- a/gpytorch/kernels/additive_grid_interpolation_kernel.py
+++ b/gpytorch/kernels/additive_grid_interpolation_kernel.py
@@ -19,17 +19,23 @@ class AdditiveGridInterpolationKernel(GridInterpolationKernel):
     .. math::
 
        \begin{equation*}
-          k(\mathbf{x_1}, \mathbf{x_2}) = k'(x_1^{(1)}, x_2^{(1)}) + \ldots + k'(x_1^({d}), x_2^{(d)})
+          k(\mathbf{x_1}, \mathbf{x_2}) = k'(x_1^{(1)}, x_2^{(1)}) + \ldots + k'(x_1^{(d)}, x_2^{(d)})
        \end{equation*}
 
     for some kernel :math:`k'` that operates on a subset of dimensions.
 
     The groupings of dimensions are specified by the :attr:`dim_groups` attribute.
-    * `dim_groups=d` (d is the dimensionality of :math:`\mathbf x`): the kernel
-        :math:`k` will be the sum of `d` sub-kernels, each operating on one dimension of :math:`\mathbf x`.
-    * `dim_groups=d/2`: the first sub-kernel operates on dimensions 1 and 2, the second sub-kernel
+
+    * `dim_groups=d` (d is the dimensionality of :math:`\mathbf x`):
+        the kernel :math:`k` will be the sum of `d` sub-kernels, each operating
+        on one dimension of :math:`\mathbf x`.
+
+    * `dim_groups=d/2`:
+        the first sub-kernel operates on dimensions 1 and 2, the second sub-kernel
         operates on dimensions 3 and 4, etc.
-    * `dim_groups=1`: there is no additive decomposition
+
+    * `dim_groups=1`:
+        there is no additive decomposition
 
     .. note::
 
@@ -47,7 +53,7 @@ class AdditiveGridInterpolationKernel(GridInterpolationKernel):
             The number of additive components
         :attr:`grid_bounds` (tuple(float, float), optional):
             The bounds of the grid, if known (high performance mode).
-            The length of the tuple must match the size of the dim group (num_dims // dim_groups).
+            The length of the tuple must match the size of the dim group (`num_dims // dim_groups`).
             The entries represent the min/max values for each dimension.
         :attr:`active_dims` (tuple of ints, optional):
             Passed down to the `base_kernel_module`.

--- a/gpytorch/kernels/additive_grid_interpolation_kernel.py
+++ b/gpytorch/kernels/additive_grid_interpolation_kernel.py
@@ -3,30 +3,91 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import warnings
 from .grid_interpolation_kernel import GridInterpolationKernel
 from ..utils import Interpolation
 
 
 class AdditiveGridInterpolationKernel(GridInterpolationKernel):
-    def __init__(self, base_kernel_module, grid_size, grid_bounds, n_components, active_dims=None):
+    r"""
+    A variant of :class:`~gpytorch.kernels.GridInterpolationKernel` designed specifically
+    for additive kernels. If a kernel decomposes additively, then this module will be much more
+    computationally efficient.
+
+    A kernel function `k` decomposes additively if it can be written as
+
+    .. math::
+
+       \begin{equation*}
+          k(\mathbf{x_1}, \mathbf{x_2}) = k'(x_1^{(1)}, x_2^{(1)}) + \ldots + k'(x_1^({d}), x_2^{(d)})
+       \end{equation*}
+
+    for some kernel :math:`k'` that operates on a subset of dimensions.
+
+    The groupings of dimensions are specified by the :attr:`dim_groups` attribute.
+    * `dim_groups=d` (d is the dimensionality of :math:`\mathbf x`): the kernel
+        :math:`k` will be the sum of `d` sub-kernels, each operating on one dimension of :math:`\mathbf x`.
+    * `dim_groups=d/2`: the first sub-kernel operates on dimensions 1 and 2, the second sub-kernel
+        operates on dimensions 3 and 4, etc.
+    * `dim_groups=1`: there is no additive decomposition
+
+    .. note::
+
+        `AdditiveGridInterpolationKernel` can only wrap **stationary kernels** (such as RBF, Matern,
+        Periodic, Spectral Mixture, etc.)
+
+    Args:
+        :attr:`base_kernel_module` (Kernel):
+            The kernel to approximate with KISS-GP
+        :attr:`grid_size` (int):
+            The size of the grid (in each dimension)
+        :attr:`num_dims` (int):
+            The dimension of the input data. Required if `grid_bounds=None`
+        :attr:`dim_groups` (int):
+            The number of additive components
+        :attr:`grid_bounds` (tuple(float, float), optional):
+            The bounds of the grid, if known (high performance mode).
+            The length of the tuple must match the size of the dim group (num_dims // dim_groups).
+            The entries represent the min/max values for each dimension.
+        :attr:`active_dims` (tuple of ints, optional):
+            Passed down to the `base_kernel_module`.
+    """
+
+    def __init__(
+        self,
+        base_kernel_module,
+        grid_size,
+        dim_groups=None,
+        num_dims=None,
+        grid_bounds=None,
+        active_dims=None,
+        n_components=None,
+    ):
+        if n_components is not None:
+            warnings.warn("n_components is deprecated. Use dim_groups instead.", DeprecationWarning)
+            dim_groups = n_components
+        if dim_groups is None:
+            raise RuntimeError("Must supply dim_groups")
+
         super(AdditiveGridInterpolationKernel, self).__init__(
-            base_kernel_module, grid_size, grid_bounds, active_dims=active_dims
+            base_kernel_module, grid_size, num_dims // dim_groups, grid_bounds, active_dims=active_dims
         )
-        self.n_components = n_components
+
+        self.dim_groups = dim_groups
 
     def _compute_grid(self, inputs):
-        inputs = inputs.view(inputs.size(0), inputs.size(1), self.n_components, -1)
-        batch_size, n_data, n_components, n_dimensions = inputs.size()
-        inputs = inputs.transpose(0, 2).contiguous().view(n_components * batch_size * n_data, n_dimensions)
+        inputs = inputs.view(inputs.size(0), inputs.size(1), self.dim_groups, -1)
+        batch_size, n_data, dim_groups, n_dimensions = inputs.size()
+        inputs = inputs.transpose(0, 2).contiguous().view(dim_groups * batch_size * n_data, n_dimensions)
         interp_indices, interp_values = Interpolation().interpolate(self.grid, inputs)
-        interp_indices = interp_indices.view(n_components * batch_size, n_data, -1)
-        interp_values = interp_values.view(n_components * batch_size, n_data, -1)
+        interp_indices = interp_indices.view(dim_groups * batch_size, n_data, -1)
+        interp_values = interp_values.view(dim_groups * batch_size, n_data, -1)
         return interp_indices, interp_values
 
     def _inducing_forward(self):
         res = super(AdditiveGridInterpolationKernel, self)._inducing_forward()
-        return res.repeat(self.n_components, 1, 1)
+        return res.repeat(self.dim_groups, 1, 1)
 
     def forward(self, x1, x2):
         res = super(AdditiveGridInterpolationKernel, self).forward(x1, x2)
-        return res.sum_batch(sum_batch_size=self.n_components)
+        return res.sum_batch(sum_batch_size=self.dim_groups)

--- a/gpytorch/kernels/grid_interpolation_kernel.py
+++ b/gpytorch/kernels/grid_interpolation_kernel.py
@@ -11,23 +11,116 @@ from ..utils import Interpolation
 
 
 class GridInterpolationKernel(GridKernel):
-    def __init__(self, base_kernel_module, grid_size, grid_bounds, active_dims=None):
-        grid = torch.zeros(len(grid_bounds), grid_size)
-        for i in range(len(grid_bounds)):
-            grid_diff = float(grid_bounds[i][1] - grid_bounds[i][0]) / (grid_size - 2)
-            grid[i] = torch.linspace(grid_bounds[i][0] - grid_diff, grid_bounds[i][1] + grid_diff, grid_size)
+    r"""
+    Implements the KISS-GP (or SKI) approximation for a given kernel.
+    It was proposed in `Kernel Interpolation for Scalable Structured Gaussian Processes`_,
+    and offers extremely fast and accurate Kernel approximations for large datasets.
 
-        inducing_points = torch.zeros(int(pow(grid_size, len(grid_bounds))), len(grid_bounds))
-        prev_points = None
-        for i in range(len(grid_bounds)):
-            for j in range(grid_size):
-                inducing_points[j * grid_size ** i : (j + 1) * grid_size ** i, i].fill_(grid[i, j])
-                if prev_points is not None:
-                    inducing_points[j * grid_size ** i : (j + 1) * grid_size ** i, :i].copy_(prev_points)
-            prev_points = inducing_points[: grid_size ** (i + 1), : (i + 1)]
+    Given a base kernel `k`, the covariance :math:`k(\mathbf{x_1}, \mathbf{x_2})` is approximated by
+    using a grid of regularly spaced *inducing points*:
+
+    .. math::
+
+       \begin{equation*}
+          k(\mathbf{x_1}, \mathbf{x_2}) = \mathbf{w_{x_1}}^\top K_{U,U} \mathbf{w_{x_2}}
+       \end{equation*}
+
+    where
+    * :math:`U` is the set of gridded inducing points
+    * :math:`K_{U,U}` is the kernel matrix between the inducing points
+    * :math:`\mathbf{w_{x_1}` and :math:`\mathbf{w_{x_2}}` are sparse vectors based on
+      :math:`\mathbf{x_1}` and :math:`\mathbf{x_2}` that apply cubic interpolation.
+
+    The user should supply the size of the grid (using the :attr:`grid_size` attribute).
+    To choose a reasonable grid value, we highly recommend using the
+    :func:`gpytorch.utils.choose_grid_size` helper function.
+    The bounds of the grid will automatically be determined by data.
+
+    (Alternatively, you can hard-code bounds using the :attr:`grid_bounds`, which
+    will speed up this kernel's computations.)
+
+    .. note::
+
+        `GridInterpolationKernel` can only wrap **stationary kernels** (such as RBF, Matern,
+        Periodic, Spectral Mixture, etc.)
+
+    Args:
+        :attr:`base_kernel_module` (Kernel):
+            The kernel to approximate with KISS-GP
+        :attr:`grid_size` (int):
+            The size of the grid (in each dimension)
+        :attr:`num_dims` (int):
+            The dimension of the input data. Required if `grid_bounds=None`
+        :attr:`grid_bounds` (tuple(float, float), optional):
+            The bounds of the grid, if known (high performance mode).
+            The length of the tuple must match the number of dimensions.
+            The entries represent the min/max values for each dimension.
+        :attr:`active_dims` (tuple of ints, optional):
+            Passed down to the `base_kernel_module`.
+
+    .. Kernel Interpolation for Scalable Structured Gaussian Processes:
+        http://proceedings.mlr.press/v37/wilson15.pdf
+    """
+
+    def __init__(self, base_kernel_module, grid_size, num_dims=None, grid_bounds=None, active_dims=None):
+        has_initialized_grid = 0
+        grid_is_dynamic = True
+
+        # Make some temporary grid bounds, if none exist
+        if grid_bounds is None:
+            if num_dims is None:
+                raise RuntimeError("num_dims must be supplied if grid_bounds is None")
+            else:
+                # Create some temporary grid bounds - they'll be changed soon
+                grid_bounds = tuple((-1., 1.) for _ in range(num_dims))
+        else:
+            has_initialized_grid = 1
+            grid_is_dynamic = False
+            if num_dims is None:
+                num_dims = len(grid_bounds)
+            elif num_dims != len(grid_bounds):
+                raise RuntimeError(
+                    "num_dims ({}) disagrees with the number of supplied "
+                    "grid_bounds ({})".format(num_dims, len(grid_bounds))
+                )
+
+        # Initialize values and the grid
+        self.grid_is_dynamic = grid_is_dynamic
+        self.num_dims = num_dims
+        self.grid_size = grid_size
+        self.grid_bounds = grid_bounds
+        inducing_points, grid = self._create_grid()
 
         super(GridInterpolationKernel, self).__init__(
             base_kernel_module=base_kernel_module, inducing_points=inducing_points, grid=grid, active_dims=active_dims
+        )
+        self.register_buffer("has_initialized_grid", torch.tensor(has_initialized_grid, dtype=torch.uint8))
+
+    def _create_grid(self):
+        grid = torch.zeros(len(self.grid_bounds), self.grid_size)
+        for i in range(len(self.grid_bounds)):
+            grid_diff = float(self.grid_bounds[i][1] - self.grid_bounds[i][0]) / (self.grid_size - 2)
+            grid[i] = torch.linspace(
+                self.grid_bounds[i][0] - grid_diff, self.grid_bounds[i][1] + grid_diff, self.grid_size
+            )
+
+        inducing_points = torch.zeros(int(pow(self.grid_size, len(self.grid_bounds))), len(self.grid_bounds))
+        prev_points = None
+        for i in range(len(self.grid_bounds)):
+            for j in range(self.grid_size):
+                inducing_points[j * self.grid_size ** i : (j + 1) * self.grid_size ** i, i].fill_(grid[i, j])
+                if prev_points is not None:
+                    inducing_points[j * self.grid_size ** i : (j + 1) * self.grid_size ** i, :i].copy_(prev_points)
+            prev_points = inducing_points[: self.grid_size ** (i + 1), : (i + 1)]
+
+        return inducing_points, grid
+
+    @property
+    def _tight_grid_bounds(self):
+        grid_spacings = tuple((bound[1] - bound[0]) / self.grid_size for bound in self.grid_bounds)
+        return tuple(
+            (bound[0] + 2.01 * spacing, bound[1] - 2.01 * spacing)
+            for bound, spacing in zip(self.grid_bounds, grid_spacings)
         )
 
     @property
@@ -49,6 +142,33 @@ class GridInterpolationKernel(GridKernel):
         return super(Kernel, self).__call__(x1, x2, **kwargs).diag().unsqueeze(-1)
 
     def forward(self, x1, x2, **kwargs):
+        # See if we need to update the grid or not
+        if self.grid_is_dynamic:  # This is true if a grid_bounds wasn't passed in
+            if torch.equal(x1, x2):
+                x = x1.view(-1, self.num_dims)
+            else:
+                x = torch.cat([x1.view(-1, self.num_dims), x2.view(-1, self.num_dims)])
+            x_maxs = x.max(0)[0].tolist()
+            x_mins = x.min(0)[0].tolist()
+
+            # We need to update the grid if
+            # 1) it hasn't ever been initialized, or
+            # 2) if any of the grid points are "out of bounds"
+            update_grid = (not self.has_initialized_grid.item()) or any(
+                x_min < bound[0] or x_max > bound[1]
+                for x_min, x_max, bound in zip(x_mins, x_maxs, self._tight_grid_bounds)
+            )
+
+            # Update the grid if needed
+            if update_grid:
+                grid_spacings = tuple((x_max - x_min) / (self.grid_size - 4.02) for x_min, x_max in zip(x_mins, x_maxs))
+                self.grid_bounds = tuple(
+                    (x_min - 2.01 * spacing, x_max + 2.01 * spacing)
+                    for x_min, x_max, spacing in zip(x_mins, x_maxs, grid_spacings)
+                )
+                inducing_points, grid = self._create_grid()
+                self.update_inducing_points_and_grid(inducing_points, grid)
+
         base_lazy_tsr = self._inducing_forward()
         if x1.size(0) > 1:
             base_lazy_tsr = base_lazy_tsr.repeat(x1.size(0), 1, 1)

--- a/gpytorch/kernels/grid_interpolation_kernel.py
+++ b/gpytorch/kernels/grid_interpolation_kernel.py
@@ -33,7 +33,7 @@ class GridInterpolationKernel(GridKernel):
 
     The user should supply the size of the grid (using the :attr:`grid_size` attribute).
     To choose a reasonable grid value, we highly recommend using the
-    :func:`gpytorch.utils.choose_grid_size` helper function.
+    :func:`gpytorch.utils.grid.choose_grid_size` helper function.
     The bounds of the grid will automatically be determined by data.
 
     (Alternatively, you can hard-code bounds using the :attr:`grid_bounds`, which

--- a/gpytorch/kernels/grid_interpolation_kernel.py
+++ b/gpytorch/kernels/grid_interpolation_kernel.py
@@ -26,9 +26,12 @@ class GridInterpolationKernel(GridKernel):
        \end{equation*}
 
     where
+
     * :math:`U` is the set of gridded inducing points
+
     * :math:`K_{U,U}` is the kernel matrix between the inducing points
-    * :math:`\mathbf{w_{x_1}` and :math:`\mathbf{w_{x_2}}` are sparse vectors based on
+
+    * :math:`\mathbf{w_{x_1}}` and :math:`\mathbf{w_{x_2}}` are sparse vectors based on
       :math:`\mathbf{x_1}` and :math:`\mathbf{x_2}` that apply cubic interpolation.
 
     The user should supply the size of the grid (using the :attr:`grid_size` attribute).

--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -16,12 +16,6 @@ class GridKernel(Kernel):
 
     GridKernel exploits Toeplitz and Kronecker structure within the covariance matrix.
     See `Fast kernel learning for multidimensional pattern extrapolation`_ for more info.
-    Implements the KISS-GP (or SKI) approximation for a given kernel.
-    It was proposed in `Kernel Interpolation for Scalable Structured Gaussian Processes`_,
-    and offers extremely fast and accurate Kernel approximations for large datasets.
-
-    Given a base kernel `k`, the covariance :math:`k(\mathbf{x_1}, \mathbf{x_2})` is approximated by
-    using a grid of regularly spaced *inducing points*:
 
     .. note::
 
@@ -38,7 +32,7 @@ class GridKernel(Kernel):
         :attr:`active_dims` (tuple of ints, optional):
             Passed down to the `base_kernel_module`.
 
-    .. Fast kernel learning for multidimensional pattern extrapolation:
+    .. _Fast kernel learning for multidimensional pattern extrapolation:
         http://www.cs.cmu.edu/~andrewgw/manet.pdf
     """
 

--- a/gpytorch/kernels/multiplicative_grid_interpolation_kernel.py
+++ b/gpytorch/kernels/multiplicative_grid_interpolation_kernel.py
@@ -3,33 +3,106 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import warnings
 from .grid_interpolation_kernel import GridInterpolationKernel
 from ..utils import Interpolation
 
 
 class MultiplicativeGridInterpolationKernel(GridInterpolationKernel):
-    def __init__(self, base_kernel_module, grid_size, grid_bounds, n_components, active_dims=None):
+    r"""
+    A variant of :class:`~gpytorch.kernels.GridInterpolationKernel` designed specifically
+    for kernels with product structure. If a kernel decomposes
+    multiplicatively, then this module will be much more computationally efficient.
+    See `Product Kernel Interpolation for Scalable Gaussian Processes`_ for more detail.
+
+    A kernel function `k` has product structure if it can be written as
+
+    .. math::
+
+       \begin{equation*}
+          k(\mathbf{x_1}, \mathbf{x_2}) = k'(x_1^{(1)}, x_2^{(1)}) * \ldots * k'(x_1^({d}), x_2^{(d)})
+       \end{equation*}
+
+    for some kernel :math:`k'` that operates on a subset of dimensions.
+
+    The groupings of dimensions are specified by the :attr:`dim_groups` attribute.
+    * `dim_groups=d` (d is the dimensionality of :math:`\mathbf x`): the kernel
+        :math:`k` will be the sum of `d` sub-kernels, each operating on one dimension of :math:`\mathbf x`.
+    * `dim_groups=d/2`: the first sub-kernel operates on dimensions 1 and 2, the second sub-kernel
+        operates on dimensions 3 and 4, etc.
+    * `dim_groups=1`: there is no multiplicative decomposition
+
+    .. note::
+
+        `AdditiveGridInterpolationKernel` can only wrap **stationary kernels** (such as RBF, Matern,
+        Periodic, Spectral Mixture, etc.)
+
+    .. note::
+
+        The :class:`~gpytorch.kernels.RBFKernel` decomposes multiplicatively. You should use
+        `MultiplicativeGridInterpolationKernel` for multi-dimension RBF kernels!
+
+    Args:
+        :attr:`base_kernel_module` (Kernel):
+            The kernel to approximate with KISS-GP
+        :attr:`grid_size` (int):
+            The size of the grid (in each dimension)
+        :attr:`num_dims` (int):
+            The dimension of the input data. Required if `grid_bounds=None`
+        :attr:`dim_groups` (int):
+            The number of multiplicative components
+        :attr:`grid_bounds` (tuple(float, float), optional):
+            The bounds of the grid, if known (high performance mode).
+            The length of the tuple must match the size of the dim group (num_dims // dim_groups).
+            The entries represent the min/max values for each dimension.
+        :attr:`active_dims` (tuple of ints, optional):
+            Passed down to the `base_kernel_module`.
+
+    .. Product Kernel Interpolation for Scalable Gaussian Processes:
+        https://arxiv.org/pdf/1802.08903
+    """
+
+    def __init__(
+        self,
+        base_kernel_module,
+        grid_size,
+        dim_groups=None,
+        num_dims=None,
+        grid_bounds=None,
+        active_dims=None,
+        n_components=None,
+    ):
+        if n_components is not None:
+            warnings.warn("n_components is deprecated. Use dim_groups instead.", DeprecationWarning)
+            dim_groups = n_components
+        if dim_groups is None:
+            raise RuntimeError("Must supply dim_groups")
+
         super(MultiplicativeGridInterpolationKernel, self).__init__(
-            base_kernel_module=base_kernel_module, grid_size=grid_size, grid_bounds=grid_bounds, active_dims=active_dims
+            base_kernel_module=base_kernel_module,
+            grid_size=grid_size,
+            num_dims=(num_dims // dim_groups),
+            grid_bounds=grid_bounds,
+            active_dims=active_dims,
         )
-        self.n_components = n_components
+        self.dim_groups = dim_groups
 
     def _compute_grid(self, inputs):
-        inputs = inputs.view(inputs.size(0), inputs.size(1), self.n_components, -1)
-        batch_size, n_data, n_components, n_dimensions = inputs.size()
-        inputs = inputs.transpose(0, 2).contiguous().view(n_components * batch_size * n_data, n_dimensions)
+        inputs = inputs.view(inputs.size(0), inputs.size(1), self.dim_groups, -1)
+        batch_size, n_data, dim_groups, n_dimensions = inputs.size()
+        inputs = inputs.transpose(0, 2).contiguous().view(dim_groups * batch_size * n_data, n_dimensions)
         interp_indices, interp_values = Interpolation().interpolate(self.grid, inputs)
-        interp_indices = interp_indices.view(n_components * batch_size, n_data, -1)
-        interp_values = interp_values.view(n_components * batch_size, n_data, -1)
+        interp_indices = interp_indices.view(dim_groups * batch_size, n_data, -1)
+        interp_values = interp_values.view(dim_groups * batch_size, n_data, -1)
         return interp_indices, interp_values
 
     def _inducing_forward(self):
         res = super(MultiplicativeGridInterpolationKernel, self)._inducing_forward()
-        return res.repeat(self.n_components, 1, 1)
+        return res.repeat(self.dim_groups, 1, 1)
 
     def forward(self, x1, x2):
         res = super(MultiplicativeGridInterpolationKernel, self).forward(x1, x2)
-        res = res.mul_batch(mul_batch_size=self.n_components)
+        res = res.mul_batch(mul_batch_size=self.dim_groups)
         return res
 
     def __call__(self, x1_, x2_=None, **params):

--- a/gpytorch/kernels/multiplicative_grid_interpolation_kernel.py
+++ b/gpytorch/kernels/multiplicative_grid_interpolation_kernel.py
@@ -20,17 +20,20 @@ class MultiplicativeGridInterpolationKernel(GridInterpolationKernel):
     .. math::
 
        \begin{equation*}
-          k(\mathbf{x_1}, \mathbf{x_2}) = k'(x_1^{(1)}, x_2^{(1)}) * \ldots * k'(x_1^({d}), x_2^{(d)})
+          k(\mathbf{x_1}, \mathbf{x_2}) = k'(x_1^{(1)}, x_2^{(1)}) * \ldots * k'(x_1^{(d)}, x_2^{(d)})
        \end{equation*}
 
     for some kernel :math:`k'` that operates on a subset of dimensions.
 
     The groupings of dimensions are specified by the :attr:`dim_groups` attribute.
-    * `dim_groups=d` (d is the dimensionality of :math:`\mathbf x`): the kernel
-        :math:`k` will be the sum of `d` sub-kernels, each operating on one dimension of :math:`\mathbf x`.
-    * `dim_groups=d/2`: the first sub-kernel operates on dimensions 1 and 2, the second sub-kernel
+
+    * `dim_groups=d` (d is the dimensionality of :math:`\mathbf x`):
+        the kernel :math:`k` will be the sum of `d` sub-kernels, each operating on one dimension of :math:`\mathbf x`.
+    * `dim_groups=d/2`:
+        the first sub-kernel operates on dimensions 1 and 2, the second sub-kernel
         operates on dimensions 3 and 4, etc.
-    * `dim_groups=1`: there is no multiplicative decomposition
+    * `dim_groups=1`:
+        there is no multiplicative decomposition
 
     .. note::
 
@@ -53,7 +56,7 @@ class MultiplicativeGridInterpolationKernel(GridInterpolationKernel):
             The number of multiplicative components
         :attr:`grid_bounds` (tuple(float, float), optional):
             The bounds of the grid, if known (high performance mode).
-            The length of the tuple must match the size of the dim group (num_dims // dim_groups).
+            The length of the tuple must match the size of the dim group (`num_dims // dim_groups`).
             The entries represent the min/max values for each dimension.
         :attr:`active_dims` (tuple of ints, optional):
             Passed down to the `base_kernel_module`.

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -67,7 +67,7 @@ class SpectralMixtureKernel(Kernel):
         >>> covar = covar_module(x)  # Output: LazyVariable of size (2 x 10 x 10)
 
 
-    .. Gaussian Process Kernels for Pattern Discovery and Extrapolation:
+    .. _Gaussian Process Kernels for Pattern Discovery and Extrapolation:
         https://arxiv.org/pdf/1302.4245.pdf
     """
     # TODO: add equation to docs

--- a/gpytorch/utils/__init__.py
+++ b/gpytorch/utils/__init__.py
@@ -8,9 +8,11 @@ from copy import deepcopy
 from operator import mul
 from .interpolation import Interpolation
 from .linear_cg import linear_cg
+from . import grid
 from . import pivoted_cholesky
 from . import lanczos
 from . import sparse
+from .grid import scale_to_bounds
 from .eig import batch_symeig
 from .cholesky import batch_potrf, batch_potrs
 from .stochastic_lq import StochasticLQ
@@ -289,17 +291,6 @@ def sparse_repeat(sparse, *repeat_sizes):
     )
 
 
-def scale_to_bounds(x, lower_bound, upper_bound):
-    """
-    """
-    # Scale features so they fit inside grid bounds
-    min_val = x.min().item()
-    max_val = x.max().item()
-    diff = max_val - min_val
-    x = (x - min_val) * (0.95 * (upper_bound - lower_bound) / diff) + 0.95 * lower_bound
-    return x
-
-
 def to_sparse(dense):
     """
     """
@@ -411,8 +402,10 @@ __all__ = [
     "batch_potrf",
     "batch_potrs",
     "batch_symeig",
+    "grid",
     "lanczos",
     "pivoted_cholesky",
+    "scale_to_bounds",
     "sparse",
     "sparse_eye",
     "sparse_getitem",

--- a/gpytorch/utils/grid.py
+++ b/gpytorch/utils/grid.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+def scale_to_bounds(x, lower_bound, upper_bound):
+    """
+    Scale the input data so that it lies in between the lower and upper bounds.
+
+    Args:
+        :attr:`x` (Tensor `n` or `b x n`):
+            the input
+        :attr:`lower_bound` (float)
+        :attr:`upper_bound` (float)
+
+    Returns:
+        :obj:`torch.Tensor`
+    """
+    # Scale features so they fit inside grid bounds
+    min_val = x.min()
+    max_val = x.max()
+    diff = max_val - min_val
+    x = (x - min_val) * (0.95 * (upper_bound - lower_bound) / diff) + 0.95 * lower_bound
+    return x
+
+
+def choose_grid_size(train_inputs, ratio=1.):
+    """
+    Given some training inputs, determine a good grid size for KISS-GP.
+
+    Args:
+        :attr:`train_inputs` (Tensor `n` or `n x d` or `b x n x d`):
+            training data
+        :attr:`ratio` (float, optional):
+            Ratio - number of grid points to the amount of data (default: 1.)
+
+    Returns:
+        :obj:`int`
+    """
+    # Scale features so they fit inside grid bounds
+    num_data = train_inputs.numel() if train_inputs.dim() == 1 else train_inputs.size(-2)
+    return int(ratio * num_data)

--- a/test/examples/test_kissgp_additive_regression.py
+++ b/test/examples/test_kissgp_additive_regression.py
@@ -44,7 +44,7 @@ class GPRegressionModel(gpytorch.models.ExactGP):
             RBFKernel(log_lengthscale_prior=SmoothedBoxPrior(exp(-3), exp(3), sigma=0.1, log_transform=True))
         )
         self.covar_module = AdditiveGridInterpolationKernel(
-            self.base_covar_module, grid_size=100, grid_bounds=[(-0.5, 1.5)], n_components=2
+            self.base_covar_module, grid_size=100, num_dims=2, dim_groups=2
         )
 
     def forward(self, x):

--- a/test/examples/test_kissgp_dkl_regression.py
+++ b/test/examples/test_kissgp_dkl_regression.py
@@ -54,12 +54,11 @@ class GPRegressionModel(gpytorch.models.ExactGP):
         self.base_covar_module = ScaleKernel(
             RBFKernel(log_lengthscale_prior=SmoothedBoxPrior(exp(-5), exp(6), sigma=0.1, log_transform=True))
         )
-        self.covar_module = GridInterpolationKernel(self.base_covar_module, grid_size=50, grid_bounds=[(0, 1)])
+        self.covar_module = GridInterpolationKernel(self.base_covar_module, grid_size=50, num_dims=1)
         self.feature_extractor = feature_extractor
 
     def forward(self, x):
         features = self.feature_extractor(x)
-        features = gpytorch.utils.scale_to_bounds(features, 0, 1)
         mean_x = self.mean_module(features)
         covar_x = self.covar_module(features)
         return GaussianRandomVariable(mean_x, covar_x)

--- a/test/examples/test_kissgp_gp_regression.py
+++ b/test/examples/test_kissgp_gp_regression.py
@@ -40,7 +40,7 @@ class GPRegressionModel(gpytorch.models.ExactGP):
         self.base_covar_module = ScaleKernel(
             RBFKernel(log_lengthscale_prior=SmoothedBoxPrior(exp(-5), exp(6), sigma=0.1, log_transform=True))
         )
-        self.covar_module = GridInterpolationKernel(self.base_covar_module, grid_size=50, grid_bounds=[(0, 1)])
+        self.covar_module = GridInterpolationKernel(self.base_covar_module, grid_size=50, num_dims=1)
 
     def forward(self, x):
         mean_x = self.mean_module(x)

--- a/test/examples/test_kissgp_kronecker_product_regression.py
+++ b/test/examples/test_kissgp_kronecker_product_regression.py
@@ -47,7 +47,7 @@ class GPRegressionModel(gpytorch.models.ExactGP):
         self.base_covar_module = ScaleKernel(
             RBFKernel(log_lengthscale_prior=SmoothedBoxPrior(exp(-3), exp(3), sigma=0.1, log_transform=True))
         )
-        self.covar_module = GridInterpolationKernel(self.base_covar_module, grid_size=64, grid_bounds=[(0, 1), (0, 1)])
+        self.covar_module = GridInterpolationKernel(self.base_covar_module, grid_size=64, num_dims=2)
 
     def forward(self, x):
         mean_x = self.mean_module(x)

--- a/test/examples/test_kissgp_multiplicative_regression.py
+++ b/test/examples/test_kissgp_multiplicative_regression.py
@@ -47,7 +47,7 @@ class GPRegressionModel(gpytorch.models.ExactGP):
             RBFKernel(log_lengthscale_prior=SmoothedBoxPrior(exp(-3), exp(3), sigma=0.1, log_transform=True))
         )
         self.covar_module = MultiplicativeGridInterpolationKernel(
-            self.base_covar_module, grid_size=100, grid_bounds=[(0, 1)], n_components=2
+            self.base_covar_module, grid_size=100, num_dims=2, dim_groups=2
         )
 
     def forward(self, x):

--- a/test/examples/test_kissgp_white_noise_regression.py
+++ b/test/examples/test_kissgp_white_noise_regression.py
@@ -40,7 +40,7 @@ class GPRegressionModel(gpytorch.models.ExactGP):
         self.base_covar_module = ScaleKernel(
             RBFKernel(log_lengthscale_prior=SmoothedBoxPrior(exp(-5), exp(6), sigma=0.1, log_transform=True))
         )
-        self.grid_covar_module = GridInterpolationKernel(self.base_covar_module, grid_size=50, grid_bounds=[(0, 1)])
+        self.grid_covar_module = GridInterpolationKernel(self.base_covar_module, grid_size=50, num_dims=1)
         self.noise_covar_module = WhiteNoiseKernel(variances=torch.ones(100) * 0.001)
         self.covar_module = self.grid_covar_module + self.noise_covar_module
 

--- a/test/examples/test_kronecker_multitask_ski_gp_regression.py
+++ b/test/examples/test_kronecker_multitask_ski_gp_regression.py
@@ -32,8 +32,8 @@ class MultitaskGPModel(gpytorch.models.ExactGP):
     def __init__(self, train_x, train_y, likelihood):
         super(MultitaskGPModel, self).__init__(train_x, train_y, likelihood)
         self.mean_module = MultitaskMean(ConstantMean(), n_tasks=2)
-        self_covar_module = GridInterpolationKernel(RBFKernel(), grid_size=100, grid_bounds=[(0, 1)])
-        self.covar_module = MultitaskKernel(self_covar_module, n_tasks=2, rank=1)
+        self.data_covar_module = GridInterpolationKernel(RBFKernel(), grid_size=100, num_dims=1)
+        self.covar_module = MultitaskKernel(self.data_covar_module, n_tasks=2, rank=1)
 
     def forward(self, x):
         mean_x = self.mean_module(x)

--- a/test/util/test_grid.py
+++ b/test/util/test_grid.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import torch
+import gpytorch
+import unittest
+
+
+class TestGrid(unittest.TestCase):
+    def test_scale_to_bounds(self):
+        """
+        """
+        x = torch.randn(100) * 50
+        res = gpytorch.utils.scale_to_bounds(x, -1, 1)
+        self.assertGreater(res.min().item(), -1)
+        self.assertLess(res.max().item(), 1)
+
+    def test_choose_grid_size(self):
+        """
+        """
+        x = torch.randn(100)
+        grid_size = gpytorch.utils.grid.choose_grid_size(x, ratio=2.)
+        self.assertEqual(grid_size, 200)
+
+        x = torch.randn(100, 4)
+        grid_size = gpytorch.utils.grid.choose_grid_size(x, ratio=2.)
+        self.assertEqual(grid_size, 200)
+
+        x = torch.randn(16, 100, 4)
+        grid_size = gpytorch.utils.grid.choose_grid_size(x, ratio=2.)
+        self.assertEqual(grid_size, 200)


### PR DESCRIPTION
For `GridInterpolationKernel` (and its variants), it is no longer necessary to pass in `grid_bounds`. They can be automatically determined by the data.

```python
grid_size = gpytorch.utils.grid.choose_grid_size(x, ratio=1.5)  # Simple helper function
kernel = GridInterpolationKernel(rbf_kernel, grid_size=grid_size, num_dim=1)
```

**Note** this probably will require some back-filled unit tests and some updated examples. I'll open a separate issue for those if it looks like we like this new interface