### PR TITLE
Fix diag calls to ScaleKernel in batch mode

### DIFF
--- a/gpytorch/kernels/scale_kernel.py
+++ b/gpytorch/kernels/scale_kernel.py
@@ -45,17 +45,23 @@ class ScaleKernel(Kernel):
         >>> scaled_covar_module = gpytorch.kernels.ScaleKernel(base_covar_module)
         >>> covar = scaled_covar_module(x)  # Output: LazyTensor of size (10 x 10)
     """
-
     def __init__(self, base_kernel, batch_size=1, log_outputscale_prior=None):
         super(ScaleKernel, self).__init__(has_lengthscale=False, batch_size=batch_size)
         self.base_kernel = base_kernel
         self.register_parameter(
-            name="log_outputscale", parameter=torch.nn.Parameter(torch.zeros(batch_size)), prior=log_outputscale_prior
+            name="log_outputscale",
+            parameter=torch.nn.Parameter(torch.zeros(batch_size)),
+            prior=log_outputscale_prior
         )
 
     @property
     def outputscale(self):
         return self.log_outputscale.exp()
+
+    def forward_diag(self, x1, x2):
+        outputscales = self.log_outputscale.exp()
+        orig_output = self.base_kernel.forward_diag(x1, x2)
+        return orig_output.squeeze(-1).mul(outputscales.unsqueeze(-1))
 
     def forward(self, x1, x2):
         outputscales = self.log_outputscale.exp()


### PR DESCRIPTION
On master, ScaleKernel's behavior in batch mode when getting only the diagonal of the kernel is broken for the same reason that other kernels are (see e.g. #249).

Here's some simple code that reproduces the error this PR fixes:
```python
covar_module = ScaleKernel(RBFKernel(batch_size=5), batch_size=5)
covar = covar_module(torch.randn(5, 20, 1))
diag = covar.diag() # fails because it returns a torch.Size(5, 20, 5) tensor
```

While we wait for the kernel refactor @gpleiss is working on, this PR fixes this issue by implementing a `forward_diag` method for ScaleKernel. An alternative fix would be to let outputscales be `torch.Size(5, 1, 1)` and allow `ConstantMulLazyTensors` to take batches of constants for batch lazy tensors.