### PR TITLE
Fix links to LOVE in example notebooks

### DIFF
--- a/examples/01_Simple_GP_Regression/Simple_GP_Regression.ipynb
+++ b/examples/01_Simple_GP_Regression/Simple_GP_Regression.ipynb
@@ -267,7 +267,7 @@
     "f_samples = f_preds.sample(sample_shape=torch.Size(1000,))\n",
     "```\n",
     "\n",
-    "The `gpytorch.fast_pred_var` context is not needed, but here we are giving a preview of using one of our cool features, getting faster predictive distributions using LOVE (https://arxiv.org/abs/1803.06058)."
+    "The `gpytorch.fast_pred_var` context is not needed, but here we are giving a preview of using one of our cool features, getting faster predictive distributions using [LOVE](https://arxiv.org/abs/1803.06058)."
    ]
   },
   {

--- a/examples/02_Simple_GP_Classification/Simple_GP_Classification.ipynb
+++ b/examples/02_Simple_GP_Classification/Simple_GP_Classification.ipynb
@@ -258,7 +258,7 @@
     "f_samples = f_preds.sample(sample_shape=torch.Size((1000,))\n",
     "```\n",
     "\n",
-    "The `gpytorch.fast_pred_var` context is not needed, but here we are giving a preview of using one of our cool features, getting faster predictive distributions using LOVE (https://arxiv.org/abs/1803.06058)."
+    "The `gpytorch.fast_pred_var` context is not needed, but here we are giving a preview of using one of our cool features, getting faster predictive distributions using [LOVE](https://arxiv.org/abs/1803.06058)."
    ]
   },
   {


### PR DESCRIPTION
Jupyter notebook's link creation is a bit wonky, so the links it create currently point to `https://arxiv.org/abs/1803.06058)`

This just fixes the links.