### PR TITLE
Add pyproject.toml with black linelength spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120


### PR DESCRIPTION
This allows to run black without having to specify the line length as an argument. 
The `pyproject.toml` file is more generally useful for setting other stuff as well. 