### PR TITLE
Smarter __add__ for lazy tensors

### DIFF
--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -38,6 +38,14 @@ class AddedDiagLazyTensor(SumLazyTensor):
     def add_diag(self, added_diag):
         return AddedDiagLazyTensor(self._lazy_tensor, self._diag_tensor.add_diag(added_diag))
 
+    def __add__(self, other):
+        from .diag_lazy_tensor import DiagLazyTensor
+
+        if isinstance(other, DiagLazyTensor):
+            return AddedDiagLazyTensor(self._lazy_tensor, self._diag_tensor + other)
+        else:
+            return AddedDiagLazyTensor(self._lazy_tensor + other, self._diag_tensor)
+
     def _preconditioner(self):
         if settings.max_preconditioner_size.value() == 0:
             return None, None

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -55,6 +55,13 @@ class DiagLazyTensor(LazyTensor):
     def add_diag(self, added_diag):
         return DiagLazyTensor(self._diag + added_diag.expand_as(self._diag))
 
+    def __add__(self, other):
+        from .added_diag_lazy_tensor import AddedDiagLazyTensor
+        if isinstance(other, DiagLazyTensor):
+            return DiagLazyTensor(self._diag + other._diag)
+        else:
+            return AddedDiagLazyTensor(other, self)
+
     def diag(self):
         return self._diag
 

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1137,11 +1137,15 @@ class LazyTensor(object):
         """
         from .sum_lazy_tensor import SumLazyTensor
         from .zero_lazy_tensor import ZeroLazyTensor
+        from .diag_lazy_tensor import DiagLazyTensor
+        from .added_diag_lazy_tensor import AddedDiagLazyTensor
 
         if isinstance(other, ZeroLazyTensor):
             return self
-
-        return SumLazyTensor(self, other)
+        elif isinstance(other, DiagLazyTensor):
+            return AddedDiagLazyTensor(self, other)
+        else:
+            return SumLazyTensor(self, other)
 
     def __div__(self, other):
         """

--- a/gpytorch/lazy/sum_lazy_tensor.py
+++ b/gpytorch/lazy/sum_lazy_tensor.py
@@ -71,9 +71,14 @@ class SumLazyTensor(LazyTensor):
         return sum(lazy_tensor.evaluate() for lazy_tensor in self.lazy_tensors)
 
     def __add__(self, other):
+        from .diag_lazy_tensor import DiagLazyTensor
+        from .added_diag_lazy_tensor import AddedDiagLazyTensor
+
         if isinstance(other, ZeroLazyTensor):
             return self
-        if isinstance(other, SumLazyTensor):
+        elif isinstance(other, DiagLazyTensor):
+            return AddedDiagLazyTensor(self, other)
+        elif isinstance(other, SumLazyTensor):
             return SumLazyTensor(*(list(self.lazy_tensors) + list(other.lazy_tensors)))
         elif isinstance(other, LazyTensor):
             return SumLazyTensor(*(list(self.lazy_tensors) + [other]))


### PR DESCRIPTION
This PR modifies three custom `__add__` methods (`LazyTensor.__add__`, `DiagLazyTensor.__add__`, `AddedDiagLazyTensor.__add__`, `SumLazyTensor.__add__`) so that we always prefer to create an `AddedDiagLazyTensor` over a `SumLazyTensor` when a `DiagLazyTensor` is involved. This way, the ability to used preconditioning is optimistically preserved as much as possible.

cc/ @Balandat this addresses one of the issues I raised in code review in #337 