### PR TITLE
Fix batch vs standard prediction inconsistencies

### DIFF
--- a/gpytorch/functions/__init__.py
+++ b/gpytorch/functions/__init__.py
@@ -66,7 +66,9 @@ def dsmm(sparse_mat, dense_mat):
     return DSMM(sparse_mat)(dense_mat)
 
 
-def exact_predictive_mean(full_covar, full_mean, train_labels, num_train, likelihood, precomputed_cache=None):
+def exact_predictive_mean(
+    full_covar, full_mean, train_labels, num_train, likelihood, precomputed_cache=None, non_batch_train=False
+):
     """
     Computes the posterior predictive mean of a GP
 
@@ -88,10 +90,12 @@ def exact_predictive_mean(full_covar, full_mean, train_labels, num_train, likeli
         from ..lazy.non_lazy_tensor import NonLazyTensor
 
         full_covar = NonLazyTensor(full_covar)
-    return full_covar.exact_predictive_mean(full_mean, train_labels, num_train, likelihood, precomputed_cache)
+    return full_covar.exact_predictive_mean(
+        full_mean, train_labels, num_train, likelihood, precomputed_cache, non_batch_train
+    )
 
 
-def exact_predictive_covar(full_covar, num_train, likelihood, precomputed_cache=None):
+def exact_predictive_covar(full_covar, num_train, likelihood, precomputed_cache=None, non_batch_train=False):
     """
     Computes the posterior predictive covariance of a GP
 
@@ -112,7 +116,7 @@ def exact_predictive_covar(full_covar, num_train, likelihood, precomputed_cache=
         from ..lazy.non_lazy_tensor import NonLazyTensor
 
         full_covar = NonLazyTensor(full_covar)
-    return full_covar.exact_predictive_covar(num_train, likelihood, precomputed_cache)
+    return full_covar.exact_predictive_covar(num_train, likelihood, precomputed_cache, non_batch_train)
 
 
 def log_normal_cdf(x):

--- a/gpytorch/lazy/interpolated_lazy_tensor.py
+++ b/gpytorch/lazy/interpolated_lazy_tensor.py
@@ -365,7 +365,9 @@ class InterpolatedLazyTensor(LazyTensor):
                 res = res.view(batch_size, n_data, -1).sum(-1)
             return res
 
-    def exact_predictive_mean(self, full_mean, train_labels, num_train, likelihood, precomputed_cache=None):
+    def exact_predictive_mean(
+        self, full_mean, train_labels, num_train, likelihood, precomputed_cache=None, non_batch_train=False
+    ):
         from ..distributions import MultivariateNormal
 
         if precomputed_cache is None:
@@ -423,7 +425,7 @@ class InterpolatedLazyTensor(LazyTensor):
         res = left_interp(test_interp_indices, test_interp_values, precomputed_cache)
         return res
 
-    def exact_predictive_covar(self, num_train, likelihood, precomputed_cache=None):
+    def exact_predictive_covar(self, num_train, likelihood, precomputed_cache=None, non_batch_train=False):
         from ..distributions import MultivariateNormal
 
         if not beta_features.fast_pred_var.on() and not beta_features.fast_pred_samples.on():

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -15,7 +15,7 @@ def _prod(iterable):
 
 def _matmul(lazy_tensors, rhs):
     res = rhs.contiguous()
-    is_batch = rhs.ndimension() == 3
+    is_batch = res.ndimension() == 3
     num_cols = rhs.size(-1)
     for lazy_tensor in list(lazy_tensors)[::-1]:
         if is_batch:
@@ -30,6 +30,7 @@ def _matmul(lazy_tensors, rhs):
             factor = lazy_tensor._matmul(res)
             factor = factor.view(lazy_tensor.size(-2), -1, num_cols).transpose(-3, -2).contiguous().view(-1, num_cols)
             res = factor.contiguous().view(-1, num_cols)
+
     return res
 
 

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -168,22 +168,26 @@ class LazyEvaluatedKernelTensor(LazyTensor):
     def evaluate(self):
         return self.evaluate_kernel().evaluate()
 
-    def exact_predictive_mean(self, full_mean, train_labels, num_train, likelihood, precomputed_cache=None):
+    def exact_predictive_mean(
+        self, full_mean, train_labels, num_train, likelihood, precomputed_cache=None, non_batch_train=False
+    ):
         if self.kernel.has_custom_exact_predictions:
             return self.evaluate_kernel().exact_predictive_mean(
-                full_mean, train_labels, num_train, likelihood, precomputed_cache
+                full_mean, train_labels, num_train, likelihood, precomputed_cache, non_batch_train
             )
         else:
             return super(LazyEvaluatedKernelTensor, self).exact_predictive_mean(
-                full_mean, train_labels, num_train, likelihood, precomputed_cache
+                full_mean, train_labels, num_train, likelihood, precomputed_cache, non_batch_train
             )
 
-    def exact_predictive_covar(self, num_train, likelihood, precomputed_cache=None):
+    def exact_predictive_covar(self, num_train, likelihood, precomputed_cache=None, non_batch_train=False):
         if self.kernel.has_custom_exact_predictions:
-            return self.evaluate_kernel().exact_predictive_covar(num_train, likelihood, precomputed_cache)
+            return self.evaluate_kernel().exact_predictive_covar(
+                num_train, likelihood, precomputed_cache, non_batch_train
+            )
         else:
             return super(LazyEvaluatedKernelTensor, self).exact_predictive_covar(
-                num_train, likelihood, precomputed_cache
+                num_train, likelihood, precomputed_cache, non_batch_train
             )
 
     def repeat(self, *sizes):

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -442,7 +442,9 @@ class LazyTensor(object):
         """
         return self.representation_tree()(*self.representation())
 
-    def exact_predictive_mean(self, full_mean, train_labels, num_train, likelihood, precomputed_cache=None):
+    def exact_predictive_mean(
+        self, full_mean, train_labels, num_train, likelihood, precomputed_cache=None, non_batch_train=False
+    ):
         """
         Computes the posterior predictive covariance of a GP
         Assumes that self is the block prior covariance matrix of training and testing points
@@ -462,11 +464,17 @@ class LazyTensor(object):
         if precomputed_cache is None:
             train_mean = full_mean.narrow(-1, 0, num_train)
             if self.ndimension() == 3:
-                train_train_covar = self[:, :num_train, :num_train]
+                if non_batch_train:
+                    train_train_covar = self[0, :num_train, :num_train]
+                else:
+                    train_train_covar = self[:, :num_train, :num_train]
             else:
                 train_train_covar = self[:num_train, :num_train]
 
             train_mean = full_mean.narrow(-1, 0, train_train_covar.size(-1))
+            if non_batch_train and train_mean.dim() == 2:
+                train_mean = train_mean[0]
+                train_labels = train_labels[0]
             mvn = likelihood(MultivariateNormal(train_mean, train_train_covar))
             train_mean, train_train_covar = mvn.mean, mvn.lazy_covariance_matrix
 
@@ -480,13 +488,15 @@ class LazyTensor(object):
             test_train_covar = self[:, num_train:, :num_train]
         else:
             test_train_covar = self[num_train:, :num_train]
+
         res = test_train_covar.matmul(precomputed_cache)
         if res.ndimension() == 3:
             res = res.squeeze(-1)
         res = res + test_mean
+
         return res, precomputed_cache.detach()
 
-    def exact_predictive_covar(self, num_train, likelihood, precomputed_cache=None):
+    def exact_predictive_covar(self, num_train, likelihood, precomputed_cache=None, non_batch_train=False):
         """
         Computes the posterior predictive covariance of a GP
         Assumes that self is the block prior covariance matrix of training and testing points
@@ -523,7 +533,10 @@ class LazyTensor(object):
             return res, None
 
         if precomputed_cache is None:
-            train_train_covar_inv_root = train_train_covar.root_inv_decomposition()
+            if non_batch_train and train_train_covar.dim() == 3:
+                train_train_covar_inv_root = train_train_covar[0].root_inv_decomposition()
+            else:
+                train_train_covar_inv_root = train_train_covar.root_inv_decomposition()
             precomputed_cache = self._exact_predictive_covar_inv_quad_form_cache(
                 train_train_covar_inv_root, test_train_covar
             )
@@ -685,17 +698,6 @@ class LazyTensor(object):
                         self.shape, tensor.shape
                     )
                 )
-        elif self.dim() != tensor.dim():
-            raise RuntimeError(
-                "LazyTensor (size={}) and right-hand-side Tensor (size={}) should have the same number "
-                "of dimensions.".format(self.shape, tensor.shape)
-            )
-        elif self.batch_shape != tensor.shape[:-2] or self.shape[-1] != tensor.shape[-2]:
-            raise RuntimeError(
-                "LazyTensor (size={}) cannot be multiplied with right-hand-side Tensor (size={}).".format(
-                    self.shape, tensor.shape
-                )
-            )
 
         func = Matmul(self.representation_tree())
         return func(tensor, *self.representation())

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -90,9 +90,13 @@ class ExactGP(GP):
                     )
 
             # Exact inference
+            non_batch_train = False
             if self.train_inputs is None:
                 full_inputs = args
             else:
+                if all(tin.dim() == 2 for tin in self.train_inputs):
+                    # Train inputs were non-batch
+                    non_batch_train = True
                 # If we're doing batch testing, but did std training, adjust the training inputs
                 for i, (train_input, input) in enumerate(zip(train_inputs, inputs)):
                     if train_input.dim() < input.dim():
@@ -125,6 +129,7 @@ class ExactGP(GP):
                     train_targets = train_targets.unsqueeze(0).expand(train_inputs[0].size(0), *train_targets.size())
 
                 if num_tasks > 1:
+                    non_batch_train = False
                     if train_targets.ndimension() == 2:
                         # Multitask
                         full_mean = full_mean.view(-1)
@@ -152,12 +157,14 @@ class ExactGP(GP):
                 num_train=num_train,
                 likelihood=self.likelihood,
                 precomputed_cache=self.mean_cache,
+                non_batch_train=non_batch_train,
             )
             predictive_covar, covar_cache = exact_predictive_covar(
                 full_covar=full_covar,
                 num_train=num_train,
                 likelihood=self.likelihood,
                 precomputed_cache=self.covar_cache,
+                non_batch_train=non_batch_train,
             )
 
             self.mean_cache = mean_cache


### PR DESCRIPTION
Mostly solves #340, with the one exception that I couldn't get it so that we don't have to replicate the caches for batch multitask. Specifically, batch multitask fails without: https://github.com/cornellius-gp/gpytorch/blob/85c4907cc9a8c49cc440d9c19bf7e788fd00ea1c/gpytorch/models/exact_gp.py#L132

Basically this PR makes two changes:
1. Two of the error checks in LazyTensor.matmul were outright wrong, in the sense that matmul with those sizes works perfectly fine on both standard tensors and lazy tensors. For example this works just fine for both tensors and lazy tensors, despite what the error check said:
    ```python
    mat1 = torch.randn(3, 51, 100)
    mat2 = torch.randn(100)
    res = mat1.matmul(mat2) # Works fine
    ```
2. `exact_predictive_*` now just takes in `non_batch_train` if the train inputs are not batched. This lets us compute the caches without repeating work. The reason I fixed it this way is because I don't think there is a better way to do it without making wasted kernel calls.

**Note:** This PR doesn't implement the batch-batch mode `b' x b x n x d` that Max wanted because that is way way beyond the scope of just fixing a couple bugs here.