### PR TITLE
Use custom KL div and log_prob with gpytorch.distributions.MultivarateNormal

### DIFF
--- a/gpytorch/distributions/multitask_multivariate_normal.py
+++ b/gpytorch/distributions/multitask_multivariate_normal.py
@@ -43,7 +43,7 @@ class MultitaskMultivariateNormal(MultivariateNormal):
         return res
 
     def log_prob(self, value):
-        return super(MultivariateNormal, self).log_prob(value.view(value.shape[:-2] + torch.Size([-1])))
+        return super(MultitaskMultivariateNormal, self).log_prob(value.view(value.shape[:-2] + torch.Size([-1])))
 
     @property
     def mean(self):

--- a/gpytorch/variational/mvn_variational_strategy.py
+++ b/gpytorch/variational/mvn_variational_strategy.py
@@ -5,38 +5,11 @@ from __future__ import unicode_literals
 
 import torch
 from .variational_strategy import VariationalStrategy
-from ..lazy import LazyTensor, NonLazyTensor
 
 
 class MVNVariationalStrategy(VariationalStrategy):
     def kl_divergence(self):
-        prior_mean = self.prior_dist.mean
-        prior_covar = self.prior_dist.lazy_covariance_matrix
-        if not isinstance(prior_covar, LazyTensor):
-            prior_covar = NonLazyTensor(prior_covar)
-        prior_covar = prior_covar.add_jitter()
-
-        variational_mean = self.variational_dist.mean
-        variational_covar = self.variational_dist.lazy_covariance_matrix
-        root_variational_covar = variational_covar.root_decomposition()
-
-        mean_diffs = prior_mean - variational_mean
-        inv_quad_rhs = torch.cat([root_variational_covar, mean_diffs.unsqueeze(-1)], -1)
-        log_det_variational_covar = variational_covar.log_det()
-        trace_plus_inv_quad_form, log_det_prior_covar = prior_covar.inv_quad_log_det(
-            inv_quad_rhs=inv_quad_rhs, log_det=True
-        )
-
-        # Compute the KL Divergence.
-        res = 0.5 * sum(
-            [
-                log_det_prior_covar,
-                log_det_variational_covar.mul(-1),
-                trace_plus_inv_quad_form,
-                -float(mean_diffs.size(-1)),
-            ]
-        )
-        return res
+        return torch.distributions.kl.kl_divergence(self.variational_dist, self.prior_dist)
 
     def trace_diff(self):
         prior_covar = self.prior_dist.lazy_covariance_matrix

--- a/test/distributions/test_multivariate_normal.py
+++ b/test/distributions/test_multivariate_normal.py
@@ -7,6 +7,7 @@ import random
 import math
 import torch
 from gpytorch.distributions import MultivariateNormal
+from torch.distributions import MultivariateNormal as TMultivariateNormal
 from gpytorch.lazy import LazyTensor, NonLazyTensor, DiagLazyTensor
 from test._utils import approx_equal
 
@@ -208,7 +209,7 @@ class TestMultivariateNormal(unittest.TestCase):
         diffs = values - mean
 
         res = MultivariateNormal(mean, DiagLazyTensor(var)).log_prob(values)
-        actual = -0.5 * (math.log(math.pi * 2) * 4 + var.log().sum() + (diffs / var * diffs).sum())
+        actual = TMultivariateNormal(mean, torch.eye(4) * var).log_prob(values)
         self.assertLess((res - actual).div(res).abs().item(), 1e-2)
 
         mean = torch.randn(3, 4)
@@ -217,7 +218,7 @@ class TestMultivariateNormal(unittest.TestCase):
         diffs = values - mean
 
         res = MultivariateNormal(mean, DiagLazyTensor(var)).log_prob(values)
-        actual = -0.5 * (math.log(math.pi * 2) * 4 + var.log().sum(1) + (diffs / var * diffs).sum(1))
+        actual = TMultivariateNormal(mean, var.unsqueeze(-1) * torch.eye(4).repeat(3, 1, 1)).log_prob(values)
         self.assertLess((res - actual).div(res).abs().norm(), 1e-2)
 
     def test_kl_divergence(self):

--- a/test/distributions/test_multivariate_normal.py
+++ b/test/distributions/test_multivariate_normal.py
@@ -2,13 +2,28 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
+import os
+import random
+import math
 import torch
 from gpytorch.distributions import MultivariateNormal
-from gpytorch.lazy import LazyTensor, NonLazyTensor
+from gpytorch.lazy import LazyTensor, NonLazyTensor, DiagLazyTensor
 from test._utils import approx_equal
 
 
 class TestMultivariateNormal(unittest.TestCase):
+    def setUp(self):
+        if os.getenv("UNLOCK_SEED") is None or os.getenv("UNLOCK_SEED").lower() == "false":
+            self.rng_state = torch.get_rng_state()
+            torch.manual_seed(1)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(1)
+            random.seed(1)
+
+    def tearDown(self):
+        if hasattr(self, "rng_state"):
+            torch.set_rng_state(self.rng_state)
+
     def test_multivariate_normal_non_lazy(self, cuda=False):
         device = torch.device("cuda") if cuda else torch.device("cpu")
         mean = torch.tensor([0, 1, 2], dtype=torch.float, device=device)
@@ -185,6 +200,47 @@ class TestMultivariateNormal(unittest.TestCase):
     def test_multivariate_normal_batch_correlated_sampels_cuda(self):
         if torch.cuda.is_available():
             self.test_multivariate_normal_batch_correlated_sampels(cuda=True)
+
+    def test_log_prob(self):
+        mean = torch.randn(4)
+        var = torch.randn(4).abs_()
+        values = torch.randn(4)
+        diffs = values - mean
+
+        res = MultivariateNormal(mean, DiagLazyTensor(var)).log_prob(values)
+        actual = -0.5 * (math.log(math.pi * 2) * 4 + var.log().sum() + (diffs / var * diffs).sum())
+        self.assertLess((res - actual).div(res).abs().item(), 1e-2)
+
+        mean = torch.randn(3, 4)
+        var = torch.randn(3, 4).abs_()
+        values = torch.randn(3, 4)
+        diffs = values - mean
+
+        res = MultivariateNormal(mean, DiagLazyTensor(var)).log_prob(values)
+        actual = -0.5 * (math.log(math.pi * 2) * 4 + var.log().sum(1) + (diffs / var * diffs).sum(1))
+        self.assertLess((res - actual).div(res).abs().norm(), 1e-2)
+
+    def test_kl_divergence(self):
+        mean0 = torch.randn(4)
+        mean1 = mean0 + 1
+        var0 = torch.randn(4).abs_()
+        var1 = var0 * math.exp(2)
+
+        dist_a = MultivariateNormal(mean0, DiagLazyTensor(var0))
+        dist_b = MultivariateNormal(mean1, DiagLazyTensor(var0))
+        dist_c = MultivariateNormal(mean0, DiagLazyTensor(var1))
+
+        res = torch.distributions.kl.kl_divergence(dist_a, dist_a)
+        actual = 0.
+        self.assertLess((res - actual).abs().item(), 1e-2)
+
+        res = torch.distributions.kl.kl_divergence(dist_b, dist_a)
+        actual = var0.reciprocal().sum().div(2.)
+        self.assertLess((res - actual).div(res).abs().item(), 1e-2)
+
+        res = torch.distributions.kl.kl_divergence(dist_a, dist_c)
+        actual = 0.5 * (8 - 4 + 4 * math.exp(-2))
+        self.assertLess((res - actual).div(res).abs().item(), 1e-2)
 
 
 if __name__ == "__main__":

--- a/test/distributions/test_multivariate_normal.py
+++ b/test/distributions/test_multivariate_normal.py
@@ -206,7 +206,6 @@ class TestMultivariateNormal(unittest.TestCase):
         mean = torch.randn(4)
         var = torch.randn(4).abs_()
         values = torch.randn(4)
-        diffs = values - mean
 
         res = MultivariateNormal(mean, DiagLazyTensor(var)).log_prob(values)
         actual = TMultivariateNormal(mean, torch.eye(4) * var).log_prob(values)
@@ -215,7 +214,6 @@ class TestMultivariateNormal(unittest.TestCase):
         mean = torch.randn(3, 4)
         var = torch.randn(3, 4).abs_()
         values = torch.randn(3, 4)
-        diffs = values - mean
 
         res = MultivariateNormal(mean, DiagLazyTensor(var)).log_prob(values)
         actual = TMultivariateNormal(mean, var.unsqueeze(-1) * torch.eye(4).repeat(3, 1, 1)).log_prob(values)


### PR DESCRIPTION
This moves the fast `log_prob` (previously in `ExactMarginalLogLikelihood`) and `kl_divergence` (previously in `MVNVariationalStrategy`) into `gpytorch.distributions.MultivariateNormal`.