### PR TITLE
Various LazyTensor fixes/improvements

### DIFF
--- a/gpytorch/functions/__init__.py
+++ b/gpytorch/functions/__init__.py
@@ -26,7 +26,7 @@ def add_diag(input, diag):
     if torch.is_tensor(input):
         from ..lazy import NonLazyTensor
 
-        return NonLazyTensor(input).add_diag()
+        return NonLazyTensor(input).add_diag(diag)
     else:
         return input.add_diag(diag)
 

--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -139,13 +139,13 @@ class BatchRepeatLazyTensor(LazyTensor):
             inv_quad_rhs, log_det, reduce_inv_quad=False
         )
 
-        if inv_quad_term.numel():
+        if inv_quad_term is not None and inv_quad_term.numel():
             inv_quad_term = inv_quad_term.view(*inv_quad_term.shape[:-1], -1, self.batch_repeat.numel())
             inv_quad_term = self._move_repeat_batches_back(inv_quad_term).squeeze(-1)
             if reduce_inv_quad:
                 inv_quad_term = inv_quad_term.sum(-1)
 
-        if log_det_term.numel():
+        if log_det_term is not None and log_det_term.numel():
             log_det_term = log_det_term.repeat(*self.batch_repeat)
 
         return inv_quad_term, log_det_term

--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -166,6 +166,15 @@ class BatchRepeatLazyTensor(LazyTensor):
             ),
         )
 
+    def root_decomposition(self):
+        return self.base_lazy_tensor.root_decomposition().repeat(*self.batch_repeat, 1, 1)
+
+    def root_inv_decomposition(self, initial_vectors=None, test_vectors=None):
+        return self.base_lazy_tensor.root_inv_decomposition(
+            initial_vectors=initial_vectors,
+            test_vectors=test_vectors,
+        ).repeat(*self.batch_repeat, 1, 1)
+
     def __getitem__(self, index):
         """
         Supports subindexing of the matrix this LazyTensor represents. This may return either another

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -79,6 +79,73 @@ class DiagLazyTensor(LazyTensor):
 
         return self.__class__(diag.sum(-2))
 
+    def inv_matmul(self, tensor):
+        is_vec = False
+        if (self.dim() == 2 and tensor.dim() == 1):
+            tensor = tensor.unsqueeze(-1)
+            is_vec = True
+
+            if self.shape[-1] != tensor.numel():
+                raise RuntimeError(
+                    "LazyTensor (size={}) cannot be multiplied with right-hand-side Tensor (size={}).".format(
+                        self.shape, tensor.shape
+                    )
+                )
+        elif self.dim() != tensor.dim():
+            raise RuntimeError(
+                "LazyTensor (size={}) and right-hand-side Tensor (size={}) should have the same number "
+                "of dimensions.".format(self.shape, tensor.shape)
+            )
+        elif self.batch_shape != tensor.shape[:-2] or self.shape[-1] != tensor.shape[-2]:
+            raise RuntimeError(
+                "LazyTensor (size={}) cannot be multiplied with right-hand-side Tensor (size={}).".format(
+                    self.shape, tensor.shape
+                )
+            )
+
+        res = tensor.div(self._diag.unsqueeze(-1))
+        if is_vec:
+            res = res.squeeze(-1)
+        return res
+
+    def inv_quad_log_det(self, inv_quad_rhs=None, log_det=False, reduce_inv_quad=True):
+        if inv_quad_rhs is not None:
+            if (self.dim() == 2 and inv_quad_rhs.dim() == 1):
+                inv_quad_rhs = inv_quad_rhs.unsqueeze(-1)
+                if self.shape[-1] != inv_quad_rhs.numel():
+                    raise RuntimeError(
+                        "LazyTensor (size={}) cannot be multiplied with right-hand-side Tensor (size={}).".format(
+                            self.shape, inv_quad_rhs.shape
+                        )
+                    )
+            elif self.dim() != inv_quad_rhs.dim():
+                raise RuntimeError(
+                    "LazyTensor (size={}) and right-hand-side Tensor (size={}) should have the same number "
+                    "of dimensions.".format(self.shape, inv_quad_rhs.shape)
+                )
+            elif self.batch_shape != inv_quad_rhs.shape[:-2] or self.shape[-1] != inv_quad_rhs.shape[-2]:
+                raise RuntimeError(
+                    "LazyTensor (size={}) cannot be multiplied with right-hand-side Tensor (size={}).".format(
+                        self.shape, inv_quad_rhs.shape
+                    )
+                )
+
+        inv_quad_term = None
+        if inv_quad_rhs is None:
+            inv_quad_term = torch.tensor([], dtype=self.dtype, device=self.device)
+        else:
+            inv_quad_term = inv_quad_rhs.div(self._diag.unsqueeze(-1)).mul(inv_quad_rhs).sum(-2)
+            if reduce_inv_quad:
+                inv_quad_term = inv_quad_term.sum(-1)
+
+        log_det_term = None
+        if log_det:
+            log_det_term = self._diag.log().sum(-1)
+        else:
+            log_det_term = torch.tensor([], dtype=self.dtype, device=self.device)
+
+        return inv_quad_term, log_det_term
+
     def zero_mean_mvn_samples(self, num_samples):
         if self.ndimension() == 3:
             base_samples = torch.randn(

--- a/test/lazy/test_batch_repeat_lazy_tensor.py
+++ b/test/lazy/test_batch_repeat_lazy_tensor.py
@@ -11,9 +11,12 @@ from test.lazy._lazy_tensor_test_case import BatchLazyTensorTestCase
 
 class TestBatchRepeatLazyTensor(BatchLazyTensorTestCase, unittest.TestCase):
     seed = 0
+    should_test_sample = True
 
     def create_lazy_tensor(self):
-        toeplitz_column = torch.tensor([4, 0, 0, 1], dtype=torch.float, requires_grad=True)
+        toeplitz_column = torch.tensor(
+            [4, 0.1, 0.05, 0.01, 0.], dtype=torch.float, requires_grad=True
+        )
         return BatchRepeatLazyTensor(ToeplitzLazyTensor(toeplitz_column), torch.Size((3,)))
 
     def evaluate_lazy_tensor(self, lazy_tensor):
@@ -23,6 +26,7 @@ class TestBatchRepeatLazyTensor(BatchLazyTensorTestCase, unittest.TestCase):
 
 class TestBatchRepeatLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
     seed = 0
+    should_test_sample = True
 
     def create_lazy_tensor(self):
         toeplitz_column = torch.tensor([[4, 0, 0, 1], [3, 0, -0.5, -1]], dtype=torch.float, requires_grad=True)


### PR DESCRIPTION
- BatchRepeatLazyTensor uses base_lazy_tensor's root decompositions
- DiagLazyTensor implements custom (faster) `inv_quad_log_det` and `inv_matmul`
- DiagLazyTensor (optionally) implements an exact root decomposition (with the `exact_root_decomposition=True` kwarg passed into the constructor)
- `gpytorch.add_diag` now works on regular torch.tensors