### PR TITLE
[WIP] Refactor LazyTensor unit tests

### DIFF
--- a/gpytorch/lazy/block_lazy_tensor.py
+++ b/gpytorch/lazy/block_lazy_tensor.py
@@ -61,7 +61,7 @@ BlockLazyTensors represent the groups of blocks as a batched Tensor.
 
         # Cases for when there's an inner batch
         else:
-            batch_index = index if isinstance(index, int) else index[0]
+            batch_index = index if not isinstance(index, tuple) else index[0]
             first_tensor_index_dim = None
 
             # Keeping all batch dimensions - recursion base case
@@ -97,7 +97,7 @@ BlockLazyTensors represent the groups of blocks as a batched Tensor.
             new_var = self.__class__(*components, num_blocks=num_blocks)
 
             # If the index was only on the batch index, we're done
-            if isinstance(index, int) or len(index) == 1:
+            if not isinstance(index, tuple) or len(index) == 1:
                 return new_var
 
             # Else - recurse

--- a/gpytorch/lazy/constant_mul_lazy_tensor.py
+++ b/gpytorch/lazy/constant_mul_lazy_tensor.py
@@ -19,13 +19,13 @@ class ConstantMulLazyTensor(LazyTensor):
     To element-wise multiply two lazy tensors, see :class:`gpytorch.lazy.MulLazyTensor`
 
     Args:
-        lazy_var (LazyTensor) or (b x n x m)): The base_lazy tensor
+        base_lazy_tensor (LazyTensor) or (b x n x m)): The base_lazy tensor
         constant (Tensor): The constant
 
-    If `lazy_var` represents a matrix (non-batch), then `constant` must be a
+    If `base_lazy_tensor` represents a matrix (non-batch), then `constant` must be a
     0D tensor, or a 1D tensor with one element.
 
-    If `lazy_var` represents a batch of matrices (b x m x n), then `constant` can be
+    If `base_lazy_tensor` represents a batch of matrices (b x m x n), then `constant` can be
     either:
     - A 0D tensor - the same constant is applied to all matrices in the batch
     - A 1D tensor with one element - the same constant is applied to all matrices
@@ -33,19 +33,19 @@ class ConstantMulLazyTensor(LazyTensor):
 
     Example::
 
-        >>> base_lazy_var = gpytorch.lazy.ToeplitzLazyTensor([1, 2, 3])
+        >>> base_base_lazy_tensor = gpytorch.lazy.ToeplitzLazyTensor([1, 2, 3])
         >>> constant = torch.tensor(1.2)
-        >>> new_lazy_var = gpytorch.lazy.ConstantMulLazyTensor(base_lazy_var, constant)
-        >>> new_lazy_var.evaluate()
+        >>> new_base_lazy_tensor = gpytorch.lazy.ConstantMulLazyTensor(base_base_lazy_tensor, constant)
+        >>> new_base_lazy_tensor.evaluate()
         >>> # Returns:
         >>> # [[ 1.2, 2.4, 3.6 ]
         >>> #  [ 2.4, 1.2, 2.4 ]
         >>> #  [ 3.6, 2.4, 1.2 ]]
         >>>
-        >>> base_lazy_var = gpytorch.lazy.ToeplitzLazyTensor([[1, 2, 3], [2, 3, 4]])
+        >>> base_base_lazy_tensor = gpytorch.lazy.ToeplitzLazyTensor([[1, 2, 3], [2, 3, 4]])
         >>> constant = torch.tensor([1.2, 0.5])
-        >>> new_lazy_var = gpytorch.lazy.ConstantMulLazyTensor(base_lazy_var, constant)
-        >>> new_lazy_var.evaluate()
+        >>> new_base_lazy_tensor = gpytorch.lazy.ConstantMulLazyTensor(base_base_lazy_tensor, constant)
+        >>> new_base_lazy_tensor.evaluate()
         >>> # Returns:
         >>> # [[[ 1.2, 2.4, 3.6 ]
         >>> #   [ 2.4, 1.2, 2.4 ]
@@ -55,50 +55,50 @@ class ConstantMulLazyTensor(LazyTensor):
         >>> #   [ 2, 1.5, 1 ]]]
     """
 
-    def __init__(self, lazy_var, constant):
+    def __init__(self, base_lazy_tensor, constant):
         if torch.is_tensor(constant):
             if constant.ndimension() > 1:
                 raise RuntimeError(
                     "Got a constant with %d dimensions - expected a 0D or 1D tensor" % constant.ndimension()
                 )
             elif constant.numel() > 1:
-                if not (lazy_var.ndimension() == 3 and lazy_var.size(0) == constant.numel()):
+                if not (base_lazy_tensor.ndimension() == 3 and base_lazy_tensor.size(0) == constant.numel()):
                     numel = constant.numel()
                     raise RuntimeError(
                         "A constant with size %d expedts a 3D lazy var. with batch size %d. "
                         "Got a %dD lazy var. with size %s"
-                        % (numel, numel, lazy_var.ndimension(), repr(lazy_var.size()))
+                        % (numel, numel, base_lazy_tensor.ndimension(), repr(base_lazy_tensor.size()))
                     )
 
             elif constant.numel() == 1:
                 constant = constant.squeeze()
         else:
-            constant = torch.tensor(constant, device=lazy_var.device, dtype=torch.float32)
+            constant = torch.tensor(constant, device=base_lazy_tensor.device, dtype=torch.float32)
 
-        super(ConstantMulLazyTensor, self).__init__(lazy_var, constant)
-        self.lazy_var = lazy_var
+        super(ConstantMulLazyTensor, self).__init__(base_lazy_tensor, constant)
+        self.base_lazy_tensor = base_lazy_tensor
         self.constant = constant
 
     def _matmul(self, rhs):
-        res = self.lazy_var._matmul(rhs)
+        res = self.base_lazy_tensor._matmul(rhs)
         res = res * self._constant_as(res)
         return res
 
     def _t_matmul(self, rhs):
-        res = self.lazy_var._t_matmul(rhs)
+        res = self.base_lazy_tensor._t_matmul(rhs)
         res = res * self._constant_as(res)
         return res
 
     def _quad_form_derivative(self, left_vecs, right_vecs):
-        res = list(self.lazy_var._quad_form_derivative(left_vecs, right_vecs))
+        res = list(self.base_lazy_tensor._quad_form_derivative(left_vecs, right_vecs))
         for i, item in enumerate(res):
             if torch.is_tensor(item) and res[i].sum():
                 res[i] = res[i] * self._constant_as(res[i])
         # Gradient with respect to the constant
         if self.constant.numel() == 1:
-            constant_deriv = (left_vecs * self.lazy_var._matmul(right_vecs)).sum().expand_as(self.constant)
+            constant_deriv = (left_vecs * self.base_lazy_tensor._matmul(right_vecs)).sum().expand_as(self.constant)
         else:
-            constant_deriv = (left_vecs * self.lazy_var._matmul(right_vecs)).sum(-2, keepdim=True).sum(-1, keepdim=True)
+            constant_deriv = (left_vecs * self.base_lazy_tensor._matmul(right_vecs)).sum(-2, keepdim=True).sum(-1, keepdim=True)
 
         if constant_deriv.dim():
             constant_deriv = constant_deriv.view(*self.constant.size())
@@ -115,38 +115,38 @@ class ConstantMulLazyTensor(LazyTensor):
         return constant
 
     def _size(self):
-        return self.lazy_var.size()
+        return self.base_lazy_tensor.size()
 
     def _transpose_nonbatch(self):
-        return ConstantMulLazyTensor(self.lazy_var._transpose_nonbatch(), self.constant)
+        return ConstantMulLazyTensor(self.base_lazy_tensor._transpose_nonbatch(), self.constant)
 
     def _batch_get_indices(self, batch_indices, left_indices, right_indices):
-        res = self.lazy_var._batch_get_indices(batch_indices, left_indices, right_indices)
+        res = self.base_lazy_tensor._batch_get_indices(batch_indices, left_indices, right_indices)
         return self.constant.expand_as(res) * res
 
     def _get_indices(self, left_indices, right_indices):
-        res = self.lazy_var._get_indices(left_indices, right_indices)
+        res = self.base_lazy_tensor._get_indices(left_indices, right_indices)
         return self.constant.expand_as(res) * res
 
     def _approx_diag(self):
-        res = self.lazy_var._approx_diag()
+        res = self.base_lazy_tensor._approx_diag()
         return res * self._constant_as(res)
 
     def evaluate(self):
-        res = self.lazy_var.evaluate()
+        res = self.base_lazy_tensor.evaluate()
         return res * self._constant_as(res)
 
     def diag(self):
-        res = self.lazy_var.diag()
+        res = self.base_lazy_tensor.diag()
         res = res * self._constant_as(res)
         return res
 
     def repeat(self, *sizes):
-        return ConstantMulLazyTensor(self.lazy_var.repeat(*sizes), self.constant)
+        return ConstantMulLazyTensor(self.base_lazy_tensor.repeat(*sizes), self.constant)
 
     def __getitem__(self, i):
         constant = self.constant
         if constant.numel() > 1:
             first_index = i[0] if isinstance(i, tuple) else i
             constant = constant[first_index]
-        return self.lazy_var.__getitem__(i) * constant
+        return self.base_lazy_tensor.__getitem__(i) * constant

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -287,6 +287,14 @@ class LazyTensor(object):
         diag = torch.tensor(jitter_val, dtype=self.dtype, device=self.device)
         return self.add_diag(diag)
 
+    def clone(self):
+        """
+        Clones the LazyTensor (creates clones of all underlying tensors)
+        """
+        args = [arg.clone() if hasattr(arg, "clone") else arg for arg in self._args]
+        kwargs = dict((key, val.clone() if hasattr(val, "clone") else val) for key, val in self._kwargs.items())
+        return self.__class__(*args, **kwargs)
+
     def cpu(self):
         """
         Returns:

--- a/test/lazy/_lazy_tensor_test_case.py
+++ b/test/lazy/_lazy_tensor_test_case.py
@@ -1,0 +1,311 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import gpytorch
+import torch
+import os
+import random
+from abc import abstractmethod
+from gpytorch.utils import approx_equal
+
+
+class LazyTensorTestCase(object):
+    should_test_sample = False
+
+    @abstractmethod
+    def create_lazy_tensor(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def evaluate_lazy_tensor(self):
+        raise NotImplementedError()
+
+    def setUp(self):
+        if hasattr(self.__class__, "seed"):
+            seed = self.__class__.seed
+            if os.getenv("UNLOCK_SEED") is None or os.getenv("UNLOCK_SEED").lower() == "false":
+                self.rng_state = torch.get_rng_state()
+                torch.manual_seed(seed)
+                if torch.cuda.is_available():
+                    torch.cuda.manual_seed_all(seed)
+                random.seed(seed)
+
+    def tearDown(self):
+        if hasattr(self, "rng_state"):
+            torch.set_rng_state(self.rng_state)
+
+    def test_matmul_vec(self):
+        lazy_tensor = self.create_lazy_tensor()
+        lazy_tensor_copy = lazy_tensor.clone()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+
+        test_vector = torch.randn(lazy_tensor.size(-1))
+        res = lazy_tensor.matmul(test_vector)
+        actual = evaluated.matmul(test_vector)
+        assert(approx_equal(res, actual))
+
+        grad = torch.randn_like(test_vector)
+        res.backward(gradient=grad)
+        actual.backward(gradient=grad)
+        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+            if arg_copy.grad is not None:
+                assert(approx_equal(arg.grad, arg_copy.grad))
+
+    def test_matmul_matrix(self):
+        lazy_tensor = self.create_lazy_tensor()
+        lazy_tensor_copy = lazy_tensor.clone()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+
+        test_vector = torch.randn(lazy_tensor.size(-1), 5)
+        res = lazy_tensor.matmul(test_vector)
+        actual = evaluated.matmul(test_vector)
+        assert(approx_equal(res, actual))
+
+        grad = torch.randn_like(test_vector)
+        res.backward(gradient=grad)
+        actual.backward(gradient=grad)
+        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+            if arg_copy.grad is not None:
+                assert(approx_equal(arg.grad, arg_copy.grad))
+
+    def test_inv_matmul_vec(self):
+        lazy_tensor = self.create_lazy_tensor()
+        lazy_tensor_copy = lazy_tensor.clone()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+
+        test_vector = torch.randn(lazy_tensor.size(-1))
+        with gpytorch.settings.max_cg_iterations(100):
+            res = lazy_tensor.inv_matmul(test_vector)
+        actual = evaluated.inverse().matmul(test_vector)
+        assert(approx_equal(res, actual))
+
+        grad = torch.randn_like(test_vector)
+        res.backward(gradient=grad)
+        actual.backward(gradient=grad)
+        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+            if arg_copy.grad is not None:
+                assert(approx_equal(arg.grad, arg_copy.grad))
+
+    def test_inv_matmul_matrix(self):
+        lazy_tensor = self.create_lazy_tensor()
+        lazy_tensor_copy = lazy_tensor.clone()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+
+        test_vector = torch.randn(lazy_tensor.size(-1), 5)
+        with gpytorch.settings.max_cg_iterations(100):
+            res = lazy_tensor.inv_matmul(test_vector)
+        actual = evaluated.inverse().matmul(test_vector)
+        assert(approx_equal(res, actual))
+
+        grad = torch.randn_like(test_vector)
+        res.backward(gradient=grad)
+        actual.backward(gradient=grad)
+        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+            if arg_copy.grad is not None:
+                assert(approx_equal(arg.grad, arg_copy.grad))
+
+    def test_diag(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        self.assertTrue(approx_equal(lazy_tensor.diag(), evaluated.diag()))
+
+    def test_evaluate(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+        self.assertTrue(approx_equal(lazy_tensor.evaluate(), evaluated))
+
+    def test_inv_quad_log_det(self):
+        # Forward
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        vecs = torch.randn(lazy_tensor.size(1), 3, requires_grad=True)
+        vecs_copy = vecs.clone()
+
+        res_inv_quad, res_log_det = lazy_tensor.inv_quad_log_det(inv_quad_rhs=vecs, log_det=True)
+        res = res_inv_quad + res_log_det
+
+        actual_inv_quad = evaluated.inverse().matmul(vecs_copy).mul(vecs_copy).sum()
+        actual = actual_inv_quad + torch.logdet(evaluated)
+
+        diff = (res - actual).abs() / actual.abs().clamp(1, 1e10)
+        self.assertLess(diff.item(), 5e-2)
+
+    def test_sample(self):
+        if self.__class__.should_test_sample:
+            lazy_tensor = self.create_lazy_tensor()
+            evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+            samples = lazy_tensor.zero_mean_mvn_samples(10000)
+            sample_covar = samples.unsqueeze(-1).matmul(samples.unsqueeze(-2)).mean(0)
+            self.assertLess(((sample_covar - evaluated).abs() / evaluated.abs().clamp(1, 1e5)).max().item(), 3e-1)
+
+    def test_getitem(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        self.assertTrue(approx_equal(lazy_tensor[2], evaluated[2]))
+        self.assertTrue(approx_equal(lazy_tensor[0:2].evaluate(), evaluated[0:2]))
+        self.assertTrue(approx_equal(lazy_tensor[:, 2:3].evaluate(), evaluated[:, 2:3]))
+        self.assertTrue(approx_equal(lazy_tensor[:, 0:2].evaluate(), evaluated[:, 0:2]))
+        self.assertTrue(approx_equal(lazy_tensor[:1, :2].evaluate(), evaluated[:1, :2]))
+        self.assertTrue(approx_equal(lazy_tensor[1, :2], evaluated[1, :2]))
+        self.assertTrue(approx_equal(lazy_tensor[:1, 2], evaluated[:1, 2]))
+
+    def test_getitem_tensor_index(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        index = (torch.tensor([0, 0, 1, 2]), torch.tensor([0, 1, 0, 2]))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+        index = (torch.tensor([0, 0, 1, 2]), slice(None, None, None))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+        index = (slice(None, None, None), torch.tensor([0, 0, 1, 2]))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+
+
+class BatchLazyTensorTestCase(object):
+    should_test_sample = False
+
+    @abstractmethod
+    def create_lazy_tensor(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def evaluate_lazy_tensor(self):
+        raise NotImplementedError()
+
+    def setUp(self):
+        if hasattr(self.__class__, "seed"):
+            seed = self.__class__.seed
+            if os.getenv("UNLOCK_SEED") is None or os.getenv("UNLOCK_SEED").lower() == "false":
+                self.rng_state = torch.get_rng_state()
+                torch.manual_seed(seed)
+                if torch.cuda.is_available():
+                    torch.cuda.manual_seed_all(seed)
+                random.seed(seed)
+
+    def tearDown(self):
+        if hasattr(self, "rng_state"):
+            torch.set_rng_state(self.rng_state)
+
+    def test_matmul_matrix(self):
+        lazy_tensor = self.create_lazy_tensor()
+        lazy_tensor_copy = lazy_tensor.clone()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+
+        test_vector = torch.randn(lazy_tensor.size(0), lazy_tensor.size(-1), 5)
+        res = lazy_tensor.matmul(test_vector)
+        actual = evaluated.matmul(test_vector)
+        assert(approx_equal(res, actual))
+
+        grad = torch.randn_like(test_vector)
+        res.backward(gradient=grad)
+        actual.backward(gradient=grad)
+        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+            if arg_copy.grad is not None:
+                assert(approx_equal(arg.grad, arg_copy.grad))
+
+    def test_inv_matmul_matrix(self):
+        lazy_tensor = self.create_lazy_tensor()
+        lazy_tensor_copy = lazy_tensor.clone()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+
+        test_vector = torch.randn(lazy_tensor.size(0), lazy_tensor.size(-1), 5)
+        with gpytorch.settings.max_cg_iterations(100):
+            res = lazy_tensor.inv_matmul(test_vector)
+        actual = torch.cat([
+            evaluated[i].inverse().matmul(test_vector[i]).unsqueeze(0) for i in range(lazy_tensor.size(0))
+        ])
+        assert(approx_equal(res, actual))
+
+        grad = torch.randn_like(test_vector)
+        res.backward(gradient=grad)
+        actual.backward(gradient=grad)
+        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+            if arg_copy.grad is not None:
+                assert(approx_equal(arg.grad, arg_copy.grad))
+
+    def test_diag(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        actual = torch.stack([evaluated[i].diag() for i in range(evaluated.size(0))])
+        self.assertTrue(approx_equal(lazy_tensor.diag(), actual))
+
+    def test_evaluate(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+        self.assertTrue(approx_equal(lazy_tensor.evaluate(), evaluated))
+
+    def test_inv_quad_log_det(self):
+        # Forward
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        vecs = torch.randn(lazy_tensor.size(0), lazy_tensor.size(1), 3, requires_grad=True)
+        vecs_copy = vecs.clone()
+
+        res_inv_quad, res_log_det = lazy_tensor.inv_quad_log_det(inv_quad_rhs=vecs, log_det=True)
+        res = res_inv_quad + res_log_det
+
+        actual_inv_quad = torch.cat([
+            evaluated[i].inverse().matmul(vecs_copy[i]).mul(vecs_copy[i]).sum().unsqueeze(0)
+            for i in range(lazy_tensor.size(0))
+        ])
+        actual = actual_inv_quad + torch.cat([
+            torch.logdet(evaluated[i]).unsqueeze(0) for i in range(lazy_tensor.size(0))
+        ])
+
+        diffs = (res - actual).abs() / actual.abs().clamp(1, 1e10)
+        for i in range(lazy_tensor.size(0)):
+            self.assertLess(diffs[i].item(), 5e-2)
+
+    def test_sample(self):
+        if self.__class__.should_test_sample:
+            lazy_tensor = self.create_lazy_tensor()
+            evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+            samples = lazy_tensor.zero_mean_mvn_samples(10000)
+            sample_covar = samples.unsqueeze(-1).matmul(samples.unsqueeze(-2)).mean(0)
+            self.assertLess(((sample_covar - evaluated).abs() / evaluated.abs().clamp(1, 1e5)).max().item(), 3e-1)
+
+    def test_getitem(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        self.assertTrue(approx_equal(lazy_tensor[1].evaluate(), evaluated[1]))
+        self.assertTrue(approx_equal(lazy_tensor[0:2].evaluate(), evaluated[0:2]))
+        self.assertTrue(approx_equal(lazy_tensor[:, 2:3].evaluate(), evaluated[:, 2:3]))
+        self.assertTrue(approx_equal(lazy_tensor[:, 0:2].evaluate(), evaluated[:, 0:2]))
+        self.assertTrue(approx_equal(lazy_tensor[1, :1, :2].evaluate(), evaluated[1, :1, :2]))
+        self.assertTrue(approx_equal(lazy_tensor[1, 1, :2], evaluated[1, 1, :2]))
+        self.assertTrue(approx_equal(lazy_tensor[1, :1, 2], evaluated[1, :1, 2]))
+
+    def test_getitem_tensor_index(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1]))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), slice(None, None, None))
+        print(evaluated)
+        print(lazy_tensor.evaluate())
+        print(lazy_tensor[index])
+        print(evaluated[index])
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+        index = (torch.tensor([0, 1, 1]), slice(None, None, None), torch.tensor([0, 1, 2]))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+        index = (slice(None, None, None), torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+        index = (torch.tensor([0, 0, 1, 1]), slice(None, None, None), slice(None, None, None))
+        self.assertTrue(approx_equal(lazy_tensor[index].evaluate(), evaluated[index]))
+        index = (slice(None, None, None), torch.tensor([0, 0, 1, 2]), torch.tensor([0, 0, 1, 1]))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), slice(None, None, None))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+        index = (torch.tensor([0, 0, 1, 0]), slice(None, None, None), torch.tensor([0, 0, 1, 1]))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))

--- a/test/lazy/test_block_diag_lazy_tensor.py
+++ b/test/lazy/test_block_diag_lazy_tensor.py
@@ -3,179 +3,50 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
-import random
 import torch
 import unittest
 import gpytorch
 from gpytorch.lazy import BlockDiagLazyTensor, NonLazyTensor
-from gpytorch.utils import approx_equal
+from ._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
 
 
-class TestBlockDiagLazyTensor(unittest.TestCase):
-    def setUp(self):
-        if os.getenv("UNLOCK_SEED") is None or os.getenv("UNLOCK_SEED").lower() == "false":
-            self.rng_state = torch.get_rng_state()
-            torch.manual_seed(0)
-            if torch.cuda.is_available():
-                torch.cuda.manual_seed_all(0)
-            random.seed(0)
+class TestBlockDiagLazyTensor(LazyTensorTestCase, unittest.TestCase):
+    seed = 0
+    should_test_sample = True
 
+    def create_lazy_tensor(self):
         blocks = torch.randn(8, 4, 4)
-        self.blocks = blocks.transpose(-1, -2).matmul(blocks)
+        blocks = blocks.matmul(blocks.transpose(-1, -2))
+        blocks.add_(torch.eye(4, 4).unsqueeze_(0))
+        blocks.requires_grad_(True)
+        return BlockDiagLazyTensor(NonLazyTensor(blocks))
 
-    def tearDown(self):
-        if hasattr(self, "rng_state"):
-            torch.set_rng_state(self.rng_state)
-
-    def test_matmul(self):
-        rhs_tensor = torch.randn(4 * 8, 4, requires_grad=True)
-        rhs_tensor_copy = rhs_tensor.clone().detach().requires_grad_(True)
-        block_tensor = self.blocks.clone().requires_grad_(True)
-        block_tensor_copy = self.blocks.clone().requires_grad_(True)
-
-        actual_block_diag = torch.zeros(32, 32)
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        blocks = lazy_tensor.base_lazy_tensor.tensor
+        actual = torch.zeros(32, 32)
         for i in range(8):
-            actual_block_diag[i * 4 : (i + 1) * 4, i * 4 : (i + 1) * 4] = block_tensor_copy[i]
+            actual[i * 4 : (i + 1) * 4, i * 4 : (i + 1) * 4] = blocks[i]
+        return actual
 
-        res = BlockDiagLazyTensor(NonLazyTensor(block_tensor)).matmul(rhs_tensor)
-        actual = actual_block_diag.matmul(rhs_tensor_copy)
 
-        self.assertTrue(approx_equal(res, actual))
+class TestBlockDiagLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+    seed = 0
+    should_test_sample = True
 
-        actual.sum().backward()
-        res.sum().backward()
+    def create_lazy_tensor(self):
+        blocks = torch.randn(8, 4, 4)
+        blocks = blocks.matmul(blocks.transpose(-1, -2))
+        blocks.add_(torch.eye(4, 4).unsqueeze_(0))
+        blocks.requires_grad_(True)
+        return BlockDiagLazyTensor(NonLazyTensor(blocks), num_blocks=4)
 
-        self.assertTrue(approx_equal(rhs_tensor.grad, rhs_tensor_copy.grad))
-        self.assertTrue(approx_equal(block_tensor.grad, block_tensor_copy.grad))
-
-    def test_batch_matmul(self):
-        rhs_tensor = torch.randn(2, 4 * 4, 4, requires_grad=True)
-        rhs_tensor_copy = rhs_tensor.clone().detach().requires_grad_(True)
-        block_tensor = self.blocks.clone().requires_grad_(True)
-        block_tensor_copy = self.blocks.clone().requires_grad_(True)
-
-        actual_block_diag = torch.zeros(2, 16, 16)
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        blocks = lazy_tensor.base_lazy_tensor.tensor
+        actual = torch.zeros(2, 16, 16)
         for i in range(2):
             for j in range(4):
-                actual_block_diag[i, j * 4 : (j + 1) * 4, j * 4 : (j + 1) * 4] = block_tensor_copy[i * 4 + j]
-
-        res = BlockDiagLazyTensor(NonLazyTensor(block_tensor), num_blocks=4).matmul(rhs_tensor)
-        actual = actual_block_diag.matmul(rhs_tensor_copy)
-
-        self.assertTrue(approx_equal(res, actual))
-
-        actual.sum().backward()
-        res.sum().backward()
-
-        self.assertTrue(approx_equal(rhs_tensor.grad, rhs_tensor_copy.grad))
-        self.assertTrue(approx_equal(block_tensor.grad, block_tensor_copy.grad))
-
-    def test_diag(self):
-        block_tensor = self.blocks.clone().requires_grad_(True)
-        actual_block_diag = torch.zeros(32, 32)
-        for i in range(8):
-            actual_block_diag[i * 4 : (i + 1) * 4, i * 4 : (i + 1) * 4] = block_tensor[i]
-
-        res = BlockDiagLazyTensor(NonLazyTensor(block_tensor)).diag()
-        actual = actual_block_diag.diag()
-        self.assertTrue(approx_equal(actual, res))
-
-    def test_batch_diag(self):
-        block_tensor = self.blocks.clone().requires_grad_(True)
-        actual_block_diag = torch.zeros(2, 16, 16)
-        for i in range(2):
-            for j in range(4):
-                actual_block_diag[i, j * 4 : (j + 1) * 4, j * 4 : (j + 1) * 4] = block_tensor[i * 4 + j]
-
-        res = BlockDiagLazyTensor(NonLazyTensor(block_tensor), num_blocks=4).diag()
-        actual = torch.cat([actual_block_diag[0].diag().unsqueeze(0), actual_block_diag[1].diag().unsqueeze(0)])
-        self.assertTrue(approx_equal(actual, res))
-
-    def test_getitem(self):
-        block_tensor = self.blocks.clone().requires_grad_(True)
-        actual_block_diag = torch.zeros(32, 32)
-        for i in range(8):
-            actual_block_diag[i * 4 : (i + 1) * 4, i * 4 : (i + 1) * 4] = block_tensor[i]
-
-        res = BlockDiagLazyTensor(NonLazyTensor(block_tensor))[:5, 2]
-        actual = actual_block_diag[:5, 2]
-        self.assertTrue(approx_equal(actual, res))
-
-    def test_getitem_batch(self):
-        block_tensor = self.blocks.clone().requires_grad_(True)
-        actual_block_diag = torch.zeros(2, 16, 16)
-        for i in range(2):
-            for j in range(4):
-                actual_block_diag[i, j * 4 : (j + 1) * 4, j * 4 : (j + 1) * 4] = block_tensor[i * 4 + j]
-
-        res = BlockDiagLazyTensor(NonLazyTensor(block_tensor), num_blocks=4)[0].evaluate()
-        actual = actual_block_diag[0]
-        self.assertTrue(approx_equal(actual, res))
-
-        res = BlockDiagLazyTensor(NonLazyTensor(block_tensor), num_blocks=4)[0, :5].evaluate()
-        actual = actual_block_diag[0, :5]
-        self.assertTrue(approx_equal(actual, res))
-
-        res = BlockDiagLazyTensor(NonLazyTensor(block_tensor), num_blocks=4)[1:, :5, 2]
-        actual = actual_block_diag[1:, :5, 2]
-        self.assertTrue(approx_equal(actual, res))
-
-    def test_get_item_tensor_index(self):
-        # Tests the default LV.__getitem__ behavior
-        block_tensor = self.blocks.clone().requires_grad_(True)
-        lazy_tensor = BlockDiagLazyTensor(NonLazyTensor(block_tensor))
-        evaluated = lazy_tensor.evaluate()
-
-        index = (torch.tensor([0, 0, 1, 2]), torch.tensor([0, 1, 0, 2]))
-        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 0, 1, 2]), slice(None, None, None))
-        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
-        index = (slice(None, None, None), torch.tensor([0, 0, 1, 2]))
-        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
-
-    def test_get_item_tensor_index_on_batch(self):
-        # Tests the default LV.__getitem__ behavior
-        block_tensor = self.blocks.clone().requires_grad_(True)
-        lazy_tensor = BlockDiagLazyTensor(NonLazyTensor(block_tensor), num_blocks=4)
-        evaluated = lazy_tensor.evaluate()
-
-        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1]))
-        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), slice(None, None, None))
-        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 1, 1]), slice(None, None, None), torch.tensor([0, 1, 2]))
-        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
-        index = (slice(None, None, None), torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]))
-        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 0, 1, 1]), slice(None, None, None), slice(None, None, None))
-        self.assertTrue(approx_equal(lazy_tensor[index].evaluate(), evaluated[index]))
-        index = (slice(None, None, None), torch.tensor([0, 0, 1, 2]), torch.tensor([0, 0, 1, 1]))
-        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), slice(None, None, None))
-        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 0, 1, 0]), slice(None, None, None), torch.tensor([0, 0, 1, 1]))
-        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
-
-    def test_sample(self):
-        block_tensor = self.blocks.clone().requires_grad_(True)
-        res = BlockDiagLazyTensor(NonLazyTensor(block_tensor))
-        actual = res.evaluate()
-
-        with gpytorch.settings.max_root_decomposition_size(1000):
-            samples = res.zero_mean_mvn_samples(10000)
-            sample_covar = samples.unsqueeze(-1).matmul(samples.unsqueeze(-2)).mean(0)
-        self.assertLess(((sample_covar - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 2e-1)
-
-    def test_batch_sample(self):
-        block_tensor = self.blocks.clone().requires_grad_(True)
-        res = BlockDiagLazyTensor(NonLazyTensor(block_tensor), num_blocks=4)
-        actual = res.evaluate()
-
-        with gpytorch.settings.max_root_decomposition_size(1000):
-            samples = res.zero_mean_mvn_samples(10000)
-            sample_covar = samples.unsqueeze(-1).matmul(samples.unsqueeze(-2)).mean(0)
-        self.assertLess(((sample_covar - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 2e-1)
+                actual[i, j * 4 : (j + 1) * 4, j * 4 : (j + 1) * 4] = blocks[i * 4 + j]
+        return actual
 
 
 if __name__ == "__main__":

--- a/test/lazy/test_chol_lazy_tensor.py
+++ b/test/lazy/test_chol_lazy_tensor.py
@@ -6,134 +6,54 @@ from __future__ import unicode_literals
 import torch
 import unittest
 from gpytorch.lazy import CholLazyTensor
-from gpytorch.utils import approx_equal
+from ._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
 
 
-class TestCholLazyTensor(unittest.TestCase):
-    def setUp(self):
+class TestCholLazyTensor(LazyTensorTestCase, unittest.TestCase):
+    seed = 0
+    should_test_sample = True
+
+    def create_lazy_tensor(self):
         chol = torch.tensor(
             [[3, 0, 0, 0, 0], [-1, 2, 0, 0, 0], [1, 4, 1, 0, 0], [0, 2, 3, 2, 0], [-4, -2, 1, 3, 4]],
             dtype=torch.float,
             requires_grad=True,
         )
-        vecs = torch.randn(5, 2, requires_grad=True)
+        return CholLazyTensor(chol)
 
-        self.chol = chol
-        self.chol_copy = chol.clone().detach().requires_grad_(True)
-        self.actual_mat = self.chol_copy.matmul(self.chol_copy.transpose(-1, -2))
-        self.vecs = vecs
-        self.vecs_copy = vecs.clone().detach().requires_grad_(True)
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        chol = lazy_tensor.root.evaluate()
+        return chol.matmul(chol.transpose(-1, -2))
 
-    def test_matmul(self):
-        # Forward
-        res = CholLazyTensor(self.chol).matmul(self.vecs)
-        actual = self.actual_mat.matmul(self.vecs_copy)
-        self.assertTrue(approx_equal(res, actual))
+    def test_inv_matmul_vec(self):
+        # We're skipping this test, since backward passes aren't defined in torch for this
+        pass
 
-        # Backward
-        grad_output = torch.randn(*self.vecs.size())
-        res.backward(gradient=grad_output)
-        actual.backward(gradient=grad_output)
-        self.assertTrue(approx_equal(self.chol.grad, self.chol_copy.grad))
-        self.assertTrue(approx_equal(self.vecs.grad, self.vecs_copy.grad))
-
-    def test_inv_matmul(self):
-        # Forward
-        res = CholLazyTensor(self.chol).inv_matmul(self.vecs)
-        actual = self.actual_mat.inverse().matmul(self.vecs_copy)
-        self.assertLess(torch.max((res - actual).abs() / actual.norm()), 1e-2)
-
-    def test_inv_quad_log_det(self):
-        # Forward
-        res_inv_quad, res_log_det = CholLazyTensor(self.chol).inv_quad_log_det(inv_quad_rhs=self.vecs, log_det=True)
-        res = res_inv_quad + res_log_det
-        actual_inv_quad = self.actual_mat.inverse().matmul(self.vecs_copy).mul(self.vecs_copy).sum()
-        actual = actual_inv_quad + torch.log(torch.det(self.actual_mat))
-        self.assertLess(((res - actual) / actual).abs().item(), 1e-2)
-
-    def test_diag(self):
-        res = CholLazyTensor(self.chol).diag()
-        actual = self.actual_mat.diag()
-        self.assertTrue(approx_equal(res, actual))
-
-    def test_getitem(self):
-        res = CholLazyTensor(self.chol)[2:4, -2]
-        actual = self.actual_mat[2:4, -2]
-        self.assertTrue(approx_equal(res, actual))
-
-    def test_evaluate(self):
-        res = CholLazyTensor(self.chol).evaluate()
-        actual = self.actual_mat
-        self.assertTrue(approx_equal(res, actual))
+    def test_inv_matmul_matrix(self):
+        # We're skipping this test, since backward passes aren't defined in torch for this
+        pass
 
 
-class TestCholLazyTensorBatch(unittest.TestCase):
-    def setUp(self):
+class TestCholLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+    seed = 0
+    should_test_sample = True
+
+    def create_lazy_tensor(self):
         chol = torch.tensor(
             [
                 [[3, 0, 0, 0, 0], [-1, 2, 0, 0, 0], [1, 4, 1, 0, 0], [0, 2, 3, 2, 0], [-4, -2, 1, 3, 4]],
                 [[2, 0, 0, 0, 0], [3, 1, 0, 0, 0], [-2, 3, 2, 0, 0], [-2, 1, -1, 3, 0], [-4, -4, 5, 2, 3]],
             ],
             dtype=torch.float,
-            requires_grad=True,
         )
-        vecs = torch.randn(2, 5, 3, requires_grad=True)
+        chol.add_(torch.eye(5).unsqueeze(0))
+        chol.requires_grad_(True)
+        return CholLazyTensor(chol)
 
-        self.chol = chol
-        self.chol_copy = chol.clone().detach().requires_grad_(True)
-        self.actual_mat = self.chol_copy.matmul(self.chol_copy.transpose(-1, -2))
-        self.actual_mat_inv = torch.cat(
-            [self.actual_mat[0].inverse().unsqueeze(0), self.actual_mat[1].inverse().unsqueeze(0)], 0
-        )
-
-        self.vecs = vecs
-        self.vecs_copy = vecs.clone().detach().requires_grad_(True)
-
-    def test_matmul(self):
-        # Forward
-        res = CholLazyTensor(self.chol).matmul(self.vecs)
-        actual = self.actual_mat.matmul(self.vecs_copy)
-        self.assertTrue(approx_equal(res, actual))
-
-        # Backward
-        grad_output = torch.randn(*self.vecs.size())
-        res.backward(gradient=grad_output)
-        actual.backward(gradient=grad_output)
-        self.assertTrue(approx_equal(self.chol.grad, self.chol_copy.grad))
-        self.assertTrue(approx_equal(self.vecs.grad, self.vecs_copy.grad))
-
-    def test_inv_matmul(self):
-        # Forward
-        res = CholLazyTensor(self.chol).inv_matmul(self.vecs)
-        actual = self.actual_mat_inv.matmul(self.vecs_copy)
-        self.assertLess(torch.max((res - actual).abs() / actual.norm()), 1e-2)
-
-    def test_inv_quad_log_det(self):
-        # Forward
-        res_inv_quad, res_log_det = CholLazyTensor(self.chol).inv_quad_log_det(inv_quad_rhs=self.vecs, log_det=True)
-        res = res_inv_quad + res_log_det
-        actual_inv_quad = self.actual_mat_inv.matmul(self.vecs_copy).mul(self.vecs_copy).sum(-1).sum(-1)
-        actual_log_det = torch.tensor(
-            [torch.log(torch.det(self.actual_mat[0])), torch.log(torch.det(self.actual_mat[1]))]
-        )
-
-        actual = actual_inv_quad + actual_log_det
-        self.assertLess(torch.max((res - actual).abs() / actual.norm()), 1e-2)
-
-    def test_diag(self):
-        res = CholLazyTensor(self.chol).diag()
-        actual = torch.cat([self.actual_mat[0].diag().unsqueeze(0), self.actual_mat[1].diag().unsqueeze(0)], 0)
-        self.assertTrue(approx_equal(res, actual))
-
-    def test_getitem(self):
-        res = CholLazyTensor(self.chol)[1, 2:4, -2]
-        actual = self.actual_mat[1, 2:4, -2]
-        self.assertTrue(approx_equal(res, actual))
-
-    def test_evaluate(self):
-        res = CholLazyTensor(self.chol).evaluate()
-        actual = self.actual_mat
-        self.assertTrue(approx_equal(res, actual))
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        chol = lazy_tensor.root.evaluate()
+        res = chol.matmul(chol.transpose(-1, -2))
+        return res
 
 
 if __name__ == "__main__":

--- a/test/lazy/test_constant_mul_lazy_tensor.py
+++ b/test/lazy/test_constant_mul_lazy_tensor.py
@@ -3,82 +3,43 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import math
 import torch
 import unittest
-import gpytorch
 from gpytorch.lazy import ToeplitzLazyTensor
+from gpytorch.utils.toeplitz import sym_toeplitz
+from ._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
 
 
-class TestConstantMulLazyTensor(unittest.TestCase):
-    def test_inv_matmul(self):
-        labels_var = torch.randn(4, requires_grad=True)
-        labels_var_copy = labels_var.clone().detach().requires_grad_(True)
-        grad_output = torch.randn(4)
+class TestConstantMulLazyTensor(LazyTensorTestCase, unittest.TestCase):
+    seed = 0
 
-        # Test case
-        c1_var = torch.tensor([5, 1, 2, 0], dtype=torch.float, requires_grad=True)
-        c2_var = torch.tensor([5, 1, 2, 0], dtype=torch.float, requires_grad=True)
-        toeplitz_lazy_var = ToeplitzLazyTensor(c1_var) * 2.5
-        actual = ToeplitzLazyTensor(c2_var).evaluate() * 2.5
+    def create_lazy_tensor(self):
+        column = torch.tensor([5, 1, 2, 0], dtype=torch.float, requires_grad=True)
+        constant = 2.5
+        return ToeplitzLazyTensor(column) * constant
 
-        # Test forward
-        with gpytorch.settings.max_cg_iterations(1000):
-            res = toeplitz_lazy_var.inv_matmul(labels_var)
-            actual = gpytorch.inv_matmul(actual, labels_var_copy)
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        constant = lazy_tensor.constant
+        column = lazy_tensor.base_lazy_tensor.column
+        return sym_toeplitz(column) * constant
 
-        # Test backwards
-        res.backward(grad_output)
-        actual.backward(grad_output)
 
-        for i in range(c1_var.size(0)):
-            self.assertLess(math.fabs(res[i].item() - actual[i].item()), 1e-2)
-            self.assertLess(math.fabs(c1_var.grad[i].item() - c2_var.grad[i].item()), 1e-2)
+class TestConstantMulLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+    seed = 0
 
-    def test_batch_inv_matmul(self):
-        labels_var = torch.randn(2, 4, 1, requires_grad=True)
-        labels_var_copy = labels_var.clone().detach().requires_grad_(True)
-        grad_output = torch.randn(2, 4, 1)
+    def create_lazy_tensor(self):
+        column = torch.tensor([[5, 1, 2, 0]], dtype=torch.float).repeat(2, 1)
+        column.requires_grad_(True)
+        constant = torch.tensor([2.5, 1.])
+        return ToeplitzLazyTensor(column) * constant
 
-        # Test case
-        c1_var = torch.tensor([[5, 1, 2, 0]], dtype=torch.float).repeat(2, 1)
-        c2_var = torch.tensor([[5, 1, 2, 0]], dtype=torch.float).repeat(2, 1)
-        c1_var.requires_grad = True
-        c2_var.requires_grad = True
-        toeplitz_lazy_var = ToeplitzLazyTensor(c1_var) * torch.tensor([2.5, 1.])
-        actual = ToeplitzLazyTensor(c2_var).evaluate() * torch.tensor([2.5, 1.]).view(2, 1, 1)
-
-        # Test forward
-        with gpytorch.settings.max_cg_iterations(1000):
-            res = toeplitz_lazy_var.inv_matmul(labels_var)
-            actual = gpytorch.inv_matmul(actual, labels_var_copy)
-
-        # Test backwards
-        res.backward(grad_output)
-        actual.backward(grad_output)
-
-        for i in range(c1_var.size(0)):
-            for j in range(c1_var.size(1)):
-                self.assertLess(math.fabs(res[i, j].item() - actual[i, j].item()), 1e-2)
-                self.assertLess(math.fabs(c1_var.grad[i, j].item() - c2_var.grad[i, j].item()), 1e-2)
-
-    def test_diag(self):
-        c1_var = torch.tensor([5, 1, 2, 0], dtype=torch.float, requires_grad=True)
-        c2_var = torch.tensor([12.5, 2.5, 5, 0], dtype=torch.float, requires_grad=True)
-        toeplitz_lazy_var = ToeplitzLazyTensor(c1_var) * 2.5
-        actual = ToeplitzLazyTensor(c2_var)
-
-        diff = torch.norm(actual.diag() - toeplitz_lazy_var.diag())
-        self.assertLess(diff, 1e-3)
-
-    def test_getitem(self):
-        c1_var = torch.tensor([5, 1, 2, 0], dtype=torch.float, requires_grad=True)
-        c2_var = torch.tensor([12.5, 2.5, 5, 0], dtype=torch.float, requires_grad=True)
-        toeplitz_lazy_var = ToeplitzLazyTensor(c1_var) * 2.5
-        actual = ToeplitzLazyTensor(c2_var)
-
-        diff = torch.norm(actual[2:, 2:].evaluate() - toeplitz_lazy_var[2:, 2:].evaluate())
-        self.assertLess(diff, 1e-3)
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        constant = lazy_tensor.constant
+        column = lazy_tensor.base_lazy_tensor.column
+        return torch.cat([
+            sym_toeplitz(column[0]).unsqueeze(0),
+            sym_toeplitz(column[1]).unsqueeze(0)
+        ]) * constant.view(2, 1, 1)
 
 
 if __name__ == "__main__":

--- a/test/lazy/test_interpolated_lazy_tensor.py
+++ b/test/lazy/test_interpolated_lazy_tensor.py
@@ -4,435 +4,81 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gpytorch
-import torch
 import unittest
-import os
-import random
+import torch
 from gpytorch.lazy import NonLazyTensor, InterpolatedLazyTensor
-from gpytorch.utils import approx_equal
+from ._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
 
 
-class TestInterpolatedLazyTensor(unittest.TestCase):
-    def setUp(self):
-        if os.getenv("UNLOCK_SEED") is None or os.getenv("UNLOCK_SEED").lower() == "false":
-            self.rng_state = torch.get_rng_state()
-            torch.manual_seed(0)
-            if torch.cuda.is_available():
-                torch.cuda.manual_seed_all(0)
-            random.seed(0)
+class TestInterpolatedLazyTensor(LazyTensorTestCase, unittest.TestCase):
+    seed = 1
+    should_test_sample = True
 
-    def tearDown(self):
-        if hasattr(self, "rng_state"):
-            torch.set_rng_state(self.rng_state)
-
-    def test_matmul(self):
-        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(3, 1)
-        left_interp_values = torch.tensor([[1, 2], [0.5, 1], [1, 3]], dtype=torch.float).repeat(3, 1)
-        left_interp_values_copy = left_interp_values.clone()
+    def create_lazy_tensor(self):
+        left_interp_indices = torch.LongTensor([[0, 1], [2, 3], [3, 4], [4, 5]])
+        left_interp_values = torch.tensor([[0.1, 0.9], [1, 2], [0.5, 1], [1, 3]], dtype=torch.float)
         left_interp_values.requires_grad = True
-        left_interp_values_copy.requires_grad = True
-        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(3, 1)
-        right_interp_values = torch.tensor([[1, 2], [2, 0.5], [1, 3]], dtype=torch.float).repeat(3, 1)
-        right_interp_values_copy = right_interp_values.clone()
+        right_interp_indices = torch.LongTensor([[0, 1], [2, 3], [3, 4], [4, 5]])
+        right_interp_values = torch.tensor([[0.1, 0.9], [1, 2], [0.5, 1], [1, 3]], dtype=torch.float)
         right_interp_values.requires_grad = True
-        right_interp_values_copy.requires_grad = True
 
-        base_lazy_tensor_mat = torch.randn(6, 6)
-        base_lazy_tensor_mat = base_lazy_tensor_mat.t().matmul(base_lazy_tensor_mat)
-        base_tensor = base_lazy_tensor_mat
+        base_tensor = torch.randn(6, 6)
+        base_tensor = base_tensor.t().matmul(base_tensor)
         base_tensor.requires_grad = True
-        base_tensor_copy = base_lazy_tensor_mat
         base_lazy_tensor = NonLazyTensor(base_tensor)
 
-        test_matrix = torch.randn(9, 4)
-
-        interp_lazy_tensor = InterpolatedLazyTensor(
+        return InterpolatedLazyTensor(
             base_lazy_tensor, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
         )
-        res = interp_lazy_tensor.matmul(test_matrix)
 
-        left_matrix = torch.zeros(9, 6)
-        right_matrix = torch.zeros(9, 6)
-        left_matrix.scatter_(1, left_interp_indices, left_interp_values_copy)
-        right_matrix.scatter_(1, right_interp_indices, right_interp_values_copy)
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        left_matrix = torch.zeros(4, 6)
+        right_matrix = torch.zeros(4, 6)
+        left_matrix.scatter_(1, lazy_tensor.left_interp_indices, lazy_tensor.left_interp_values)
+        right_matrix.scatter_(1, lazy_tensor.right_interp_indices, lazy_tensor.right_interp_values)
 
-        actual = left_matrix.matmul(base_tensor_copy).matmul(right_matrix.t()).matmul(test_matrix)
-        self.assertTrue(approx_equal(res, actual))
+        base_tensor = lazy_tensor.base_lazy_tensor.tensor
+        actual = left_matrix.matmul(base_tensor).matmul(right_matrix.t())
+        return actual
 
-        res.sum().backward()
-        actual.sum().backward()
 
-        self.assertTrue(approx_equal(base_tensor.grad, base_tensor_copy.grad))
-        self.assertTrue(approx_equal(left_interp_values.grad, left_interp_values_copy.grad))
+class TestInterpolatedLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+    seed = 0
+    should_test_sample = True
 
-    def test_batch_matmul(self):
-        left_interp_indices = torch.tensor([[2, 3], [3, 4], [4, 5]], dtype=torch.long).repeat(5, 3, 1)
-        left_interp_values = torch.tensor([[1, 2], [0.5, 1], [1, 3]], dtype=torch.float).repeat(5, 3, 1)
-        left_interp_values_copy = left_interp_values.clone()
+    def create_lazy_tensor(self):
+        left_interp_indices = torch.LongTensor([[0, 1], [2, 3], [3, 4], [4, 5]]).repeat(5, 1, 1)
+        left_interp_values = torch.tensor([[0.1, 0.9], [1, 2], [0.5, 1], [1, 3]], dtype=torch.float).repeat(5, 1, 1)
         left_interp_values.requires_grad = True
-        left_interp_values_copy.requires_grad = True
-        right_interp_indices = torch.tensor([[0, 1], [1, 2], [2, 3]], dtype=torch.long).repeat(5, 3, 1)
-        right_interp_values = torch.tensor([[1, 2], [2, 0.5], [1, 3]], dtype=torch.float).repeat(5, 3, 1)
-        right_interp_values_copy = right_interp_values.clone()
+        right_interp_indices = torch.LongTensor([[0, 1], [2, 3], [3, 4], [4, 5]]).repeat(5, 1, 1)
+        right_interp_values = torch.tensor([[0.1, 0.9], [1, 2], [0.5, 1], [1, 3]], dtype=torch.float).repeat(5, 1, 1)
         right_interp_values.requires_grad = True
-        right_interp_values_copy.requires_grad = True
 
-        base_lazy_tensor_mat = torch.randn(5, 6, 6)
-        base_lazy_tensor_mat = base_lazy_tensor_mat.transpose(-1, -2).matmul(base_lazy_tensor_mat)
-        base_tensor = base_lazy_tensor_mat
-        base_tensor_copy = base_tensor.clone()
+        base_tensor = torch.randn(5, 6, 6)
+        base_tensor = base_tensor.transpose(-2, -1).matmul(base_tensor)
         base_tensor.requires_grad = True
-        base_tensor_copy.requires_grad = True
         base_lazy_tensor = NonLazyTensor(base_tensor)
 
-        test_matrix = torch.randn(5, 9, 4)
-
-        interp_lazy_tensor = InterpolatedLazyTensor(
+        return InterpolatedLazyTensor(
             base_lazy_tensor, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
         )
-        res = interp_lazy_tensor.matmul(test_matrix)
 
+    def evaluate_lazy_tensor(self, lazy_tensor):
         left_matrix_comps = []
         right_matrix_comps = []
         for i in range(5):
-            left_matrix_comp = torch.zeros(9, 6)
-            right_matrix_comp = torch.zeros(9, 6)
-            left_matrix_comp.scatter_(1, left_interp_indices[i], left_interp_values_copy[i])
-            right_matrix_comp.scatter_(1, right_interp_indices[i], right_interp_values_copy[i])
+            left_matrix_comp = torch.zeros(4, 6)
+            right_matrix_comp = torch.zeros(4, 6)
+            left_matrix_comp.scatter_(1, lazy_tensor.left_interp_indices[i], lazy_tensor.left_interp_values[i])
+            right_matrix_comp.scatter_(1, lazy_tensor.right_interp_indices[i], lazy_tensor.right_interp_values[i])
             left_matrix_comps.append(left_matrix_comp.unsqueeze(0))
             right_matrix_comps.append(right_matrix_comp.unsqueeze(0))
         left_matrix = torch.cat(left_matrix_comps)
         right_matrix = torch.cat(right_matrix_comps)
 
-        actual = left_matrix.matmul(base_tensor_copy).matmul(right_matrix.transpose(-1, -2))
-        actual = actual.matmul(test_matrix)
-        self.assertTrue(approx_equal(res, actual))
-
-        res.sum().backward()
-        actual.sum().backward()
-
-        self.assertTrue(approx_equal(base_tensor.grad, base_tensor_copy.grad))
-        self.assertTrue(approx_equal(left_interp_values.grad, left_interp_values_copy.grad))
-
-    def test_inv_matmul(self):
-        base_lazy_tensor_mat = torch.randn(6, 6)
-        base_lazy_tensor_mat = base_lazy_tensor_mat.t().matmul(base_lazy_tensor_mat)
-        test_matrix = torch.randn(3, 4)
-
-        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]])
-        left_interp_values = torch.tensor([[1, 2], [0.5, 1], [1, 3]], dtype=torch.float)
-        left_interp_values_copy = left_interp_values.clone()
-        left_interp_values.requires_grad = True
-        left_interp_values_copy.requires_grad = True
-
-        right_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]])
-        right_interp_values = torch.tensor([[1, 2], [0.5, 1], [1, 3]], dtype=torch.float)
-        right_interp_values_copy = right_interp_values.clone()
-        right_interp_values.requires_grad = True
-        right_interp_values_copy.requires_grad = True
-
-        base_lazy_tensor = base_lazy_tensor_mat
-        base_lazy_tensor.requires_grad = True
-        base_lazy_tensor_copy = base_lazy_tensor_mat
-        test_matrix_tensor = test_matrix
-        test_matrix_tensor.requires_grad = True
-        test_matrix_tensor_copy = test_matrix
-
-        interp_lazy_tensor = InterpolatedLazyTensor(
-            NonLazyTensor(base_lazy_tensor),
-            left_interp_indices,
-            left_interp_values,
-            right_interp_indices,
-            right_interp_values,
-        )
-        res = interp_lazy_tensor.inv_matmul(test_matrix_tensor)
-
-        left_matrix = torch.zeros(3, 6)
-        right_matrix = torch.zeros(3, 6)
-        left_matrix.scatter_(1, left_interp_indices, left_interp_values_copy)
-        right_matrix.scatter_(1, right_interp_indices, right_interp_values_copy)
-        actual_mat = left_matrix.matmul(base_lazy_tensor_copy).matmul(right_matrix.transpose(-1, -2))
-        actual = gpytorch.inv_matmul(actual_mat, test_matrix_tensor_copy)
-
-        self.assertTrue(approx_equal(res, actual))
-
-        # Backward pass
-        res.sum().backward()
-        actual.sum().backward()
-
-        self.assertTrue(approx_equal(base_lazy_tensor.grad, base_lazy_tensor_copy.grad))
-        self.assertTrue(approx_equal(left_interp_values.grad, left_interp_values_copy.grad))
-
-    def test_inv_matmul_batch(self):
-        base_lazy_tensor = torch.randn(6, 6)
-        base_lazy_tensor = (base_lazy_tensor.t().matmul(base_lazy_tensor)).unsqueeze(0).repeat(5, 1, 1)
-        base_lazy_tensor_copy = base_lazy_tensor.clone()
-        base_lazy_tensor.requires_grad = True
-        base_lazy_tensor_copy.requires_grad = True
-
-        test_matrix_tensor = torch.randn(5, 3, 4)
-        test_matrix_tensor_copy = test_matrix_tensor.clone()
-        test_matrix_tensor.requires_grad = True
-        test_matrix_tensor_copy.requires_grad = True
-
-        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).unsqueeze(0).repeat(5, 1, 1)
-        left_interp_values = torch.tensor([[1, 2], [0.5, 1], [1, 3]], dtype=torch.float).unsqueeze(0).repeat(5, 1, 1)
-        left_interp_values_copy = left_interp_values.clone()
-        left_interp_values.requires_grad = True
-        left_interp_values_copy.requires_grad = True
-
-        right_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).unsqueeze(0).repeat(5, 1, 1)
-        right_interp_values = torch.tensor([[1, 2], [0.5, 1], [1, 3]], dtype=torch.float).unsqueeze(0).repeat(5, 1, 1)
-        right_interp_values_copy = right_interp_values.clone()
-        right_interp_values.requires_grad = True
-        right_interp_values_copy.requires_grad = True
-
-        interp_lazy_tensor = InterpolatedLazyTensor(
-            NonLazyTensor(base_lazy_tensor),
-            left_interp_indices,
-            left_interp_values,
-            right_interp_indices,
-            right_interp_values,
-        )
-        res = interp_lazy_tensor.inv_matmul(test_matrix_tensor)
-
-        left_matrix_comps = []
-        right_matrix_comps = []
-        for i in range(5):
-            left_matrix_comp = torch.zeros(3, 6)
-            right_matrix_comp = torch.zeros(3, 6)
-            left_matrix_comp.scatter_(1, left_interp_indices[i], left_interp_values_copy[i])
-            right_matrix_comp.scatter_(1, right_interp_indices[i], right_interp_values_copy[i])
-            left_matrix_comps.append(left_matrix_comp.unsqueeze(0))
-            right_matrix_comps.append(right_matrix_comp.unsqueeze(0))
-        left_matrix = torch.cat(left_matrix_comps)
-        right_matrix = torch.cat(right_matrix_comps)
-        actual_mat = left_matrix.matmul(base_lazy_tensor_copy).matmul(right_matrix.transpose(-1, -2))
-        actual = gpytorch.inv_matmul(actual_mat, test_matrix_tensor_copy)
-
-        self.assertTrue(approx_equal(res, actual))
-
-        # Backward pass
-        res.sum().backward()
-        actual.sum().backward()
-
-        self.assertTrue(approx_equal(base_lazy_tensor.grad, base_lazy_tensor_copy.grad))
-        self.assertTrue(approx_equal(left_interp_values.grad, left_interp_values_copy.grad))
-
-    def test_matmul_batch(self):
-        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 3, 1)
-        left_interp_values = torch.tensor([[1, 2], [0.5, 1], [1, 3]], dtype=torch.float).repeat(5, 3, 1)
-        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(5, 3, 1)
-        right_interp_values = torch.tensor([[1, 2], [2, 0.5], [1, 3]], dtype=torch.float).repeat(5, 3, 1)
-
-        base_lazy_tensor_mat = torch.randn(5, 6, 6)
-        base_lazy_tensor_mat = base_lazy_tensor_mat.transpose(1, 2).matmul(base_lazy_tensor_mat)
-        base_lazy_tensor_mat.requires_grad = True
-        test_matrix = torch.randn(1, 9, 4)
-
-        base_lazy_tensor = NonLazyTensor(base_lazy_tensor_mat)
-        interp_lazy_tensor = InterpolatedLazyTensor(
-            base_lazy_tensor, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
-        )
-        res = interp_lazy_tensor.matmul(test_matrix)
-
-        left_matrix = torch.tensor(
-            [
-                [0, 0, 1, 2, 0, 0],
-                [0, 0, 0, 0.5, 1, 0],
-                [0, 0, 0, 0, 1, 3],
-                [0, 0, 1, 2, 0, 0],
-                [0, 0, 0, 0.5, 1, 0],
-                [0, 0, 0, 0, 1, 3],
-                [0, 0, 1, 2, 0, 0],
-                [0, 0, 0, 0.5, 1, 0],
-                [0, 0, 0, 0, 1, 3],
-            ],
-            dtype=torch.float,
-        ).repeat(5, 1, 1)
-
-        right_matrix = torch.tensor(
-            [
-                [1, 2, 0, 0, 0, 0],
-                [0, 2, 0.5, 0, 0, 0],
-                [0, 0, 1, 3, 0, 0],
-                [1, 2, 0, 0, 0, 0],
-                [0, 2, 0.5, 0, 0, 0],
-                [0, 0, 1, 3, 0, 0],
-                [1, 2, 0, 0, 0, 0],
-                [0, 2, 0.5, 0, 0, 0],
-                [0, 0, 1, 3, 0, 0],
-            ],
-            dtype=torch.float,
-        ).repeat(5, 1, 1)
-        actual = left_matrix.matmul(base_lazy_tensor_mat).matmul(right_matrix.transpose(-1, -2)).matmul(test_matrix)
-
-        self.assertTrue(approx_equal(res, actual))
-
-    def test_getitem_batch(self):
-        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 1, 1)
-        left_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float).repeat(5, 1, 1)
-        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(5, 1, 1)
-        right_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float).repeat(5, 1, 1)
-
-        base_lazy_tensor_mat = torch.randn(5, 6, 6)
-        base_lazy_tensor_mat = base_lazy_tensor_mat.transpose(1, 2).matmul(base_lazy_tensor_mat)
-        base_lazy_tensor_mat.requires_grad = True
-
-        base_lazy_tensor = NonLazyTensor(base_lazy_tensor_mat)
-        interp_lazy_tensor = InterpolatedLazyTensor(
-            base_lazy_tensor, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
-        )
-
-        actual = (
-            base_lazy_tensor[:, 2:5, 0:3]
-            + base_lazy_tensor[:, 2:5, 1:4]
-            + base_lazy_tensor[:, 3:6, 0:3]
-            + base_lazy_tensor[:, 3:6, 1:4]
-        ).evaluate()
-
-        self.assertTrue(approx_equal(interp_lazy_tensor[2].evaluate(), actual[2]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[0:2].evaluate(), actual[0:2]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[:, 2:3].evaluate(), actual[:, 2:3]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[:, 0:2].evaluate(), actual[:, 0:2]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[1, :1, :2].evaluate(), actual[1, :1, :2]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[1, 1, :2], actual[1, 1, :2]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[1, :1, 2], actual[1, :1, 2]))
-
-    def test_get_item_tensor_index(self):
-        # Tests the default LV.__getitem__ behavior
-        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]])
-        left_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float)
-        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]])
-        right_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float)
-
-        base_lazy_tensor_mat = torch.randn(6, 6)
-        base_lazy_tensor_mat = base_lazy_tensor_mat.transpose(-1, -2).matmul(base_lazy_tensor_mat)
-
-        base_lazy_tensor = NonLazyTensor(base_lazy_tensor_mat)
-        interp_lazy_tensor = InterpolatedLazyTensor(
-            base_lazy_tensor, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
-        )
-        evaluated = interp_lazy_tensor.evaluate()
-
-        index = (torch.tensor([0, 0, 1, 2]), torch.tensor([0, 1, 0, 2]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 0, 1, 2]), slice(None, None, None))
-        self.assertTrue(approx_equal(interp_lazy_tensor[index], evaluated[index]))
-        index = (slice(None, None, None), torch.tensor([0, 0, 1, 2]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[index], evaluated[index]))
-
-    def test_get_item_tensor_index_on_batch(self):
-        # Tests the default LV.__getitem__ behavior
-        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 1, 1)
-        left_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float).repeat(5, 1, 1)
-        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(5, 1, 1)
-        right_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float).repeat(5, 1, 1)
-
-        base_lazy_tensor_mat = torch.randn(5, 6, 6)
-        base_lazy_tensor_mat = base_lazy_tensor_mat.transpose(1, 2).matmul(base_lazy_tensor_mat)
-        base_lazy_tensor_mat.requires_grad = True
-
-        base_lazy_tensor = NonLazyTensor(base_lazy_tensor_mat)
-        interp_lazy_tensor = InterpolatedLazyTensor(
-            base_lazy_tensor, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
-        )
-        evaluated = interp_lazy_tensor.evaluate()
-
-        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), slice(None, None, None))
-        self.assertTrue(approx_equal(interp_lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 1, 1]), slice(None, None, None), torch.tensor([0, 1, 2]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[index], evaluated[index]))
-        index = (slice(None, None, None), torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 0, 1, 1]), slice(None, None, None), slice(None, None, None))
-        self.assertTrue(approx_equal(interp_lazy_tensor[index].evaluate(), evaluated[index]))
-        index = (slice(None, None, None), torch.tensor([0, 0, 1, 2]), torch.tensor([0, 0, 1, 1]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), slice(None, None, None))
-        self.assertTrue(approx_equal(interp_lazy_tensor[index], evaluated[index]))
-        index = (torch.tensor([0, 0, 1, 0]), slice(None, None, None), torch.tensor([0, 0, 1, 1]))
-        self.assertTrue(approx_equal(interp_lazy_tensor[index], evaluated[index]))
-
-    def test_diag(self):
-        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]])
-        left_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float)
-        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]])
-        right_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float)
-
-        base_lazy_tensor_mat = torch.randn(6, 6)
-        base_lazy_tensor_mat = base_lazy_tensor_mat.t().matmul(base_lazy_tensor_mat)
-        base_lazy_tensor_mat.requires_grad = True
-
-        base_lazy_tensor = NonLazyTensor(base_lazy_tensor_mat)
-        interp_lazy_tensor = InterpolatedLazyTensor(
-            base_lazy_tensor, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
-        )
-
-        actual = interp_lazy_tensor.evaluate()
-        self.assertTrue(approx_equal(actual.diag(), interp_lazy_tensor.diag()))
-
-    def test_batch_diag(self):
-        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 1, 1)
-        left_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float).repeat(5, 1, 1)
-        right_interp_indices = torch.LongTensor([[0, 1], [1, 2], [2, 3]]).repeat(5, 1, 1)
-        right_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float).repeat(5, 1, 1)
-
-        base_lazy_tensor_mat = torch.randn(5, 6, 6)
-        base_lazy_tensor_mat = base_lazy_tensor_mat.transpose(1, 2).matmul(base_lazy_tensor_mat)
-        base_lazy_tensor_mat.requires_grad = True
-
-        base_lazy_tensor = NonLazyTensor(base_lazy_tensor_mat)
-        interp_lazy_tensor = InterpolatedLazyTensor(
-            base_lazy_tensor, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
-        )
-
-        actual = interp_lazy_tensor.evaluate()
-        actual_diag = torch.stack(
-            [actual[0].diag(), actual[1].diag(), actual[2].diag(), actual[3].diag(), actual[4].diag()]
-        )
-
-        self.assertTrue(approx_equal(actual_diag, interp_lazy_tensor.diag()))
-
-    def test_sample(self):
-        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]])
-        left_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float)
-
-        base_lazy_tensor_mat = torch.randn(6, 6)
-        base_lazy_tensor_mat = base_lazy_tensor_mat.t().matmul(base_lazy_tensor_mat)
-        base_lazy_tensor_mat.requires_grad = True
-
-        base_lazy_tensor = NonLazyTensor(base_lazy_tensor_mat)
-        interp_lazy_tensor = InterpolatedLazyTensor(
-            base_lazy_tensor, left_interp_indices, left_interp_values, left_interp_indices, left_interp_values
-        )
-
-        actual = interp_lazy_tensor.evaluate()
-
-        samples = interp_lazy_tensor.zero_mean_mvn_samples(10000)
-        sample_covar = samples.unsqueeze(-1).matmul(samples.unsqueeze(-2)).mean(0)
-        self.assertLess(((sample_covar - actual).abs() / actual.abs().clamp(1e-5, 1e5)).max().item(), 2e-1)
-
-    def test_batch_sample(self):
-        left_interp_indices = torch.LongTensor([[2, 3], [3, 4], [4, 5]]).repeat(5, 1, 1)
-        left_interp_values = torch.tensor([[1, 1], [1, 1], [1, 1]], dtype=torch.float).repeat(5, 1, 1)
-
-        base_lazy_tensor_mat = torch.randn(5, 6, 6)
-        base_lazy_tensor_mat = base_lazy_tensor_mat.transpose(1, 2).matmul(base_lazy_tensor_mat)
-        base_lazy_tensor_mat.requires_grad = True
-
-        base_lazy_tensor = NonLazyTensor(base_lazy_tensor_mat)
-        interp_lazy_tensor = InterpolatedLazyTensor(
-            base_lazy_tensor, left_interp_indices, left_interp_values, left_interp_indices, left_interp_values
-        )
-
-        actual = interp_lazy_tensor.evaluate()
-
-        samples = interp_lazy_tensor.zero_mean_mvn_samples(10000)
-        sample_covar = samples.unsqueeze(-1).matmul(samples.unsqueeze(-2)).mean(0)
-        self.assertLess(((sample_covar - actual).abs() / actual.abs().clamp(1e-5, 1e5)).max().item(), 2e-1)
+        base_tensor = lazy_tensor.base_lazy_tensor.tensor
+        actual = left_matrix.matmul(base_tensor).matmul(right_matrix.transpose(-1, -2))
+        return actual
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We've seen a number of bugs recently in LazyTensor behaviors. Some LTs have comprehensive unit tests, covering lots of edge cases. Others do not.

I propose creating super classes for all LT unit tests that contain lots of test cases. For each LT unit test, we will only have to write a method that constructs/evaluates the LT.

I started on a couple LTs.