### PR TITLE
Fix interpolation boundary with one test point

### DIFF
--- a/gpytorch/utils/interpolation.py
+++ b/gpytorch/utils/interpolation.py
@@ -100,6 +100,9 @@ class Interpolation(object):
             lower_grid_pt_idxs = lower_grid_pt_idxs - interp_points.max()
             lower_grid_pt_idxs.detach_()
 
+            if len(lower_grid_pt_idxs.shape) == 0:
+                lower_grid_pt_idxs = lower_grid_pt_idxs.unsqueeze(0)
+
             scaled_dist = lower_pt_rel_dists.unsqueeze(-1) + interp_points_flip.unsqueeze(-2)
             dim_interp_values = self._cubic_interpolation_kernel(scaled_dist)
 


### PR DESCRIPTION
Fixes #250 . The issue has to do with what I think is strange behavior with calling `torch.nonzero` on scalars:

```python
test_scalar = torch.tensor(1.)
test_vec = torch.tensor([1.])
torch.nonzero(scalar) # Returns an empty tensor that can't be used for indexing
torch.nonzero(test_vec) # Returns torch.tensor([0], dtype=torch.int64)
```

Just trying to work through our back log of issues.