### PR TITLE
Use preconditioning for NonLazyTensors

### DIFF
--- a/gpytorch/lazy/non_lazy_tensor.py
+++ b/gpytorch/lazy/non_lazy_tensor.py
@@ -48,9 +48,6 @@ class NonLazyTensor(LazyTensor):
     def _get_indices(self, left_indices, right_indices):
         return self.tensor[left_indices, right_indices]
 
-    def add_diag(self, diag):
-        return NonLazyTensor(add_diag(self.tensor, diag))
-
     def _preconditioner(self):
         # For a NonLazyTensor, it is intended to not use preconditioning, even when called for.
         return None, None


### PR DESCRIPTION
On master, `NonLazyTensors` don't benefit from preconditioning because they define a custom `add_diag` that returns a new `NonLazyTensor`. This turns out to be really really bad in some cases (most often the very low noise setting):

```python
# Before this PR
M = RBFKernel()(torch.randn(1000, 1)).evaluate().cuda()
rhs = torch.randn(1000).cuda()
lv = NonLazyTensor(M).add_diag(torch.tensor(1e-3).cuda())
print(lv) # NonLazyTensor
solve_cg = lv.inv_matmul(rhs)
print(torch.norm((M + 1e-3 * torch.eye(1000).cuda()).matmul(solve_cg) - rhs).item()) # ~100 sometimes!
```

```python
# After this PR
M = RBFKernel()(torch.randn(1000, 1)).evaluate().cuda()
rhs = torch.randn(1000).cuda()
lv = NonLazyTensor(M).add_diag(torch.tensor(1e-3).cuda())
print(lv) # AddedDiagLazyTensor
solve_cg = lv.inv_matmul(rhs)
print(torch.norm((M + 1e-3 * torch.eye(1000).cuda()).matmul(solve_cg) - rhs).item()) # Very small
```

@gpleiss 