### PR TITLE
Improve GridKernel

### DIFF
--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import torch
 from .kernel import Kernel
 from ..lazy import ToeplitzLazyTensor, KroneckerProductLazyTensor
 from .. import settings

--- a/test/kernels/test_grid_kernel.py
+++ b/test/kernels/test_grid_kernel.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import torch
+import unittest
+from gpytorch.kernels import RBFKernel, GridKernel, GridInterpolationKernel
+
+cv = GridInterpolationKernel(RBFKernel(), grid_size=10, grid_bounds=[(0, 1), (0, 2)])
+grid = cv.grid
+
+grid_size = grid.size(-2)
+grid_dim = grid.size(-1)
+grid_data = torch.zeros(int(pow(grid_size, grid_dim)), grid_dim)
+prev_points = None
+for i in range(grid_dim):
+    for j in range(grid_size):
+        grid_data[j * grid_size ** i : (j + 1) * grid_size ** i, i].fill_(grid[j, i])
+        if prev_points is not None:
+            grid_data[j * grid_size ** i : (j + 1) * grid_size ** i, :i].copy_(prev_points)
+    prev_points = grid_data[: grid_size ** (i + 1), : (i + 1)]
+
+
+class TestGridKernel(unittest.TestCase):
+    def test_grid_grid(self):
+        base_kernel = RBFKernel()
+        kernel = GridKernel(base_kernel, grid)
+        grid_eval = kernel(grid, grid).evaluate()
+        actual_eval = base_kernel(grid_data, grid_data).evaluate()
+        self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
+
+    def test_nongrid_grid(self):
+        base_kernel = RBFKernel()
+        data = torch.randn(5, 2)
+        kernel = GridKernel(base_kernel, grid)
+        grid_eval = kernel(grid, data).evaluate()
+        actual_eval = base_kernel(grid_data, data).evaluate()
+        self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
+
+    def test_nongrid_nongrid(self):
+        base_kernel = RBFKernel()
+        data = torch.randn(5, 2)
+        kernel = GridKernel(base_kernel, grid)
+        grid_eval = kernel(data, data).evaluate()
+        actual_eval = base_kernel(data, data).evaluate()
+        self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
GridKernel and GridInterpolationKernel both constructed the full dimensional grid of points despite clearly not needing them to function. I think this was an artifact from back when variational inference needed to know these things?

Either way, we obviously shouldn't be doing this because it requires O(dm^d) storage to store `inducing_points` compared to O(dm) storage to store `grid`.

Related to #344, this also dramatically simplifies usage of `GridKernel` for data that exactly lies on a grid by requiring a user to only specify the grid in each dimension.