### PR TITLE
GridKernel now functions stand-alone.

### DIFF
--- a/examples/05_Scalable_GP_Regression_Multidimensional/Grid_GP_Regression.ipynb
+++ b/examples/05_Scalable_GP_Regression_Multidimensional/Grid_GP_Regression.ipynb
@@ -1,0 +1,343 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GP Regression with Grid Structured Training Data\n",
+    "\n",
+    "In this notebook, we demonstrate how to perform GP regression when your training data lies on a regularly spaced grid. For this example, we'll be modeling a 2D function where the training data is on an evenly spaced grid on (0,1)x(0, 2) with 100 grid points in each dimension. \n",
+    "\n",
+    "In other words, we have 10000 training examples. However, the grid structure of the training data will allow us to perform inference very quickly anyways."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gpytorch\n",
+    "import torch\n",
+    "import math"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Make the grid and training data\n",
+    "\n",
+    "In the next cell, we create the grid, along with the 10000 training examples and labels. After running this cell, we create three important tensors:\n",
+    "\n",
+    "- `grid` is a tensor that is `grid_size x 2` and contains the 1D grid for each dimension.\n",
+    "- `train_x` is a tensor containing the full 10000 training examples.\n",
+    "- `train_y` are the labels. For this, we're just using a simple sine function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid_bounds = [(0, 1), (0, 2)]\n",
+    "grid_size = 100\n",
+    "grid = torch.zeros(grid_size, len(grid_bounds))\n",
+    "for i in range(len(grid_bounds)):\n",
+    "    grid_diff = float(grid_bounds[i][1] - grid_bounds[i][0]) / (grid_size - 2)\n",
+    "    grid[:, i] = torch.linspace(grid_bounds[i][0] - grid_diff, grid_bounds[i][1] + grid_diff, grid_size)\n",
+    "\n",
+    "# Here we actually construct the full grid. We only do this in the example notebook\n",
+    "# to easily get the training labels. We won't need the full grid constructed ever.\n",
+    "grid_size = grid.size(-2)\n",
+    "grid_dim = grid.size(-1)\n",
+    "grid_data = torch.zeros(int(pow(grid_size, grid_dim)), grid_dim)\n",
+    "prev_points = None\n",
+    "for i in range(grid_dim):\n",
+    "    for j in range(grid_size):\n",
+    "        grid_data[j * grid_size ** i : (j + 1) * grid_size ** i, i].fill_(grid[j, i])\n",
+    "        if prev_points is not None:\n",
+    "            grid_data[j * grid_size ** i : (j + 1) * grid_size ** i, :i].copy_(prev_points)\n",
+    "    prev_points = grid_data[: grid_size ** (i + 1), : (i + 1)]\n",
+    "    \n",
+    "train_y = torch.sin((grid_data[:, 0] + grid_data[:, 1]) * (2 * math.pi)) + torch.randn_like(grid_data[:, 0]).mul(0.01)\n",
+    "train_x = grid_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating the GP Model\n",
+    "\n",
+    "In the next cell we create our GP model. Like other scalable GP methods, we'll use a scalable kernel that wraps a base kernel. In this case, we create a `GridKernel` that wraps an `RBFKernel`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class GridGPRegressionModel(gpytorch.models.ExactGP):\n",
+    "    def __init__(self, grid, train_x, train_y, likelihood):\n",
+    "        super(GridGPRegressionModel, self).__init__(train_x, train_y, likelihood)\n",
+    "        num_dims = train_x.size(-1)\n",
+    "        self.mean_module = gpytorch.means.ConstantMean()\n",
+    "        self.covar_module = gpytorch.kernels.GridKernel(gpytorch.kernels.RBFKernel(), grid=grid)\n",
+    "    \n",
+    "    def forward(self, x):\n",
+    "        mean_x = self.mean_module(x)\n",
+    "        covar_x = self.covar_module(x)\n",
+    "        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)\n",
+    "\n",
+    "likelihood = gpytorch.likelihoods.GaussianLikelihood()\n",
+    "model = GridGPRegressionModel(grid, train_x, train_y, likelihood)\n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jrg365/gpytorch/gpytorch/utils/cholesky.py:14: UserWarning: torch.potrf is deprecated in favour of torch.cholesky and will be removed in the next release. Please use torch.cholesky instead and note that the :attr:`upper` argument in torch.cholesky defaults to ``False``.\n",
+      "  potrf_list = [sub_mat.potrf() for sub_mat in mat.view(-1, *mat.shape[-2:])]\n",
+      "/home/jrg365/gpytorch/gpytorch/lazy/added_diag_lazy_tensor.py:66: UserWarning: torch.potrf is deprecated in favour of torch.cholesky and will be removed in the next release. Please use torch.cholesky instead and note that the :attr:`upper` argument in torch.cholesky defaults to ``False``.\n",
+      "  ld_one = lr_flipped.potrf().diag().log().sum() * 2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iter 1/50 - Loss: 1.150   log_lengthscale: 0.000   log_noise: 0.000\n",
+      "Iter 2/50 - Loss: 1.113   log_lengthscale: -0.100   log_noise: -0.100\n",
+      "Iter 3/50 - Loss: 1.070   log_lengthscale: -0.196   log_noise: -0.200\n",
+      "Iter 4/50 - Loss: 1.019   log_lengthscale: -0.290   log_noise: -0.300\n",
+      "Iter 5/50 - Loss: 0.963   log_lengthscale: -0.385   log_noise: -0.400\n",
+      "Iter 6/50 - Loss: 0.899   log_lengthscale: -0.481   log_noise: -0.500\n",
+      "Iter 7/50 - Loss: 0.819   log_lengthscale: -0.579   log_noise: -0.601\n",
+      "Iter 8/50 - Loss: 0.718   log_lengthscale: -0.676   log_noise: -0.702\n",
+      "Iter 9/50 - Loss: 0.612   log_lengthscale: -0.774   log_noise: -0.804\n",
+      "Iter 10/50 - Loss: 0.520   log_lengthscale: -0.874   log_noise: -0.907\n",
+      "Iter 11/50 - Loss: 0.446   log_lengthscale: -0.972   log_noise: -1.011\n",
+      "Iter 12/50 - Loss: 0.384   log_lengthscale: -1.066   log_noise: -1.115\n",
+      "Iter 13/50 - Loss: 0.327   log_lengthscale: -1.153   log_noise: -1.221\n",
+      "Iter 14/50 - Loss: 0.273   log_lengthscale: -1.232   log_noise: -1.326\n",
+      "Iter 15/50 - Loss: 0.221   log_lengthscale: -1.304   log_noise: -1.433\n",
+      "Iter 16/50 - Loss: 0.171   log_lengthscale: -1.368   log_noise: -1.539\n",
+      "Iter 17/50 - Loss: 0.117   log_lengthscale: -1.426   log_noise: -1.646\n",
+      "Iter 18/50 - Loss: 0.069   log_lengthscale: -1.476   log_noise: -1.753\n",
+      "Iter 19/50 - Loss: 0.015   log_lengthscale: -1.520   log_noise: -1.860\n",
+      "Iter 20/50 - Loss: -0.036   log_lengthscale: -1.558   log_noise: -1.968\n",
+      "Iter 21/50 - Loss: -0.087   log_lengthscale: -1.590   log_noise: -2.075\n",
+      "Iter 22/50 - Loss: -0.138   log_lengthscale: -1.616   log_noise: -2.182\n",
+      "Iter 23/50 - Loss: -0.187   log_lengthscale: -1.636   log_noise: -2.289\n",
+      "Iter 24/50 - Loss: -0.238   log_lengthscale: -1.651   log_noise: -2.396\n",
+      "Iter 25/50 - Loss: -0.291   log_lengthscale: -1.660   log_noise: -2.503\n",
+      "Iter 26/50 - Loss: -0.338   log_lengthscale: -1.663   log_noise: -2.610\n",
+      "Iter 27/50 - Loss: -0.391   log_lengthscale: -1.660   log_noise: -2.717\n",
+      "Iter 28/50 - Loss: -0.442   log_lengthscale: -1.652   log_noise: -2.824\n",
+      "Iter 29/50 - Loss: -0.487   log_lengthscale: -1.637   log_noise: -2.930\n",
+      "Iter 30/50 - Loss: -0.536   log_lengthscale: -1.617   log_noise: -3.037\n",
+      "Iter 31/50 - Loss: -0.591   log_lengthscale: -1.591   log_noise: -3.143\n",
+      "Iter 32/50 - Loss: -0.641   log_lengthscale: -1.559   log_noise: -3.249\n",
+      "Iter 33/50 - Loss: -0.697   log_lengthscale: -1.520   log_noise: -3.354\n",
+      "Iter 34/50 - Loss: -0.750   log_lengthscale: -1.478   log_noise: -3.460\n",
+      "Iter 35/50 - Loss: -0.801   log_lengthscale: -1.430   log_noise: -3.565\n",
+      "Iter 36/50 - Loss: -0.850   log_lengthscale: -1.379   log_noise: -3.670\n",
+      "Iter 37/50 - Loss: -0.900   log_lengthscale: -1.320   log_noise: -3.775\n",
+      "Iter 38/50 - Loss: -0.947   log_lengthscale: -1.259   log_noise: -3.880\n",
+      "Iter 39/50 - Loss: -1.011   log_lengthscale: -1.191   log_noise: -3.984\n",
+      "Iter 40/50 - Loss: -1.060   log_lengthscale: -1.123   log_noise: -4.089\n",
+      "Iter 41/50 - Loss: -1.115   log_lengthscale: -1.056   log_noise: -4.193\n",
+      "Iter 42/50 - Loss: -1.162   log_lengthscale: -0.993   log_noise: -4.298\n",
+      "Iter 43/50 - Loss: -1.201   log_lengthscale: -0.937   log_noise: -4.402\n",
+      "Iter 44/50 - Loss: -1.242   log_lengthscale: -0.892   log_noise: -4.506\n",
+      "Iter 45/50 - Loss: -1.282   log_lengthscale: -0.870   log_noise: -4.611\n",
+      "Iter 46/50 - Loss: -1.335   log_lengthscale: -0.875   log_noise: -4.715\n",
+      "Iter 47/50 - Loss: -1.389   log_lengthscale: -0.901   log_noise: -4.820\n",
+      "Iter 48/50 - Loss: -1.453   log_lengthscale: -0.934   log_noise: -4.924\n",
+      "Iter 49/50 - Loss: -1.506   log_lengthscale: -0.968   log_noise: -5.028\n",
+      "Iter 50/50 - Loss: -1.546   log_lengthscale: -0.998   log_noise: -5.132\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Find optimal model hyperparameters\n",
+    "model.train()\n",
+    "likelihood.train()\n",
+    "\n",
+    "# Use the adam optimizer\n",
+    "optimizer = torch.optim.Adam([\n",
+    "    {'params': model.parameters()},  # Includes GaussianLikelihood parameters\n",
+    "], lr=0.1)\n",
+    "\n",
+    "# \"Loss\" for GPs - the marginal log likelihood\n",
+    "mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, model)\n",
+    "\n",
+    "training_iter = 50\n",
+    "for i in range(training_iter):\n",
+    "    # Zero gradients from previous iteration\n",
+    "    optimizer.zero_grad()\n",
+    "    # Output from model\n",
+    "    output = model(train_x)\n",
+    "    # Calc loss and backprop gradients\n",
+    "    loss = -mll(output, train_y)\n",
+    "    loss.backward()\n",
+    "    print('Iter %d/%d - Loss: %.3f   log_lengthscale: %.3f   log_noise: %.3f' % (\n",
+    "        i + 1, training_iter, loss.item(),\n",
+    "        model.covar_module.base_kernel.log_lengthscale.item(),\n",
+    "        model.likelihood.log_noise.item()\n",
+    "    ))\n",
+    "    optimizer.step()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing the model\n",
+    "\n",
+    "In the next cell, we create a set of 400 test examples and make predictions. Note that unlike other scalable GP methods, testing is more complicated. Because our test data can be different from the training data, in general we may not be able to avoid creating a `num_train x num_test` (e.g., `10000 x 400`) kernel matrix between the training and test data.\n",
+    "\n",
+    "For this reason, if you have large numbers of test points, memory may become a concern. The time complexity should still be reasonable, however, because we will still exploit structure in the train-train covariance matrix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jrg365/gpytorch/gpytorch/utils/cholesky.py:14: UserWarning: torch.potrf is deprecated in favour of torch.cholesky and will be removed in the next release. Please use torch.cholesky instead and note that the :attr:`upper` argument in torch.cholesky defaults to ``False``.\n",
+      "  potrf_list = [sub_mat.potrf() for sub_mat in mat.view(-1, *mat.shape[-2:])]\n",
+      "/home/jrg365/gpytorch/gpytorch/lazy/added_diag_lazy_tensor.py:66: UserWarning: torch.potrf is deprecated in favour of torch.cholesky and will be removed in the next release. Please use torch.cholesky instead and note that the :attr:`upper` argument in torch.cholesky defaults to ``False``.\n",
+      "  ld_one = lr_flipped.potrf().diag().log().sum() * 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.eval()\n",
+    "likelihood.eval()\n",
+    "n = 20\n",
+    "test_x = torch.zeros(int(pow(n, 2)), 2)\n",
+    "for i in range(n):\n",
+    "    for j in range(n):\n",
+    "        test_x[i * n + j][0] = float(i) / (n-1)\n",
+    "        test_x[i * n + j][1] = float(j) / (n-1)\n",
+    "\n",
+    "with torch.no_grad(), gpytorch.fast_pred_var():\n",
+    "    observed_pred = likelihood(model(test_x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQEAAADSCAYAAABKMXXIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJztnXu8XVV177+/88hJzsnjJOQdngqlPhBUCnppNRZFoAjqFQ3Xq2BFpbdcrvej90p9IEW0tLdWvcVqESmIFbUqNV4RiKhViiiBGwEF5CGQkJD3iyTnPfrHmidZ2dlrrn322idn7bPH9/NZn732GnPPOddjjzUfY44hM8NxnNalbaIr4DjOxOJKwHFaHFcCjtPiuBJwnBbHlYDjtDiuBBynxZnUSkDSkZJMUkf4/gNJ5x+Eci+X9NVmyzun3L+S9P4a0n1R0sfC/lJJa+os70lJrw37H5Z0bdjf756OJ5J+IunCsH+2pK+Pd5kTwYQrgXCz90h6TtJ6Sf8kafp4lGVmZ5jZDTXW6bWNLl/SEklDkp5fRXazpL9tdJmNQNI84J3AP4bvmX9uM7vIzD7RyPLN7FNmdmEj86yjDsuBF0t6yUTWYzyYcCUQeIOZTQdeBvwB8NHKBEooS33rwsyeAe4A3pE+LmkOcCaQq6AmiAuAW8xsz0RXZIK5CXjvRFei0ZTqTxX+JD8AXgx7m2OflPTvwG7geZJmSfqypHWSnpF0paT2kL5d0t9K2iTpCeBP0vmnm3fh+3skPSRpp6TfSHqZpBuBw4HvhdbJ/w5pXyHpLknbJP1K0tJUPkdJ+reQzwpgbuQ0b6BCCQDLgF+b2QMhv89JWi1ph6R7Jf1RtYyqvZErmtFtki6V9LikzZK+GRQOkqZK+mo4vk3SPZIWZNT5DODfIueULv96SVdmyC4J1/nQ8P0sSatC+XdlvWUzukBvl/R0uNcfSaXtkvRZSWvD9llJXSn5eyQ9JmmLpOWSFqdkr5P0sKTtkq4GVFHmT6h4piYDpVICkg4jeSP+/9Thd5Bo3xnAUyR/oiHgaOClwGnA6B/7PcBZ4fiJwFsiZZ0LXE7SzJ0JnA1sNrN3AE8TWidm9jeSlgDfB64E5gAfBL4dmskAXwPuJfnzfwKIjTvcDMyV9IcV5/iV1Pd7gBNCWV8D/kXS1EieWVwCvBF4NbAY2Ap8PsjOB2YBhwGHABcBWW/644BH6ih/L2Gc4ALg1Wa2RtLLgOuA94Xy/xFYnv7D5vCHwLHAqcBlkl4Qjn8EeAXJ9TseOInQspT0x8BfAW8FFpE8T18PsrnAt0PaucDjwCkVZT4EHClp5ljOvfSY2YRuwJPAc8A2kpvyD8C0IPsJcEUq7QKgf1Qejp0H/Djs/wi4KCU7DTCgI5XfhWH/NuB/ROr02tT3DwE3VqS5jeSPdDiJUupJyb4GfDVyztcC14T9Y4ABYH4k/Vbg+LB/+WjewFJgTVbdSR7aU1OyRcAg0AH8KXAX8JIa7tEg8Pup7weUm5JdD1yZSvcM8HfAncCsVLovAJ+o+O0jJEqi8jzS53xkuKeHpn73S2BZ2H8cODMlez3wZNj/MvA3Kdn0cG5HkrwM7k7JBKwZfV7Csc5Q9uET/b9p5DbuI6w18kYz+2GGbHVq/wiSG7FO2ttSa0ulWVyR/qlImYeRPDC1cARwrqQ3pI51Aj8OZW41s10V5R4Wye8Gku7GJSStgFvNbMOoUNIHSFo3i0keupnEuxixet8saSR1bJhEmd4Y6vh1Sb3AV4GPmNlglXy2krTE6qGXpCX3NjPbXlG38yX999SxKSTnXAvPpvZ3k/yhCb9P3/enUnkuBu4bFZjZc5I2A0uoeHbMzCSlnyXYdw221VjHpqBU3YEM0sscV5O0BOaaWW/YZprZi4J8Hfv/+Q6P5LsaOGCUvkqZo2lvTJXZa2Y9ZnZVKHO2pJ4ay8XMfgZsBs4B/iuprkDo/3+IpMk628x6ge0c2D8F2AV0p37bDsxLyVcDZ1TUe6qZPWNmg2b2l2b2QuA/kXSj3plR5fuB34udU4StIe9/kpRuXq8GPllRt24zu6nOckZZS6JgRjk8HDtAFu7ZISStlf2eHSVvmUpF/gKSVsWOgnUsFc2gBPZiZuuA24FPS5oZBr6eL+nVIck3gUskHSppNnBpJLtrgQ9KenmYeTha0ugDsh54XirtV4E3SHp9GHycGgblDjWzp4CVwF9KmhL6+m8gn68Af03ypvxe6vgMku7FRqBD0mUkLYFq/BaYKulPJHWS9GfTfeovAp8cPS9J8ySdE/ZfI+m4oDh2kDSLhzPKuYVkXGE/wnVIb9UUFWb2E+DtJK2Sk8PhLwEXSTo5XP+ecB71tjhGuQn4aDjXucBlJPcPkm7auySdEMYePgX8wsyeJBnzeZGkNyuxQbgEWFiR96tJBq4nFU2lBALvJGk2/obkLfMtkr4uJA/WbcCvSJp938nKxMz+BfgkyYOxE/hXkoE4SAaPPhpGrT9oZqtJ3tofJvlzrgb+F/uu338BTga2AB9n/0G+LL5C8pb6hpn1p47fRvKg/ZakKdvH/l2c9DlsB/4biUJ7hqRlkJ4t+BywHLhd0k7g7lBPSB7wb5EogIdIRv+zjJC+ApwpaVrq2BKSgcT0ltWywsxWAO8iGfx7uZmtJBnIvZrkPj5GMnBYlCtJlPL9wAMkz8GVoQ53AB8jGQBcF+q7LMg2AecCV5G00o4B/r0i7/MIthKTCYUBD8eJIulTwAYz++xE12UiCONB7zCzt050XRqNKwHHaXGasTvgOE4DcSXgOC2OKwHHaXFcCThOi1PIYlDS6STTUO3AtcF4Ji3vIpleejnJtMvbwpxslPYZPdZxyOxM+bSpA9Hf93bsziuCmW39UfmUZE1SJnaAPdH+9OcMuO4cyTeR3zbYHZX3DXRG5W19Vaft99IevwS09WeZDexDA0NRuQ3H5TmXEaqbHuwTd8TvEwAd8cd8pDP7Xdi3ZyuDA7vilQi8/jU9tnlL9jW79/7+28zs9FryOpjUrQSCkcnngdeRzE3fI2m5mf0mlezdJCa1R0taRmIc87bcSh0ym4UfuyRTftzvVZ0238ubF9wXlQP8cfcTUfnhHXGXBsM2EpU/PhRfdfujXfkGeMvXHx+VP/S7uIVt96NTovLex+PnMOOJ56JygLbVG6Lykc1bonIbiisJdcbPoT3ysthbh/nxNH2Lsu/1fXf9fW7+o2zaMsRdty7JlE9d/Lt6TL/HnSLdgZOAx8zsCTMbIFmNdU5FmnPYt0b+W8CpWVZljtPsGDCCZW5lpUh3YAn7W7KtYZ812gFpzGxI0nYSW+1NBcp1nFJiGIOW34UqG0WUQLU3eqW6qyVNklB6L8FrS/uc3gLVcpyJo8xv/CyKdAfWsP8qq0PZt1rrgDRhUcYsEvv6AzCza8zsRDM7sX1GT7UkjlNqDBhkJHMrK0WUwD3AMUpca00hWYixvCLNcvZ52XkL8CNzO2VnkmLAsFnmVlbq7g6EPv7FJKve2oHrzOzXkq4AVlrinfXLwI2SHiNpASyrJe8pXUM876j1mfKlh/w2+vs/mBrzJZKwoL1WL1bVWTccn4a8ry/mUwTu3HZMbhmPrpsflXetiU8R9qyNP3jd6+JzhO2bd0blANYfz0NT4qP7bbNyPHXNnhUVD87P9/S1Z2HcM9vuednvwuF7ax/HNozBJuwOFLITMLNbSNaap49dltrvI1me6TiTHjMYbD4dUBr3Yo4zCRDDVcfCy40rAcdpEAYMmisBx2lZDLwl4DitTNISaL41ea4EHKdBGGK4CRfmNl+NHaekjLYEsrY8JF0naYOkBzPkS0OItFVhu6xaurFSypbAjI4+XjXvsUz5yd3ZMoDF7fnzNG05+m/dUHwF3X398Tn8O3fEVwmuejZ7tdle1kyLirsr7TMr6Hm2WhyRfXRuyVly3Zez1hhyl+m2TY+vxhyZE/cw3j8/bj26e2HcVgJg9/z4ve6fnf28jORnn0IMF+sOXE/ifTnmrfpnZnZWkUIqKaUScJxmJDEbrsG/QdbvzX4q6chG1adWvDvgOA3CTAxae+bWIF6pJCr2DyS9KD95Pt4ScJwGkUwRRt+rcyWtTH2/xsyuGUMR9wFHhBiKZ5IEzMm3P8/BlYDjNAhDDFr0L7XJzE6sO/9UDEQzu0XSP0iaG6In1Y0rAcdpIMPjaDEoaSGwPkRMPomkO7+5aL5FfAweRjKKuRAYIWnafK4izVLgu8DvwqHvmNkV9ZbpOGWmhpZAFEk3AUtJug1rSOJadgKY2RdJluP/maQhktiPyxqxNL9IS2AI+ICZ3Rciyd4raUWFo1EYhykNxykjNYwJxH9vdl6O/GqSKcSGUsSfwDqSyK6Y2U5JD5H4FKxUAo7TEiQtgYbNAhw0GjImEOY2Xwr8oor4lZJ+ReJ67INm9uuMPPb6GJy3uJOTex7PLG9xe15cgXxtvG447hL8gYG4d+if7Tw2Kv/F+iOi8t3PxI1oAGasi/cve9bHnVp2bclx+LEnxxgoxxAoqUTcoGl4dvw89yyM/37XwvifaveC/D54/5y4a6+RGdnX0Tprb22PThE2G4WVgKTpJPHe358evQzUPKURpkquATjmuGlN6JrBaXUS92LNZ3pTqMaSOkkUwD+b2Xcq5Wa2w8yeC/u3AJ2SShmAwXGKMtodGGdjoYZTZHZAJD4EHzKzv8tIMy5TGo5TVppxFWGR7sApwDuAByStCsc+DBwO4zul4ThlpOUGBs3sTqoHF0mnGZcpDccpIwaMNOGYgFsMOk6DaNnZAcdxEhKnIq4EGkKnhlnYXjnbuI+8gE6rh/ObZI8OLIzK79p5dFy+4aiofNOaeDzF7rX5D0v3+viZdm2NOw1Rf1xuHfE6WHc8aAfA0Oz4PP/uhfHgI3l2AHsWxIeQBubGQ5sDdM6K20NM68rOo61jLOHDCjsVmRBKqQQcpxnxloDjtDiGGPG4A47TuiRhyLwl4DgtjbcEHKeFaTljIcdx9scQQyOuBBynpRnxWISNwRADkYUYTw7Niv7+8YEFuWWseu7wqHzlhsOi8o05dgDT1sQvbfez+UsourbG/QW098XnyK09/lYa6Y1H1hjs7YrKAXbPi5/nrkXxefM8O4CR+fE5/pmz4n4hAGZMrSGISgbtbbXbCZjBYIGWgKTrgLOADWb24ipyAZ8DzgR2AxeY2X11FxgobNkg6UlJD4SwSCuryCXp/0p6TNL9kl5WtEzHKSOjU4RZWw1cD5wekZ9B4o/jGBIHPF8oXGka1xJ4TcTtcbriJ5NU/OQGles4pcGAoQIWgzVEIDoH+EpYiXu3pF5Ji4Krv7o5GDaOeytuZncDvZIWHYRyHeegM2JtmVsDWAKsTn1fE44VohE1M+B2SfcGP4GVjEvFHadsmIkha8vcCBGIUlu1/0uMan2KCXU5PsopZrZW0nxghaSHzeynKXlNFU87Gl24pPmmWRzHgKGR6Hu1UAQikhdoesT6UBIHvoUo3BIws7XhcwNwM3BSRZKaKm5m15jZiWZ2Yu8cVwJOc1JwYDCP5cA7w2D7K4DtRccDoGBLQFIP0BbiDvQApwGVEYaWAxdL+jrJgGBDKu44ZcNQoYHBGiIQ3UIyPfgYyRThuwpWGSjeHVgA3JxMX9IBfM3MbpV0EdRf8T7rjK73/13/vOjv79+RP+Tw8Kb5UfnOdTOi8mnPFLMDmLYlbgMA0LEnnsba4w/ccG+8jgOz4vLdh+S3yPbk+P3fszB+Dh3z+qLyBbN3RuWHTMuLQQFtOd3mbf3ZPhHG9P62YmsHaohAZMCf111ABoWUgJk9ARxf5fgXU/vjUnHHKRs1jAmUklJaDDpOM+L+BBzHcfdijtPKmMGwdwccp5Xx7oDjtDSGtwQcp7WxpEvQbJRSCewa7uLnO7L9/j+0Pe4v4OkNc3LLGFkf96nfsz6u0adtKGYH0LEr307A2uJNy4GZcX8AAzNzfPrPLbbWH6B/QTy2wfT5u6LyJbO2R+Xzp8XtBDqVv95/60BObITB7Os4luZ9s4YmL6UScJzmxMcEHKflGRlxJeA4LYtPETqO05QDg3WrLUnHBr+Co9sOSe+vSLNU0vZUmsuKV9lxyokhRkbaMreyUndLwMweAU4AkNQOPEPiT6CSn5nZWfWW4zjNRBM2BBrWHTgVeNzMnmpQfo7TfBhYEw4MNqqNsgy4KUP2Skm/kvQDSS9qUHmOU0rMlLmVlcItAUlTgLOBv6givg84wsyek3Qm8K8krser5bPXx2DnvJn8/NkjMsvcsnFmtE6d6+NGNADT18dvyrSNcSOUqdvyAoPUHrQii6HuuLFP3+wcY6B5OQ4/5scbr8MLB6JygHnzdkTlR87aEpUvnBr/fafi13nbYHdUDrBzMG4Ytm1ntjHRWEb7jeacImxES+AM4D4zW18pMLMdZvZc2L8F6JQ0t1omaR+DHbPyb6zjlI7QHcjaakHS6ZIeCcF6Lq0iv0DSxtRg+4VFq92IMYHzyOgKSFoIrDczk3QSidLZ3IAyHaecFBgZDAPsnwdeR+Kg9x5Jy83sNxVJv2FmF9df0v4UdTTaTVLh96WOpf0LvgX4M0lDwB5gWXA35jiTkNrf+BmcBDwW3PYRnPOeA1QqgYZS1MfgbuCQimNp/4JXA1cXKcNxmgaj6ABgtUA91UL2/WdJrwJ+C/xPM1tdJU3NlNeCwXGaEVP2lh+BqJZAPd8DjjSzlwA/BG4oWmU3G3acRhLv7OZFIMoN1GNm6TG1LwF/PcYaHoC3BBynURgwouwtn3uAYyQdFabel5EE79lLRTDfs4GHila7lC2B4YF2tqzuzZRPfTZe7TyHHwDdm+Lzz1O2DUXl7f1xOwBrj9/0wen5l74vJxzb7tzAHzm2CovigT+OmLc1/nvg6JlZEekTFk/dFpXn2QFszbEDyHMYArB+5/SofHBrth2BDY2tj28FzEPMbEjSxcBtQDtwnZn9WtIVwEozWw5cIulsYAjYAlxQf4kJpVQCjtO0FLQMDPY0t1Qcuyy1/xdUN8yrG1cCjtMoDGrwdlY6XAk4TsNQ4ZbAROBKwHEaibcEHKfFaUJ7WFcCjtMoDNSEqwhdCThOI/GWQGNoGxDdq7Or1r0+fqW7N+YH9piyLR40o60/bidgHXE7q6GeKVF5f2++nVaeHcDuRfEOaPvi3VH58+bHF3T+/qwDVocfwOFdcX8BeXYAW4Z6ovKNA/E5/jU7s+1JRtm5KV5G18ZsewyN0U5ATagEarIYlHSdpA2SHkwdmyNphaRHw+fsjN+eH9I8Kun8RlXccUpHcYvBCaFWs+HrgdMrjl0K3GFmxwB3hO/7IWkO8HGSlVAnAR/PUhaOMymwyFZSalICZvZTEhPFNOewbwXTDcAbq/z09cAKM9tiZluBFRyoTBxn0qCR7K2sFBkTWGBm6wDMbJ2k+VXSVFsfvaRaZmkfgx0zvbHgNCklfuNnMd6rCGtZH50cTPsY7I4P5DhOGVGYIszaykoRJbB+dFlj+NxQJU3u+mjHmUw0Y3egiBJYDoyO9p8PfLdKmtuA0yTNDgOCp4VjjjM5acKBwZrGBCTdBCwlcY+0hmTE/yrgm5LeDTwNnBvSnghcZGYXmtkWSZ8gcZYAcIWZxSeWgbZB6FmbfdW6N8bn8Kdsy/eX37Ynngc5/gCGu+Jr/ftn5cQEmJuvf/PiArQv2hOVH70gvtb/uN54o+yoro1ROcDUtri9xbbhuD+AjQMzovKnd86Jyjdtjv8eoHNTPA7F1E3Z97ot5zHZj8m8itDMzssQnVol7UrgwtT364Dr6qqd4zQbJX7jZ1FKi0HHaVYmrcWg4zg1UnBMoIYIRF2SvhHkv5B0ZNEquxJwnEZhxWYHUhGIzgBeCJwn6YUVyd4NbDWzo4HP4N6GHac8iMJThHsjEJnZADAagShN2lL3W8CpkgoZIbgScJxGUqw7UIuF7d40ZjYEbKciCthY8YFBx2kU+VOEcyWtTH2/xsyuSX2vxcK2ZivcWimlEmgbMro3ZU/Q5tkB5NoA1MDwtPjccv/suDzPDmDPgvz7Zgtz4gLMj5tcvGDms1F5nh1Ab3vcHwHAjpG43/91A/H1/k88F3+Jrd0yMypv2xj32wDQFbEDAOjamn0vctwhHMg4RyBKpVkjqQOYxYGL+8aEdwccp4EUHBPIjUDE/pa6bwF+VDTSdylbAo7TlBQ0D64xAtGXgRslPUbSAlhWtNquBByngRQ1G64hAlEfwUS/UbgScJwGMiktBjP8C/4fSQ9Lul/SzZKqjv5IelLSA5JWVYyKOs7kw0iCj2RtJaWWgcHrOdAl2ArgxWb2EuC3xAMkvsbMTsgZFXWcpkcExyIZW1nJVQLV/Aua2e3BUAHgbpKpDMdpeSalEqiBPwV+kCEz4HZJ9wYfgo4zuWnC7kChgUFJHwGGgH/OSHKKma0NTkhXSHo4tCyq5bXX0WhX1yw6n8s2+GkbzLmiOYFBAIa746feNyduhLJ7XjFjoMEFcWccAIvnbY/Kj5kZN/Y5bGrchmRGe9wYqc/iBlGQbwz0+HNzo/Knt8adyg5tihsjTducf69jxkAAU3ZlP09jMhYq+Rs/i7pbAiGQyFnA27OMFcxsbfjcANxMskCiKmlHo1M63dGo05y0jI9BSacDHwLONrOqtqWSeiTNGN0n8S/4YLW0jjNpaEIfg7VMEd4E/Bw4VtKa4FPwamAGSRN/laQvhrSLJY0aOiwA7pT0K+CXwPfN7NZxOQvHKQMF/QlMFLljAhn+Bb+ckXYtcGbYfwI4vlDtHKeJGPUn0Gy4xaDjNJISN/uzcCXgOI3CQCPNpwVcCThOA2nGKcLyKoHh7KuZF/hjJEcO0N8bP/U8pyC7F8YdVfTn2AHMnrszKgc4amZ8nn9x17aovLst7nxl10hXVL5hMO7QA+DRXdXi0O7jia1xpyG7NsWDk3Rtjt/LKXFTCgA6d8f/mfG399j+1T4m4DitjrcEHKeFmcxhyBzHySeZImy+poD7GHScBjJeqwglzZG0QtKj4bPqogtJw8GAb5WkSv+EVXEl4DiNwpIFR1lbQS4F7jCzY4A7wvdq7An+O04ws7NrydiVgOM0kvFbO5COPHQD8MbCOQZcCThOowjGQllbQRaY2TqA8Jk1NztV0kpJd0uqSVGUcmDQJIanZs8Pj0yJ666Bmfl2AnvmxPPoi09/07cwHuBk+vxdUfnhs+Jz/ACLpsYnwfPsAHaPxH0ibB2KL9l+fNe8qBzgsW1xfwFbN0+Pyju3xB/BKTvi5Xfk2ABA/oj9cOx5GmOYv5y+fzQCkaQfAgur/O4jY6jC4cGHx/OAH0l6wMwej/0gVwlIuo7Eb8AGM3txOHY58B5g1KvFh4Or5Mrfng58jsSH+rVmdtUYTsZxmooaFhBFIxCZ2Wsz85bWS1pkZuskLQI2ZOQx6sPjCUk/AV4KRJVAvY5GAT6TGoCopgBqCbPsOJMHy+4KNKA7kI48dD7w3coEkmZL6gr7c4FTgN/kZVyXo9EaqSXMsuNMLsZvYPAq4HWSHgVeF74j6URJ14Y0LwBWBh8ePwauMrNcJVBkTOBiSe8EVgIfMLOtFfJqYZZPzspsPx+DU+N+6xynlBgosualUNZmm4FTqxxfCVwY9u8Cjhtr3vXODnwBeD5wArAO+HSVNGMKoZz2MdjpPgadZqUJ3YvV1RIws/Wj+5K+BPy/KslqCbPsOJOKljEbDqOTo7yJ6g5Eawmz7DiTimYMPlLLFOFNwFKSOc41wMeBpZJOIGnkPAm8L6RdTDIVeGZWmOVaKmXtYnBmdtUGpufM8c/On9vtPyR+V/rnx+08u+fF7QAO643bASzuzl8IP729PyrvG4nHBdg+HPfZv3p33Of/73bMicoBNm6eEZW3b4nXsXN7/F6174mXX8ufa7grXsZwxJxiJN/kZL+6NGNLYNwcjYbvB4RZdpzJzHgNDI4npbQYdJympOQDgFm4EnCchtEQo6CDjisBx2kk1SPylRpXAo7TKMbRWGg8cSXgOI2k+XSAKwHHaSQaaT5Po6VUAtYBfb3ZtgD9OXYAfTk2AACDh8T9AfTMqxpseS9LZsXn+Zfk2AHM6OiLygEGLT5JvXkwbl79bF88bsDTO+J2Ahu3xG0AkkrEYxd07ojbdORdhryBtuF48QCMdMafl4HIadoY/iEy8+6A47Q8PjDoOC2MEY2cVVZcCThOA5G3BBynlTGYjAODGT4GvwEcG5L0AtvM7IQqv30S2AkMA0Mx/2qO0/QYTTkmUJePQTN726h/QeDbwHciv39NSOsKwJn0aNgyt0L5SudK+rWkEUmZ/yVJp0t6RNJjkrIClOxHIR+DkgS8FbiplsIcZ1JjwPBI9laMB4E3Az/NSlCvc9+iwUf+CFhvZo9myA24XdK9wYdgJpLeG4ImrBzaE1+r7zjlxJLuQNZWJGezh8zskZxkdTn3LToweB7xVsApIRDCfGCFpIdDy+IAQhCGawCmLTzM+uZkG3jkOQTJMwQC6JlbzBjo0J6405Deznj+tbAlzxhoT9yYZ3WOMdCWrfH8bUu+Jc6U7TnGQHlOQXJi9I1Mqd8hyChD8fgnDPRmv6Vz/LZU+cGEDgyOybnvKHUrAUkdJM2Tl2elSQVC2CDpZhJNldmccZymxoC4hWPdEYjM7IA4A1UYk3PfUYq0BF4LPGxma6rWRuoB2sxsZ9g/DbiiQHmOU3IMRqJNm7ojENVIXc59c8cEgo/BnwPHSloj6d1BtIyKroCkxZJG3YktAO4MgRB+CXzfzG7NPQ3HaVZGWwJZ2/hTl3Pfen0MYmYXVDm218egmT0BHJ+Xv+NMKsZpTEDSm4C/B+YB35e0ysxe3wjnvm4x6DiNwgyGc0Y6687abgZurnK8sHNfVwKO00ia0GLQlYDjNAxrhFHQQaeUSsA6YGB2tkYdnB1vck2bkzM5DSyatSMqX9wTtxMoagewc2hqbpq1u2dF5c/sjMuL2gFMyQkMAtCRcxnaBuPykZwnMM9pyOCMGhzI5DwvU+ZkezZR5xj+1AZmrgQcp7XxloDjtDA2SZcSO45TOzZOswPjiSsBx2kU5gODjuP4wKDjtC5m5t0Bx2l1rAmL6yLvAAACCUlEQVQDkspKaOEkaSPwVOrQXGDTBFWnFspeP/A61ssRZjavloSSbiU5hyw2mdnpEfmEUEolUImklWX2UVj2+oHX0cmmqHsxx3GaHFcCjtPiNIsSuCY/yYRS9vqB19HJoCnGBBzHGT+apSXgOM44UWolUE80lYONpCclPSBpVYUn2QlD0nWSNkh6MHVsjqQVkh4Nn3F/5BNTx8slPROu5SpJZ8bycBpDaZVAvdFUJoiyhVq7norQccClwB1mdgxwR/g+kVzPgXUE+MxoiLvgKssZZ0qrBKgzmoqTGTruHOCGsH8D8MaDWqkKYuHtnINLmZVAtWgqSyaoLjFqDrU2wSwws3UA4XP+BNcni4sl3R+6CxPaZWkVyqwE6oqmMgGcYmYvI+m2/LmkV010hZqYLwDPB04A1gGfntjqtAZlVgJ1RVM52KRDrZG4hD5pYmuUyXpJiwDC54YJrs8BmNl6Mxu2xFHflyjvtZxUlFkJ1BVN5WAiqUfSjNF9klBrD8Z/NWEsB84P++cDtcS2O6iMKqnAmyjvtZxUlHYpcb3RVA4yC4CbJUFyLb9WhlBrIXTcUpIAmGuAjwNXAd8MYeSeBs6duBpm1nGppBNIun1PAu+bsAq2EG4x6DgtTpm7A47jHARcCThOi+NKwHFaHFcCjtPiuBJwnBbHlYDjtDiuBBynxXEl4Dgtzn8AUApsjW3P58UAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 288x216 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQcAAADSCAYAAABHLwWPAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAHwxJREFUeJztnXm4XFWZ7n9vTkgCYUqIhEHGBmmwkdBGUFFkEgIi0leEABcBcWy5iq3dNHq74YL0xe5GtB9sJWoEkbFR6LREIFeQ4TJI4DIKSAgBQphDMJDxnPPdP9aqsFNnT6d2Jbuq8v2eZz+naq+9hn1Ona/W8O53ycxwHMdpZkTdDXAcpzPx4OA4TioeHBzHScWDg+M4qXhwcBwnFQ8OjuOk4sFhGEjaT9L8biu7oN6DJV1X4rrjJd2UeG+SdmqhvoslfTu+/rCkJxJp8yQdNNwyW2jDWZJ+EV9PlPSYpNFrut5uo6uCg6TfSXq97B9S0vbxQzxyLbTtcUmfSTn/VUmz13T9Ffgn4LzGm6x/ejO7zMwObmfFZna7me3SzjJbaMNLwC3A5+tsRyfSNcFB0vbAhwEDjqi1MelcAnw65fwJMa3jkPQ+YBMzu7vuttTMZcAX6m5Ep9E1wYHwj3c3cDFwYjJB0vqSzpf0jKQ3JN0haX3gtnjJIklvSvpAsksZ867Wu5B0cuxmLpY0V1LZD82lwIckbZcoe1fgPcAVwy27+Rs82R2P7w+X9ICkRZLulPSeRNrpkp6P9Twh6cCMag4Fbi1zc5JOknRHRtqHJD0naf/4/s8lzZK0MNZ/dEa+tKHUJEkPxb/jVZLGJK7/nKQ5sdwZkrZKpH1Q0r0x372SPphI20HSrfH3MQuY0FTnPcCOyb+d033B4bJ4HCJpYiLtX4H3Ah8ExgN/BwwC+8b0Tc1sQzO7q0Q9LwOHAxsDJwMXSPrLokxmNp/QPT2hqc0zzezVKmU3E/NMJ3zbbQZcBMyQNFrSLsCpwPvMbCPgEGBeRlG7A09kpJVtyyGE4PdJM7tF0lhgFnA5sDlwLPDvkt5dssijgSnADoTAelKs5wDgf8f0LYFngCtj2njgeuDfCL+P7wLXS9oslnk5cB8hKJxD05eLmfUDc4A9hnf3vU1XBAdJHwK2A642s/uAp4DjYtoI4DPAV83seTMbMLM7zWx5K3WZ2fVm9pQFbgVuIgxnynAJMTjEdh1PYkhRsewknwMuMrN74v1eAiwH3g8MAKOB3SStZ2bzzOypjHI2BRa3UH+DTwHTgMPM7Pfx3OHAPDP7mZn1m9n9wC+Bo0qW+W9mtsDMFgL/BUyK548HppvZ/fFvewbwgTjc/BjwpJldGuu8Angc+LikbYH3Af9gZsvN7LZYbjOLCb8PJ9IVwYEQ6W9KfANfztvRfwIwhhAwKiPpUEl3x67rIuAwhnZDs/gVsKWk9wP7ARsQvtHaUXaS7YCvxyHFoljWNsBWZjYHOA04C3hZ0pXJ7ncTrwMbtVB/g9MIAfvhprbt3dS244EtSpb5YuL1EmDD+HorQm8BADN7E3gN2Lo5LfJMIu11M3urKa2ZjYBFJdu4TtDxwSHOHRwNfETSi5JeBL4G7CFpD+BVYBnwZynZ0x45fYvwT9tg1Yc2roL8kjBMmWhmmwIzAZVpq5ktAa4hDCdOAK40sxUtlr0kq53Ac8C5ZrZp4tggfmNiZpebWaO3ZcB3Mup4CHhXmXvL4FPAkZJOa2rbrU1t29DMvlShHoAFhPsBIA5fNgOeb06LbBvTXgDGxeuTaauI8007AQ9WbGNP0fHBATiS0FXejdDFnATsCtwOfNrMBgnj7+9K2kpSX5x4HA28Qph72DFR3gPAvpK2lbQJoXvaYBShS/4K0C/pUGC4y3eXAMcAn2T1VYrhlv0AcFy8nynARxJpPwa+KGlvBcZK+pikjSTtIumAeP/LgKWE318aM5vKXdVWSWMSR19G/gXAgcBXJP11PPdr4F2STpC0XjzepzA5W4XLgZMlTYr39k/APWY2L97HuyQdJ2mkpGMIn5dfm9kzwGzgf0kaFYeoH28qey/CUCitR7HO0g3B4UTgZ2b2rJm92DiAC4HjY9T/BvAwcC+wkPBNOSJ+k58L/N/YxX2/mc0CriJ8a95H+DADYGaLga8AVxO63McBM4bZ3tuAN4DnzezeCmV/lfAhbnTLVwmVzGw2Yd7hwljWHOLEHSEAnUfoUb1ImBT8ZloFcT7gDUl7NyU9SggqjePkrEaa2bOEAHG6pM/G+zwYmEoIHi8S/h6VREZm9lvgHwi9rxcIPcWpMe01wlzH1wlDjb8DDk8MQ48D9iZ8Ns4Eft5U/PHAj6q0rxeRm72s20g6GPhrMzuy7rbUgaTNCcu5e5rZsrrb00l4cHAcJ5VuGFY4jlMDHhwcx0nFg4PjOKl4cHAcJ5VKjzLH9ffvA33AT8zsvKb00YRlo/cSlpiOievSufRtONZGjh+fmT5ydH9u/k1GLS2qgk368q9Zv0D2NKJAF7XSsqQFgcU2Kr8CYFH/Brnpby3PL2PE0vzY31cgMO9bln8PAKxYkZtsA4P5+Qt+zxq5Xn75Y/LTAfrH5FcyMCY7rX/hQgbefKuUCO6Q/cfaawuzf2f3PbT8RjObUqasTqDl4BCFMT8APgrMB+6VNMPM/pC47BSCdHUnSVMJ693HFDZq/Hi2+vppmembveu13Pwfe+ejhe0/fOMHctP/YlT+52G08j+UL/S/mZt++7Ktc9MBrnsl/5mse+Zun5s+5rH1c9PHPZH/z7/RE2/kpgPo2QW56QN/+lN+/pH5H8G+LSbmpi/fKT8d4PVd8iUWi/48e8VuwfnfKyy/wasL+7nzhuy/65itnm5FKl8bVYYVewFzzGxulAhfCXyi6ZpP8LZK8BrgQEmlorDjdBsGDGKZR7dRZVixNUFH32A+QYWWeo2Z9Ut6g6CHfxXH6TEMKxxOdhNVgkNaD6A5PJa5JlwofZ5o1dU3blyFZjlOfXRjDyGLKsOK+YTHhBu8k6ClT70mPgOxCUHfPgQzm2Zmk81sct+GY9MucZyOxoCVDGYe3UaV4HAvsHO04BpFeAim+UGiGbztu3AUcLO5XtvpUQwYMMs8uo2WhxVxDuFU4EbCUuZ0M3tU0tnAbDObAfwUuFTSHEKPYWqpRo3uz12RKFqNKFqJgPpXI4pWIqD+1YiilQiofzWiaCUC8lcjIH/16+WCZfMkhrGyh4YVlXQOZjaT8Cx98tw/Jl4vIxiCOE7PYwYreyc2VAsOjuMkEQPlTMO6Ag8OjtMmDFhpHhwcx2nCwHsOjuMMJfQceudZRg8OjtMmDDHQQw86e3BwnDbhPYe1wCajluZqGao+UQn16xiKNAxQv46hSMMA9esYijQMUO0p3gUlHv9/GzHQQ8Ghd+7EcWomyKf7Mo8ySJqisPnwHEl/n5J+gcIGyg9I+mPcUayRNpBIG+6WCkPoyJ6D43QjZmKllQsCaZTxSDGzryWu/x/AnokilprZJNqE9xwcp02EpcwRmUcJynikJDmWsMP5GsGDg+O0CUOstJGZRwnSPFJSJ7ckbQfsANycOD1G0uy4WXPlTYp8WOE4bWQgXyE5QdLsxPtpZjYt8b60/wnhIcZrzFZzl9nWzBZI2hG4WdLDZtby7vNVPCS3IZjHbkHYrHaamX2/6Zr9gP8Eno6nfmVmZ7dap+N0Mo2eQw6vmtnknPQyHikNpgJfXq1+swXx51xJvyPMR6z94AD0A183s/slbQTcJ2lWk8EswO1mdniFehynK2jMOVRglUcK8DwhABzXfJGkXYBxwF2Jc+OAJWa2XNIEYB/gn6s0poqfwwuE3Y4xs8WSHiOMj5qDg+OsE4SeQ+urFSU9UiBMRF7ZZJy0K3CRpEHCXOJ5KV/Uw6Itcw6Stid0Ye5JSf6ApAcJ3aNvmFmq4iTpIbnF1n25QqeqRi1Qv8ipSOAE9YucigROUL/IqUjgBNXMga4u2N8kSdWlzFBGvkdKfH9WSr47gd0rVd5E5eAgaUPgl8BpZtb8absf2M7M3pR0GHAdsHNaOXFiZhrAru8Z3UOWGc66QrCJ650FwEp3Imk9QmC4zMx+1ZxuZn8yszfj65nAenE85Dg9R2NYkXV0G1VWK0TwiHzMzL6bcc0WwEtmZpL2IgSj4n6g43Qp/lRmYB/gBOBhSY1B2zeBbQHM7EcEx+kvSeoHlgJT3X3a6VWqTkh2GlVWK+6gYBtUM7sQuLDVOhynmzBgsIfmHFwh6Thtoh2rFZ2EBwfHaRPB7MWDwxplfeVrGaoatUD9OoYiDQPUr2Mo0jBA/TqGIg0DVDMHWn9YfrG9ZfbSkcHBcboR7zk4jpOKIQZ93wrHcZoJ2+F5z8FxnBR6qefQO7MnjlMz7ZBPlzCYPUnSKwkj2c8m0k6U9GQ8Tqx6P95zcJw2YYj+wTVrMBu5ysxObco7HjgTmEyYG70v5n291fZ4z8Fx2sggyjxKMFyD2SSHALPMbGEMCLOAKS3dRKQjew4jUK6WoaoXA9SvYyjSMED9OoYiDQPUr2Mo0jBANf+PEcPYGNcMVub3HIo8JNMMZvdOKeeTkvYF/gh8zcyey8hb/I+QQzv8HOYBi4EBoL/ZIy8+vfl94DBgCXCSmd1ftV7H6TRKLGUWeUiWMZj9L+CKaAf3ReAS4ICSeYdFu4YV+5vZpIwbP5Rg8LIzwenph22q03E6CgP6bUTmUYJCg1kze83Mlse3PwbeWzbvcFkbcw6fAH5ugbuBTSVtuRbqdZy1zqCNyDxKsMpgVtIogsHsatvaNf3vHAE8Fl/fCBwsaVw0mz04nmuZdsw5GHCTJAMuahpDQfZY6IU21O04HYOZyvYQMvKXMpj9iqQjCO7vC4GTYt6Fks4hBBiAs81sYet3057gsE/cSGNzYJakx83stkR6qbFQ0mB22607cp7UcXIxoH+wWme8yGDWzM4AzsjIOx2YXqkBCSoPKxIbabwMXEtYjklSaixkZtPMbLKZTX7HZr0jQXXWLQZNmUe3UdVgdmzc0AZJYwnjnEeaLpsBfFqB9wNvxD0vHKenMFR1QrKjqNp/nwhcG1YrGQlcbmY3xCWWho/kTMIy5hzCUubJRYWutIFcLUNVLwaoX8dQpGGA+nUMRRoGqF/HUKRhgGr+Hyut2HdjFdZbz1ZUCg5mNhfYI+X8jxKvjaY9/RynF2nHnEMn4TN/jtMm3M/BcZxM3CbOcZwhmMGADyscxxmKDyscx0nB8J6D4zhpWBha9AodGRwW26hcLUNVLwaoX8dQpGGA+nUMRRoGqF/HUKRhgGr+H4ut+O/UwOitCcneuRPHqZ1s6XTZuYgSHpJ/I+kPkh6S9FtJ2yXSBhLekjOa8w6Xjuw5OE63MjjY+oRkSQ/J/wdMNrMlkr4E/DNwTExbamaTWm5AE95zcJw20VjKzDpKUOghaWa3mNmS+PZuwoOMawQPDo7TRsyyjxIM1wfyFOA3ifdjJM2WdLekI4fd+CZaHlZI2gW4KnFqR+Afzex7iWv2A/4TeDqe+pWZnd1qnY7TyRhiML+HUGQwW9oHUtJ/J9jQfyRxetvorbIjcLOkh83sqZLNH0LLwcHMngAmxYb2Ac8T/Byaud3MDm+1HsfpJgo6CEUGs6W8TyQdBHwL+EjCTzLprTJX0u+APYGWg0O7hhUHAk+Z2TNtKs9xug8DG1TmUYIyHpJ7AhcBR0SDpcb5cZJGx9cTgH2A5s1whkW7gsNU4IqMtA9IelDSbyS9u031OU5HYqbMoziv9QMND8nHgKsbHpLRNxLgX4ANgf9oWrLcFZgt6UHgFuC8lJ2yhkU79q0YRXDBTfO1ux/YzszelHQYcB3Boj6tnFUekhtM3DBX6FTVqAXqFzkVCZygfpFTkcAJ6hc5FQmcoJo50KL+8p1ho9pSJpTykDwoI9+dwO6VKm+iHT2HQ4H7zeyl5gQz+5OZvRlfzwTWi12eISQ9JEePG9OGZjnOWqb6sKKjaEdwOJaMIYWkLeKOV0jaK9ZX/HXkON2K5RxdRqVhhaQNCGquLyTOJf0jjwK+JKkfWApMjbZxjtODdGcPIYuqHpJLgM2aziX9Iy8ELqxSh+N0DUapicduwZ+tcJx24sHBcZxUemjQ7MHBcdqFAT7nsGZ5a/moXC1DVaMWqF/HUKRhgPp1DEUaBqhfx1CkYYBq5kBvLR9VWH4SGxzW5R1NRwYHx+lafM7BcZwhGMh7Do7jDEXec3AcJ4Me6jm4E5TjtJOK8ukSBrOjJV0V0++RtH0i7Yx4/glJh1S9FQ8OjtMuDDSozKOIhMHsocBuwLGSdmu67BTgdTPbCbgA+E7MuxvBOuHdwBTg32N5LePBwXHaSbWeQ6HBbHx/SXx9DXBgfLjxE8CVZrbczJ4G5sTyWqYj5xxGLB2Rq2Wo6sUA9esYijQMUL+OoUjDAPXrGIo0DFDN/2PE0uF9fyr/T1LkIZlmMLt3UxmrrjGzfklvEJ5v2prgRp3MWywCyaHUnUuaLullSY8kzo2XNEvSk/HnuIy8J8ZrnpR0YpXGOk5H01BIZh3RQzJxTGsqoYzBbNY1pc1py1I2LF5MGMck+Xvgt2a2M/Db+H41JI0HziREv72AM7OCiOP0BNWGFWUMZlddI2kksAmwsGTeYVEqOJjZbbEBSZJjn0uANJ/8Q4BZZrbQzF4HZjE0yDhOz6DB7KMEhQaz8X2jB34UcHP0SJkBTI2rGTsQ7Bh/X+Veqsw5TDSzFwDM7AVJm6dcU3qTjqSH5MiNvXPhdCkVOvJxDqFhMNsHTG8YzAKzzWwG8FPgUklzCF/YU2PeRyVdTXCc7ge+bGbFDxnlsKYnJEuPg+L4axrA+ltu00MPvjrrCopLmVUoYTC7DPhURt5zgXMrNSBBlaXMlyRtCRB/vpxyTdvHQY7TyVQcVnQUVYJDcuxzImHbu2ZuBA6OG26MAw6O5xynN1nXDGYlXQHsR1innU9YgTgPuFrSKcCzxK6OpMnAF83ss2a2UNI5hIkWgLPNrHlicwh9y/O1DFW9GKB+HUORhgHq1zEUaRigfh1DkYYBqvl/PLc8M2ko6+JTmWZ2bEbSgSnXzgY+m3g/HZjeUuscp9vowh5CFh2pkHScbqVAIdlVeHBwnHbiwcFxnCGsi3MOjuMUIzw4OI6ThQ8rHMcZgg8r1jx9ywZytQxVvRigfh1DkYYB6tcxFGkYoH4dQ5GGAar5f/QtG+bjCT3Uc3AnKMdpI2tKPl3GP0XSJEl3SXpU0kOSjkmkXSzpaUkPxGNSUZ0eHBynXeRJp6v3KAr9U4AlwKfNrOEj+T1JmybS/9bMJsWj0ObLg4PjtJE1+OBVoX+Kmf3RzJ6MrxcQHoZ8R6sVenBwnDYiyz4qspp/CpDmn/J2O6S9gFHAU4nT58bhxgWSCh/uKZyQlDQdOBx42cz+Ip77F+DjwIpY+clmtigl7zxgMTAA9JvZ5KL6HKdrMYo2tck1mJX0f4AtUvJ9azjNiBYKlwInmq3a2vcM4EVCwJgGnA6cnVdOmdWKi4ELgZ8nzs0CzojONd+JFZ+ekX9/M3u1RD2O09WIwh7Cq3lfkGZ2UGbZ0kuStoyua1n+KUjaGLge+J9mtsqNutHrAJZL+hnwjdyWUmJYkeYfaWY3mVl/fHs3wcTFcdZ51uCwotA/JfpOXgv83Mz+oymtYcwkwnzFI835m2nHnMNngN9kpBlwk6T7okek4/Q2gzlHNc4DPirpSeCj8T2SJkv6SbzmaGBf4KSUJcvLJD0MPAxMAL5dVGElEZSkbxHMLC/LuGQfM1sQzWdnSXo89kTSylplMDtGY3OFTlWNWqB+kVORwAnqFzkVCZygfpFTkcAJKpoDrVhRWP4q2tNDSC/a7DUK/FPM7BfALzLyHzDcOlvuOcQNag4Hjo/W2GkNWhB/vkzo7mRuz2Vm0xqbfYwaMabVZjlOrazzHpKSphAmII8wsyUZ14yVtFHjNcE/snCc4zhdTQ95SBYGh+gfeRewi6T50TPyQmAjwlDhAUk/itduJalhqz0RuEPSg4TNNa43sxvWyF04TidgvdVzKBycZ/hH/jTj2gXAYfH1XGCPSq1znC7C/Rwcx8mmC4cPWXhwcJx2YaDB3okOHhwcp424+/QaxgYGc7UMVY1aoH4dQ5GGAerXMRRpGKB+HUORhgGqmQO9/WhCOXzOwXGcdLzn4DjOENxD0nGcNMJSZu90HTw4OE4b6aUJSXeCcpx2YaCB7KMKZQxm43UDiScyZyTO7yDpnpj/qvh4dy4eHBynndRrMAuwNGEie0Ti/HeAC2L+14FTiir04OA47SKKoLKOihQazGYRDV4OAK4ZTv7OnHNQvpahqhcD1K9jKNIwQP06hiINA9SvYyjSMEBF/4/+7KTUsvI/NrkekgWsZjAbPVLSGBPr6AfOM7PrgM2ARQn3tvlAoYilVYPZs4DPAa/Ey75pZjNT8k4Bvg/0AT8xs/OK6nOcbqXEg1e5HpJtMpjdNhos7QjcHN2f0qJjYVemVYNZCOOXf83KJKkP+AHB0mo+cK+kGWb2hxJ1Ok73YdWGD+0wmE0YLM2V9DtgT+CXwKaSRsbewzuBwi5XSwazJdkLmGNmc81sBXAlYdzkOL3LmpuQLGMwO66xH4WkCcA+wB+iU9stwFF5+ZupMiF5atwgY3rGssrWwHOJ97njHEmflzRb0uyVtrxCsxynJgw0YJlHRcoYzO4KzI4GS7cQ5hwaPfXTgb+RNIcwB5HqyZKk1QnJHwLnEOLhOcD5BBfqJGmzaZm/oTgxMw1g4xHje0hK4qxT1Gsweyewe0b+ueR4uKbRUnAws5caryX9GPh1ymXzgW0S70uNcxynm+kl+XSrBrNbJt7+FenGsfcCO0dl1ihgKmHc5Dg9yxrc1GatU2Yp8wpgP8Ia7XzgTGC/uFmGAfOAL8RrtyIsWR4Wt8o7FbiRsJQ53cyKTQwAjVwvV8tQ1YsB6tcxFGkYoH4dQ5GGAerXMRRpGKCa/4dezP8brHbtuuYE1arBbHw/Exiif3CcXqUNE48dQ2cqJB2nG+nS/Smy8ODgOG2jLc9QdAweHBynnaTvDNmVeHBwnHZhPufgOE4WvRMbPDg4TjvRYO84zHZkcLAx6+VqGap6MUD9OoYiDQPUr2Mo0jBA/TqGIg0DVPP/sEXD0Tm05RmKjsGdoBynnZhlHxUo4yEpaf+Ef+QDkpZJOjKmXSzp6UTapKI6PTg4TrswYMCyj2oUekia2S0N/0iCLdwS4KbEJX+b8JcstCLz4OA4bURmmUdFhusheRTwGzNb0mqFHhwcp20YDA5mH9VYzUMSyPKQbDAVuKLp3LnRg+WChilMHq16SF4F7BIv2ZRgXjlkDCNpHrAYGAD68/zzHKfrMYrmFnINZtvkIdl4anp3wkOPDc4AXgRGEXxTTgfOziunJQ9JMzsm0ZDzgbwp6f3N7NUS9ThO11OwWpFrMNsOD8nI0cC1ZrYyUfYL8eVyST8DvpHXUKjoIRn98I9maPfFcdY9DBgYzD6qUeghmeBYmv4nGx4s8X/2SNI9WFaj6pzDh4GXzOzJjHQDbpJ0n6TP5xWU9JBcseKtis1ynDrIWcasPiFZxkMSSdsTHNhubcp/WbSpfxiYAHy7qMKqIqghEaqJfaKH/ubALEmPx57IEJIekhtsvo3lCZ2qGrVA/SKnIoET1C9yKhI4Qf0ipyKBE1QzB+p/pNiUZzXWkEKyjIdkfD+PFCNnMztguHW23HOQNBL4b8BVWdckPPRfBq5lmAaXjtNVGDBo2UeXUWVYcRDwuJnNT0uUNFbSRo3XwMGUGOc4TvdiMDiQfXQZhcEhekjeBewiab6kxu68Q9ZRJW0lqWELNxG4I3ro/x643sxuaF/THafD6LGeQ6sekpjZSSnnVnlIRp/8PSq2z3G6C38q03GcIZjBQPcNH7Lw4OA47cRt4hzHGYq1Q+zUMXRkcBgYk69lqGrUAvXrGIo0DFC/jqFIwwD16xiKNAxQzRxoYExh8W9jYObBwXGcNLzn4DjOEMx8tcJxnHTMVyscxxmC+YSk4zhZ+ISk4zjNmJkPKxzHSce68BmKLGQdqOiS9ArwTOLUBKCTreY6vX3gbWyV7czsHWUulHQD4R6yeNXMprSnWWuejgwOzUia3cnmtJ3ePvA2OsPHrekdx0nFg4PjOKl0S3CYVnxJrXR6+8Db6AyTrphzcBxn7dMtPQfHcdYyHR0cJE2R9ISkOZKG7CrcCUiaJ+nhuK357OIcax5J0yW9LOmRxLnCLdw7oI1nSXo+sU38YXW2cV2nY4ODpD7gB8ChwG7AsZJ2q7dVmewftzXvlGW4i4Hm9fTCLdzXMhcztI0AFyS2iZ+Zku6sJTo2OBD2uJhjZnPNbAVwJWEbcqeAjC0Mh7uF+xolb5tFpzPo5OCwNfBc4v18Unby6QBKb/lXM8Pdwr0uTo3bxE+ve+izrtPJwSHNp60Tl1b2MbO/JAx/vixp37ob1MX8EPgzYBLwAnB+vc1Zt+nk4DCfsCFog3cC+YaFNdBFW/69lNhpuWgL91ows5fMbMCCEeOP6dzf5TpBJweHe4GdJe0gaRRhh60ZNbdpNbpsy7/hbOFeC43gFfkrOvd3uU7QsY9sm1m/pFOBG4E+YLqZFdtKr10mAtdKgvC7vLwTtvyLWxjuB0yQNB84k7Bl+9VxO8NngU/V18LMNu4naRJh+DgP+EJtDXRcIek4TjqdPKxwHKdGPDg4jpOKBwfHcVLx4OA4TioeHBzHScWDg+M4qXhwcBwnFQ8OjuOk8v8BpqiqHhk75/gAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 288x216 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPkAAADSCAYAAACIJGZlAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJztnX24XVV95z/fc+69ebshLwQCxEAcQYaXqbGi6INaUKtIHbQzvoA6wohVp6Kjth219VGqM0/tWEvtgwVDy0RaAakDNVpEUq2jqFgBURFQUEMIgYSQF5LcJPeec37zx973unNy9lo7d++b85Lf53n2c8/Za+211973/PZae631+/5kZjiOM7jUul0Bx3FmFjdyxxlw3MgdZ8BxI3ecAceN3HEGHDdyxxlwDisjl7Ra0v+suMyLJd1eZZmHG5LmSPqypB2S/rHb9Rk0BtLIJX1T0jZJs7pdlyxlHwjp8U1Ju9q246qsZ4F6nCbptvQeb5d0l6TzShT5WmApcKSZva6iajopA2fkklYALwIMOL+rlZkZvmdmo23bxvZMkoaK7Ishqd5h95eBtSSGeTTwHuCpgy07U/4JwM/NrDGdMpwwA2fkwFuAO4DVwEUd0pdIWitpp6T/J+kEACVcLmlz2m38saTT07QFkq6V9ISkhyV9WNIB907SCkmWNaa0V/E2SacAVwEvSFvf7Wn6LEl/IWm9pE2SrpI0ZzoXLmmdpA9I+jGwW9JQzr5T0nptl/RTSednylgt6UpJt0jaDZzTdo4lwNOBq81sPN2+Y2a3p+kH9FbSe3JiTvnfAj4CvCG9L5dIeoakb0h6UtIWSZ+XtDBT3nJJN6X/jyclXZFJe6uk+9Nextcm/7+HNWY2UBvwEPD7wHOACWBpJm01sBN4MTAL+DRwe5r2CuAuYCEg4BTg2DTtWuBLwHxgBfBz4JI07eJMGStIehBDmXN+E3hbe95M+l8Ba4DFaflfBv4s59oOOL4tfR1wD7AcmNNpHzCc3qM/BkaAl6T35OTMPdoBnEXSCMxuO4eAB4GvAK/J3t/ANRpwYl75wGXAP2Tynwj8dvo/OorkQfBXaVod+BFwOTAvPf6Fadpr0ms7BRgCPgx8t9u/yW5vXa9ApRcDL0wNe0n6/QHgfZn01cANme+jQDM1gJekxvt8oJbJUwf2Aadm9r0D+Gb6edpGnhrMbuAZmX0vAH6Vc30XAw1ge2b7RSZ9HfDWtmP220fyKvN42zVeD1yWuUfXRu7z04ArgF8ArdQIT+p0jem+diO/ti19PyPvcL7XAD/M3J8nsvc4k++rpA/f9HsNGANO6PZvs5vboHXXLwJuM7Mt6ffrOLDL/sjkBzPbBWwFjjOzb5D8cD8DbJK0StIRwBKSFu/hTBkPA8sqqO9RwFzgrrTrvB24Nd2fxx1mtjCzPaMt/ZEOx2T3HQc8YmatzL726+lUxhRmtsHMLk3PfQLJg+ra0DEF6jiFpKMl3SDpUUlPAf9A8n+A5IH8sHV+fz8B+HTmXm4leZBW8b/qWwbGyNP32NcDvyXpcUmPA+8DniXpWZmsyzPHjJJ0kzcCmNlfm9lzgNOAZwJ/BGwh6R1k3+2OBx7tUI3d6d+5mX3HZD63u/xtAfYAp2WMdoGZjRa55hw6uRVm920ElreNKbRfT2HXRDN7hOTBeHq6azeZ65d0TKfDIsX+WZrnN8zsCODNJMYKyQPi+JxBxEeAd7Q9BOeY2XeLXs8gMjBGTtKlawKnAivT7RTg2ySDcZOcJ+mFkkaAjwPfN7NHJD1X0pmShkl+qHuBppk1gRuB/yVpfjqQ836S1mU/zOwJEmN5s6S6pLcC2ZZ2E/C09NykrenVwOWSjgaQtEzSK6q6KR34Psn1/Q9Jw5LOBv4jcEORgyUtkvSnkk6UVEsH4t5KMtgJyfvyaZJWSpp83z5Y5gO7gO2SlpE8bCf5N+Ax4BOS5kmaLemsNO0q4EOSTkvrukDSYT8lN0hGfhHwf8xsvZk9PrmRdMHflHnyXwd8lKQr9xzgTen+I0gMbhtJ9/VJ4C/StHeTGMYvgdvTMq7JqcfvkfwonyTpEWRbkW8APwUelzT5SvEBksGiO9Ku6b8AJweuc3J0Prs9N3RjspjZOMnU4itJehJ/A7zFzB4oWMQ4ydjDv5BMm91LMmZxcVr+z4GPpekPktyvg+VPgd8kGaD7Z+CmTP2bJA+lE4H1wAbgDWnazcCfAzek9/Le9DoPa5QOUDiOM6AMUkvuOE4H3MgdZ8BxI3ecAceN3HEGHDdyxxlwDtorKYukc0nWf9eBvzWzT7SlzyJZCfUckimlN5jZuli59XnzbGjx4tz02XPHg8cfObIrdgrmK1xGTQqmj0cmJZ5qzQ6mbxufG0wHmNg7HEyv7w0fP7SnFUzX2L5IAZ0c0PbHRsI/odZIuB1pRX6BsXQr8AvWUPg+DNebuWl7N+1gYsee8I8h5RXnzLMnt+aXddeP933NzM4tUlaVTNvIlbgIfobEkWAD8ANJa8zsvky2S4BtZnaipAtI5jDfEK3U4sUse+/7ctOfecbDuWkAFy/7TrT+L5rdacHar5lfC9+ahxthK1+7+5Rg+k0bnh1MB9jws6OD6QvvCxvQkp/sCabX73kwmF5bvCiYDjC+IrQCF3YvC7v0jx0VvoZ9R4bPv29JvlFNMnRk+Gl43JE7ctN++Pt/Hy1/ki1bG3z31vwVtLOP+9WS3MQZpEx3/XnAQ2b2y3SBxQ3Aq9vyvBr4XPr5i8BLpUgT6Th9igEtLHfrFmW668vY39FgA3BmXh4za0jaARxJstLKcQYKw5iweM/iUFPGyDu1yO2PqyJ5kozS24G3A9QXxbuJjtOLdLPFzqNMd30DGY8uEh/jdhmiqTzp2vEFJGvGD8DMVpnZGWZ2Rn3evBLVcpzuYMAErdytW5Qx8h8AJ0l6eupVdQGJwkmWNfzan/u1wDfMF8s7A4oBTbPcrVtMu7uevmNfCnyNZArtGjP7qaSPAXea2Rrg74C/l/QQSQt+QZGyNdJieEX+NNi/G30yePy8WmRqCNhp4fG/7Y3wk/fBifDI90NjS4PpT+6KT6ENjYWfwUPhwXNq+yK6iM3I+2OBH6aa4ftU3xcuY2gsnN6cHf4/NWfH26mJkZFg+pZZ+T3HRqt4O2gYEz3YXS81T25mtwC3tO37SObzXuCw9+d1Dg/MYKL3bLyckTuOk0U0O441dxc3csepCAMmIq+B3cCN3HEqwsBbcscZZJKWvPd8vnqvRo7TpxiiSS13K4KkcyX9TNJDkj7YIf14Sf8q6YdKovxEY9B5S+44FVG2JS/o9PVh4EYzu1LSqSSzWytC5fakkY8MNTh+8bbc9KNGdgaPnyjgf/hEMxxubHcr7D21bjzsULRxzxHB9L17wnO3ACMRD8f6eMSVdCI8D26ROe4i1CZi8+QRN8/INbYiXsNWj78DW+Rnvtvy1yy0GgdjtKJZrrs+5fQFIGnS6Str5EaiLAzJCtIDgl2205NG7jj9SLKsNeiDv0TSnZnvq8xsVeZ7Eaevy4DbJL2bJBbcy2L1ciN3nIowExMWNPItZnZGIL2IQ9eFwGoz+5SkF5CsKD29LezVfriRO05FJFNopbrrRZy+LgHOBTCz76VRapYAm/MK9dF1x6kIQ0zYUO5WgCJOX+uBlwIoiXk/myTKay7ekjtOhTRLrHgr6PT1B8DVkt5H0nm4OObZWUbjbTmJSOMxJDGqV5nZp9vynA18CfhVuusmM/vYdM/pOL3MZEteqoy409d9wFntx4UoU6MG8Admdrek+SQxtte2zekBfNvMXlXiPI7TF1TwTj4jlPEnf4wkhCxmtlPS/SRTAO1G7jiHBUlLHpexPtRU8k4uaQXwbJLY1+28QNKPSEYJ/9DMfppTxpTG29yloyyaPZZ7vtiN3NwIL0QB2NsKa5pvb4ZFHdbtDS+G2Tw2P5je2hO/9bWwNDz1mPNyM5KeP+uS0IiIThBfcDM0FlmQE1vMEllcUpsIHw5QGw+fI6Rvr4ni79gFptC6QmkjlzQK/F/gvWb2VFvy3cAJZrYrXWP7T8BJncpJFwWsAlh8ylE96HrvOGES+afe666XqpGkYRID/7yZ3dSebmZPmdmu9PMtwLCkrgjMO85MM9ldz9u6RZnRdZFouN1vZn+Zk+cYYJOZmaTnkTxUwgJtjtPHDNTAG8kw/n8BfiLpnnTfHwPHA5jZVSQKrf9NUgPYA1zgaq3OoDJwA29mdjud19pm81wBXDHdczhOP2FAqwffyX3Fm+NURK+OrvfeY8dx+pRENKLcwFsBZZjLJd2Tbj+XtD1WZk+25C0TY418UYXH9i4IHr8vFtQamFULzwE/1QjHF1+/Oz9+OsD2sbAohfbGn6+xOWCV1HxQJOiA7Y0EQAe0O5xnKBLENiY6MTQWNo5CwRV2hPOMj+an1+NxOjKUE40oogxjZu/L5H83yfqUIN6SO05FVNCSFwkHnuVC4PpYoW7kjlMRhmhZ/laATsowyzpllHQC8HTgG7FCe7K77jj9SBImqZT8U+FQ3yS+5l80iwdEdyN3nAqJtNgx+aciyjCTXAC8q0id3MgdpyIqWAwzpQwDPEpiyG9szyTpZGAR8L0ihbqRO05FGKLRmr6RF1SGgWTA7Yaiq0fdyB2nQlolY6HFlGHS75cdTJk9aeTjzTobduTPhT85Evb1Hh2OOGIDw/XweMW+ZvjWbI3Mg4/tCgdnqO8pP08ew4bDrUptbvgamk9ujZ6jXg+fo743/L+oD4fv81AknaF4y9maHS6jOTd/vUAsOEQWM5go0ZLPFFX4k68DdgJNoNE+sJB6q30aOA8YIxGeu7vseR2n15icQus1qmrJzzGzLTlpryQRijiJJBrElRwYFcJx+h4DGoepg8qrgWvTQYI7JC2UdGyqEec4A0UveqFVUSMjic10V6rT1k7hVTyO08+YiYbVcrduUUVLfpaZbZR0NLBW0gNm9q1MeqFVPFkhx+Gj4kKMjtNrGNBoDWBLbmYb07+bgZtJFtlnKbSKx8xWmdkZZnbG0ILw6Lnj9Col167PCGWFHOelgRWQNA94OXBvW7Y1wFuU8Hxgh7+PO4OIMZjd9aXAzcksGUPAdWZ2q6R3wpTO2y0k02cPkUyh/ddYoc2JOts25XfZtw1FAt+PxOc2a5F5ciJP3sa+yK3bGZn/HYs/2SMu77Eq0poTrkNtYfi1qN6M38fWjnYV7v2x2Fx7LTyvrFrkIhU3Ho2ENfaH5+RrBygyz78fFl273hVKGbmZ/RJ4Vof9V2U+GwUX0jtOPzOw7+SO4yRU4E8elX9K87xe0n2SfirpuliZPbms1XH6lZmWf5J0EvAhklmtbemsVhA3csepCDNoluuuT8k/AUialH/KBhH9PeAzZrYtOadtjhXq3XXHqYxod32JpDszW/visSILx54JPFPSdyTdIencWK28JXecijCiLXlMGabIwrEhEj+Qs0nWnHxb0ulmlivN7C2541SFJV32vK0ARRaObQC+ZGYTZvYr4GfkRAqepCdbco2L2Rvy5zZbQ+E71grLiQPQHI7c9chgaK0RzlCPSJbX94TTk3OE6xiL7d0YDc8PqzEaTK9H5pcB6ovCGvg0I+sRWiVD4xWxnkgdbG9AXP0gqldB6OIi8k//RKIMszqNEPxM4JehQnvSyB2nPym3fLWg/NPXgJdLuo9Ew+GPzCwYKdiN3HEqpNWaWfmndHHZ+9OtEG7kjlMRFUyhzQhu5I5TIQUH2A4p037sSDo5E13xHklPSXpvW56zJe3I5PlIXnmO0+8YotWq5W7dYtotuZn9DFgJU8vxHiXxJ2/n22b2qumex3H6iR5syCvrrr8U+IWZPVxReY7TfxhYyYG3maCqPsQF5IdQfYGkH0n6qqTTKjqf4/QkZsrdukUVuusjwPkknjHt3A2cYGa7JJ1HMpHfcXXOfhpvo4uYtyG/49OKrNFozorf0NZIOE80pFWkXxYTfCgS3F6RMlqR/97EvPBFtOr5YgkA9dH4qqJaTFgipjtxCEaq1Ayfozaef6PtvviCoKm8lJ9CmwmqaMlfCdxtZpvaE8zsKTPblX6+BRhOV+kcwH4ab7PnVVAtxznEpN31vK1bVGHkF5LTVZd0TBpBBUnPS88XXJ3jOH2NBbYuUVbIcS6Jg/tNmX3vnNR4A14L3CvpR8BfAxcUjcToOP1HfitetCWPKcNIuljSE5lp6bfFyiyr8TYGHNm2L6vvdgVwRZlzOE7fYJQaYCuiDJPyBTO7tGi5vbcGz3H6GVP+FmdKGcbMxoFJZZhSuJE7TpWE38mrUIYB+M+Sfizpi5KWd0jfD1+77jhVYUD43bsKZZgvA9eb2b507OtzwEtCJ+1JI69PGKOP5c9dNmeFOyBF5smbw+XmyUsHxCgw/KjYFHRENGIiEm2qMTu2GCCWDio7jBrT7oiVX2ActxbRrajvy7/R9uDB/aMtHo8iRFQZps13/Grgz2OFenfdcaqk3Dv5lDJMusjsApIwY1NIOjbz9Xzg/lihPdmSO05fYvHeV/DwYsow75F0PtAAtgIXx8p1I3ecyijcYudSQBnmQ3ReQp6LG7njVEm5d/IZwY3ccaqkB9dzupE7TlUYqAe90NzIHadKvCUvhhrGyPb84O+tWRE/6eH4zGBrKDJPXoukR+5c7PjY+ZM84fTYXH8z4jMf88uPBW+AAusFYkXE5skj77gxX3Eo4Ns/nn8RRf5P+9WnB4280Dy5pGskbZZ0b2bfYklrJT2Y/l2Uc+xFaZ4HJV1UVcUdp+eYXPGWt3WJoothVgPt0RM/CHzdzE4Cvp5+3w9Ji4GPAmeSLL7/aN7DwHEGgn71Jzezb5FMvGd5Ncm6WdK/r+lw6CuAtWa2NY2nvJYDHxaOMzColb91izLv5EvN7DEAM3tM0tEd8hT1qtlP4232rEgQPcfpVfr1nbwERbxqkp0ZjbfhIdd4c/oPpVNoeVuhMiLKMJl8r5VkkkJebUA5I980uVg+/bu5Q54i8ZYdZ2Ao013PKMO8EjgVuFDSqR3yzQfeA3y/SJ3KGPkaYHK0/CLgSx3yTIZZXZQOuL083ec4g0m5gbeiyjAfB/43sLdIoYXeySVdD5xNomyxgWTE/BPAjZIuAdYDr0vzngG808zeZmZbJX2cxIUO4GNm1j6A1/mcjfxHX03hro8m4o/NuKd0hEgdYnP1zdnx52tjbqSM2Dx5xK++OSd8/uascDrE59qj8+SxwyO+4GrET1CbCKfX85dkxPX398tceoCt0xjWmdkMkp4NLDezr0j6wyKFFjJyM7swJ+mlHfLeCbwt8/0a4Joi53GcvifcYi+RdGfm+yozW5X5HhzDklQDLqeAe2mWnlzx5jj9SmTFW0z+KTaGNR84HfhmGs7gGGCNpPPTxrUjrgzjOFVS7p08qAxjZjvMbImZrTCzFcAdQNDAwY3ccarDyo2um1kDmFSGuR+4cVIZJlWDmRbeXXecihDlV7bFlGHa9p9dpEw3csepkh5c8eZG7jhVUX4KbUboTSMXtOZMv2pqFPAxHg9PwGoiMkEb0fu2kXD9FZ1ghlZkHjzmuxw7RSMyT94Yjd/H5kjkPgxFyogIH8bmyWvjFcyT78svo3WwCyq8JXecwcZbcscZZLrsN56HG7njVIi35I4z4PSlxluOvtsnJT2Qhk+9WdLCnGPXSfqJpHva1uw6zuBhJMEV8rYuUWTF22oOlGxaC5xuZr8B/Jxw2JZzzGxlZM2u4/Q9IhWOyNm6RdTIO+m7mdlt6RI8SNbPPm0G6uY4fUdfGnkB3gp8NSfNgNsk3ZVquDnOYFOyux6Tf5L0zswr8O2dlGPaKTXwJulPSEKofj4ny1lmtjEVeVwr6YG0Z9CprCkhx1lzFrJvYf5Kjtp4+LE4PBZR0wcYC9917QkoCQA0I4tpxsO3tkDcAmpzyklbxAJANOeE72NjNP7LtDnh+1AbiaxmidBqhNuh1r74PdK+WBn5aQctGlGixc7IP/02idvpDyStMbP7MtmuM7Or0vznA39JRAF52i15GijhVcCbzDov/zKzjenfzcDNJPI2HckKOQ7NciFHpz8pKckclX8ys6cyX+dRYGZ+WkYu6VzgAyS+rGM5eealgnNImkei73Zvp7yOMzCE/cmXSLozs7W/whaSMJf0Lkm/INF5e0+sStHueo6+24eAWSRdcIA7zOydko4D/tbMzgOWAjen6UMk3YxbY+dznL4l7qASU4YpJGFuZp8BPiPpjcCH+bWgakeiRp6j7/Z3OXk3Aueln38JPCtWvuMMChX4kx+shPkNwJWxQl0ZxnGqZAblnwAknZT5+jvAg7FCfVmr41SFgVrTH143s4akSfmnOnDNpPwTcKeZrQEulfQyYALYRqSrDm7kjlMpZRe9xOSfzOy/H2yZPWnkVhd7F+VPUA7vDr/4hILKT+WJpGsiMtc+HlEiaIbrWJsVF42I/WAscpnNkXB6Y27kBPMj1wjMHQ1MMgOzR8Jl1CLrBcYb4f/U3n3x+zixN/wzb+wJpNcOzmrdC81xBp0e9EJzI3ecqnCNN8cZbJIptN5ryt3IHadCelE0wo3ccarC4uqy3cCN3HGqxFtyxxlgSi6GmSl60sitDuNH5E+gqhnxDx6KO2urFRkGjfiL04jMo9fLrxguOw8e8xdvjYavcf6CPeETAMfO3xlMXzS7o5PiFEOR4eixRngefOveuFvy1rFwFImxodn5ifWDnCfvPRuftpDjZZIeTdUp7pF0Xs6xQZULxxkkJh1USviTF1GGeb+k+1IR1a9LOiFW5nSFHAEuTwUaV6ZL8dorM6ly8UrgVODCIlI1jtO3mKFW/hajoM38EDgjFVH9IolPeZBpCTkWJKpy4TgDRzkvtCLKMP+aEWopJKJa5sXx0rTLcI2kRR3SC6lcTCLp7ZOKGY09u0tUy3G6hIGalrsV4KBsBriEfBHVKaZr5FcCzwBWAo8Bn+qQp5DKxVRCVuNtjmu8OX1KOfmnwjYj6c3AGcAnY1Wa1ui6mW3KnOxq4Csdsh2syoXj9D2Rd++Y/FMhm0n9yf8E+C0zC7sBMn0hx2MzX3+XzgKNUZULxxk0SgZXKKIM82zgsyQiqpuLFDpdIcezJa0k6UqsA96R5p0ScsxTuShSKRO04m7CudQaBUYyG5E5jUZ4DjlHhfrX5dcic/mz452oxtxwGROj4fUAE0eEr3H2wr3B9OMXbg+mA5w8f1Mw/ZhZO4Lp9ciI1I5meI5746yOYfj2Y32905DRr3kskFY7CH9yHRplmE8Co8A/piKp683s/FC5MybkmH4/QOXCcQaZggNsuRRQhnnZwZbZkyveHKcvKT5VdkhxI3ecyii26OVQ40buOFUSGavpBm7kjlMVVv6dfCZwI3ecKuk9G3cjd5wqibowd4GeNHIZ1ALhwYf3RHTX9xSIT76vZPzx4fBEfmteeH53fEHEGRzYuyg8T75vcaTZODK8GOr4xduC6SsXbgiXD5w+J5znmKHwPHkt4oP5ROOIYPpoPTzXD9CIOObvmsj/X9RrxY1WVniN+iGlJ43ccfoWH3hznAHGgB5syT2qqeNUiMxyt0LHx5VhXizpbkkNSa8tUqYbueNUhkGrlb9FKKgMsx64GLiuaK2KOKhcA7wK2Gxmp6f7vgCcnGZZCGw3s5Udjl0H7ASaQCPiZuc4/Y1R9p18ShkGQNKkMsx9U6cwW5emFR4RLPJOvhq4Arg2c6I3TH6W9CkgNIR6jpltKVohx+lnSo6ud1KGObNUhSjmhfYtSSs6pSnxdXs98JKyFXGcvseIhaxeIunOzPdVZrYq8/2g1JSKUnZ0/UXAJjN7MCfdgNskGfDZtgvaj1QK5+0Aw/PD/r+O05tYrLteiTLMwVLWyC8Erg+kn2VmGyUdDayV9ECq/noA6QNgFcC8I5fbnC35T8Q5T4QXsgw9GReC1J6Iak69Hky2yGKXiSVzg+ljS+OqGGPHhEUhxo8J34flR4dFH56zeH0w/XnzfhFMB/j3I08E0xdHhnYnIu+wRyj8f9pr8fv4+PCCYPrc4XzhidrBRksot+JtShkGeJREGeaNZQqEEqPrkoaA/wR8IS9PKiJBKlNzM8nAguMMJga0LH+LHW7WACaVYe4HbpxUhpF0PoCk56YKTa8DPispqrZUpiV/GfCAmXVc1yhpHlAzs53p55cDHytxPsfpcQxa5cKaFlCG+QEFtNazFAmTdD3wPeBkSRskXZImXUBbV13ScZImK7gUuF3Sj4B/A/7ZzG49mMo5Tl9RsiWfKaar8YaZXdxh35TGWzrX96yS9XOc/sK90BxngDGLR8PtAm7kjlMl7oXmOIOMxRbDdIWeNPL63hYLHsqf665vDs//2lO7ouewWngOWgvCYgUTR40G03ctC4tC7FwePj/AnuUTwfRlTwsHmz3zqHXB9OePPhRM/w8j8QAdTxsKrxcYVni9wVgrPNe/08L3YLbC6QBDEeGHevFl4GEMzNzIHWew8ZbccQYYMx9dd5xBx3x03XEGGPOBN8cZfHzgzXEGFzPz7rrjDDrWgwEPZT24QkfSE8DDmV1LgF6WkOr1+oHXcbqcYGZHFcko6VaSa8hji5mdW021itOTRt6OpDt7WQSy1+sHXsfDGZdkdpwBx43ccQacfjHyXAHIHqHX6wdex8OWvngndxxn+vRLS+44zjTpaSOPBX/rBSStk/QTSfe0Ced3DUnXSNos6d7MvsWS1kp6MP3bVXH7nDpeJunR9F7eI+m8btZxUOhZIy8Y/K1XOMfMVvbQ9M9qoH0+9oPA183sJODr6fduspoD6whweXovV6bKpU5JetbIyQR/M7NxYDL4mxMhDWDRrijxauBz6efPAa85pJVqI6eOzgzQy0beKfjbsi7VJcRkKKi70lBPvcpSM3sMIP17dJfrk8elkn6cduc9XlYF9LKRz0jwtxngLDP7TZLXindJenG3K9THXAk8A1gJPAZ8qrvVGQx62chnJPhb1fRRKKhNko4FSP/GBdwOMWa2ycyalgilXU3v3su+opeNfCr4m6QRkogta7pcp/2QNE/S/MnPJKGg7g0f1TXWABelny8CvtTFunRk8iGU8rv07r0fB/CNAAAAgklEQVTsK3rW1dTMGpImg7/VgWvMLBrc7RCzFLg5CdPOEHBdL4SCSkNbnU0SD3sD8FHgE8CNaZir9SQB87pGTh3PlrSS5LVsHfCOrlVwgPAVb44z4PRyd91xnApwI3ecAceN3HEGHDdyxxlw3MgdZ8BxI3ecAceN3HEGHDdyxxlw/j+U87gmnM3EqQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 288x216 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "pred_labels = observed_pred.mean.view(n, n)\n",
+    "\n",
+    "# Calc abosolute error\n",
+    "test_y_actual = torch.sin(((test_x[:, 0] + test_x[:, 1]) * (2 * math.pi))).view(n, n)\n",
+    "delta_y = torch.abs(pred_labels - test_y_actual).detach().numpy()\n",
+    "\n",
+    "# Define a plotting function\n",
+    "def ax_plot(f, ax, y_labels, title):\n",
+    "    im = ax.imshow(y_labels)\n",
+    "    ax.set_title(title)\n",
+    "    f.colorbar(im)\n",
+    "\n",
+    "# Plot our predictive means\n",
+    "f, observed_ax = plt.subplots(1, 1, figsize=(4, 3))\n",
+    "ax_plot(f, observed_ax, pred_labels, 'Predicted Values (Likelihood)')\n",
+    "\n",
+    "# Plot the true values\n",
+    "f, observed_ax2 = plt.subplots(1, 1, figsize=(4, 3))\n",
+    "ax_plot(f, observed_ax2, test_y_actual, 'Actual Values (Likelihood)')\n",
+    "\n",
+    "# Plot the absolute errors\n",
+    "f, observed_ax3 = plt.subplots(1, 1, figsize=(4, 3))\n",
+    "ax_plot(f, observed_ax3, delta_y, 'Absolute Error Surface')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/gpytorch/kernels/grid_interpolation_kernel.py
+++ b/gpytorch/kernels/grid_interpolation_kernel.py
@@ -94,7 +94,7 @@ class GridInterpolationKernel(GridKernel):
         grid = self._create_grid()
 
         super(GridInterpolationKernel, self).__init__(
-            base_kernel=base_kernel, grid=grid, active_dims=active_dims
+            base_kernel=base_kernel, grid=grid, interpolation_mode=True, active_dims=active_dims
         )
         self.register_buffer("has_initialized_grid", torch.tensor(has_initialized_grid, dtype=torch.uint8))
 

--- a/gpytorch/utils/grid.py
+++ b/gpytorch/utils/grid.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 
 import math
+import torch
 
 
 def scale_to_bounds(x, lower_bound, upper_bound):
@@ -45,3 +46,18 @@ def choose_grid_size(train_inputs, ratio=1.0):
     num_data = train_inputs.numel() if train_inputs.dim() == 1 else train_inputs.size(-2)
     num_dim = 1 if train_inputs.dim() == 1 else train_inputs.size(-1)
     return int(ratio * math.pow(num_data, 1.0 / num_dim))
+
+
+def create_data_from_grid(grid):
+        grid_size = grid.size(-2)
+        grid_dim = grid.size(-1)
+        grid_data = torch.zeros(int(pow(grid_size, grid_dim)), grid_dim)
+        prev_points = None
+        for i in range(grid_dim):
+            for j in range(grid_size):
+                grid_data[j * grid_size ** i : (j + 1) * grid_size ** i, i].fill_(grid[j, i])
+                if prev_points is not None:
+                    grid_data[j * grid_size ** i : (j + 1) * grid_size ** i, :i].copy_(prev_points)
+            prev_points = grid_data[: grid_size ** (i + 1), : (i + 1)]
+
+        return grid_data

--- a/test/kernels/test_grid_kernel.py
+++ b/test/kernels/test_grid_kernel.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import torch
 import unittest
 from gpytorch.kernels import RBFKernel, GridKernel, GridInterpolationKernel
+from gpytorch.lazy import KroneckerProductLazyTensor
 
 cv = GridInterpolationKernel(RBFKernel(), grid_size=10, grid_bounds=[(0, 1), (0, 2)])
 grid = cv.grid
@@ -26,7 +27,9 @@ class TestGridKernel(unittest.TestCase):
     def test_grid_grid(self):
         base_kernel = RBFKernel()
         kernel = GridKernel(base_kernel, grid)
-        grid_eval = kernel(grid, grid).evaluate()
+        grid_covar = kernel(grid_data, grid_data).evaluate_kernel()
+        self.assertIsInstance(grid_covar, KroneckerProductLazyTensor)
+        grid_eval = kernel(grid_data, grid_data).evaluate()
         actual_eval = base_kernel(grid_data, grid_data).evaluate()
         self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
 
@@ -34,7 +37,7 @@ class TestGridKernel(unittest.TestCase):
         base_kernel = RBFKernel()
         data = torch.randn(5, 2)
         kernel = GridKernel(base_kernel, grid)
-        grid_eval = kernel(grid, data).evaluate()
+        grid_eval = kernel(grid_data, data).evaluate()
         actual_eval = base_kernel(grid_data, data).evaluate()
         self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
 


### PR DESCRIPTION
`GridKernel` can now correctly be used as a scalable GP kernel in the case where the training data lies on a regularly spaced grid. See the new `Grid_GP_Regression.ipynb` for an example of usage.

This maintains the efficiency updates made in #345 for GridInterpolationKernel in the interpolation setting, but forming the full grid seems practically unavoidable in the "your training data actually lies on a grid" setting.