### PR TITLE
Fix bug in MatmulLazyTensor derivative return

### DIFF
--- a/gpytorch/lazy/matmul_lazy_tensor.py
+++ b/gpytorch/lazy/matmul_lazy_tensor.py
@@ -51,9 +51,19 @@ class MatmulLazyTensor(LazyTensor):
             right_vecs = right_vecs.unsqueeze(1)
         right_vecs_times_right_lazy_tensor = self.right_lazy_tensor._matmul(right_vecs)
         left_vecs_times_left_lazy_tensor_t = self.left_lazy_tensor._t_matmul(left_vecs)
-        left_grad, = self.left_lazy_tensor._quad_form_derivative(left_vecs, right_vecs_times_right_lazy_tensor)
-        right_grad, = self.right_lazy_tensor._quad_form_derivative(left_vecs_times_left_lazy_tensor_t, right_vecs)
-        return left_grad, right_grad
+        left_grad = self.left_lazy_tensor._quad_form_derivative(left_vecs, right_vecs_times_right_lazy_tensor)
+        right_grad = self.right_lazy_tensor._quad_form_derivative(left_vecs_times_left_lazy_tensor_t, right_vecs)
+
+        if isinstance(left_grad, tuple) and isinstance(right_grad, tuple):
+            retr_tuple = left_grad + right_grad
+        elif isinstance(left_grad, tuple):
+            retr_tuple = left_grad + (right_grad,)
+        elif isinstance(right_grad, tuple):
+            retr_tuple = (left_grad,) + right_grad
+        else:
+            retr_tuple = (left_grad, right_grad)
+
+        return retr_tuple
 
     def _size(self):
         if self.left_lazy_tensor.ndimension() > 2:

--- a/gpytorch/lazy/matmul_lazy_tensor.py
+++ b/gpytorch/lazy/matmul_lazy_tensor.py
@@ -54,8 +54,8 @@ class MatmulLazyTensor(LazyTensor):
         left_grad = self.left_lazy_tensor._quad_form_derivative(left_vecs, right_vecs_times_right_lazy_tensor)
         right_grad = self.right_lazy_tensor._quad_form_derivative(left_vecs_times_left_lazy_tensor_t, right_vecs)
 
-        left_grad = (left_grad,) if not isinstance(right_grad, tuple)
-        right_grad = (right_grad,) if not isinstance(right_grad, tuple)
+        left_grad = (left_grad,) if not isinstance(left_grad, tuple) else left_grad
+        right_grad = (right_grad,) if not isinstance(right_grad, tuple) else right_grad
         return left_grad + right_grad
 
     def _size(self):

--- a/gpytorch/lazy/matmul_lazy_tensor.py
+++ b/gpytorch/lazy/matmul_lazy_tensor.py
@@ -54,16 +54,9 @@ class MatmulLazyTensor(LazyTensor):
         left_grad = self.left_lazy_tensor._quad_form_derivative(left_vecs, right_vecs_times_right_lazy_tensor)
         right_grad = self.right_lazy_tensor._quad_form_derivative(left_vecs_times_left_lazy_tensor_t, right_vecs)
 
-        if isinstance(left_grad, tuple) and isinstance(right_grad, tuple):
-            retr_tuple = left_grad + right_grad
-        elif isinstance(left_grad, tuple):
-            retr_tuple = left_grad + (right_grad,)
-        elif isinstance(right_grad, tuple):
-            retr_tuple = (left_grad,) + right_grad
-        else:
-            retr_tuple = (left_grad, right_grad)
-
-        return retr_tuple
+        left_grad = (left_grad,) if not isinstance(right_grad, tuple)
+        right_grad = (right_grad,) if not isinstance(right_grad, tuple)
+        return left_grad + right_grad
 
     def _size(self):
         if self.left_lazy_tensor.ndimension() > 2:


### PR DESCRIPTION
On master, `MatmulLazyTensor.quad_form_derivative` fails if the sub lazy tensors return derivatives with mutliple components. This fixes the return value to merge the two derivative components in to a single tuple.

cc @Balandat 