### PR TITLE
Optional default preconditioner for LazyTensors

### DIFF
--- a/gpytorch/beta_features.py
+++ b/gpytorch/beta_features.py
@@ -40,6 +40,13 @@ class diagonal_correction(_feature_flag):
     _state = True
 
 
+class default_preconditioner(_feature_flag):
+    """
+    Add a diagonal correction to scalable inducing point methods
+    """
+    pass
+
+
 class fast_pred_samples(_feature_flag):
     """
     Fast predictive samples - with Lanczos
@@ -48,4 +55,4 @@ class fast_pred_samples(_feature_flag):
     pass
 
 
-__all__ = ["diagonal_correction", "fast_pred_var", "fast_pred_samples"]
+__all__ = ["diagonal_correction", "default_preconditioner", "fast_pred_var", "fast_pred_samples"]

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import math
+import gpytorch
 import torch
 from ..functions._inv_matmul import InvMatmul
 from ..functions._inv_quad_log_det import InvQuadLogDet
@@ -11,6 +12,8 @@ from ..functions._root_decomposition import RootDecomposition
 from ..functions._matmul import Matmul
 from .. import beta_features, settings
 from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
+from ..utils.qr import batch_qr
+from ..utils.svd import batch_svd
 
 
 class LazyTensor(object):
@@ -250,6 +253,46 @@ class LazyTensor(object):
             self, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
         )
         return res
+
+    def _inv_matmul_preconditioner(self):
+        """
+        (Optional) define a preconditioner that can be used for linear systems, but not necessarily
+        for log determinants. By default, this can call :meth:`~gpytorch.lazy.LazyTensor._preconditioner`.
+
+        Returns:
+            function: a function on x which performs P^{-1}(x)
+        """
+        base_precond, _ = self._preconditioner()
+
+        if base_precond is not None:
+            return base_precond
+        elif gpytorch.beta_features.default_preconditioner.on():
+            if hasattr(self, "_default_preconditioner_cache"):
+                U, S, V = self._default_preconditioner_cache
+            else:
+                precond_basis_size = min(gpytorch.settings.max_preconditioner_size.value(), self.size(-1))
+                random_basis = torch.randn(
+                    self.batch_shape + torch.Size((self.size(-2), precond_basis_size)),
+                    device=self.device,
+                    dtype=self.dtype,
+                )
+                projected_mat = self._matmul(random_basis)
+                proj_q = batch_qr(projected_mat)
+                orthog_projected_mat = self._matmul(proj_q).transpose(-2, -1)
+                U, S, V = batch_svd(orthog_projected_mat)
+                U = proj_q.matmul(U)
+
+                self._default_preconditioner_cache = (U, S, V)
+
+            def preconditioner(v):
+                res = V.transpose(-2, -1).matmul(v)
+                res = (1 / S).unsqueeze(-1) * res
+                res = U.matmul(res)
+                return res
+
+            return preconditioner
+        else:
+            return None
 
     def _preconditioner(self):
         """
@@ -582,7 +625,7 @@ class LazyTensor(object):
                 )
             )
 
-        func = InvMatmul(self.representation_tree(), preconditioner=self._preconditioner()[0])
+        func = InvMatmul(self.representation_tree(), preconditioner=self._inv_matmul_preconditioner())
         return func(tensor, *self.representation())
 
     def inv_quad(self, tensor):

--- a/gpytorch/lazy/non_lazy_tensor.py
+++ b/gpytorch/lazy/non_lazy_tensor.py
@@ -43,10 +43,6 @@ class NonLazyTensor(LazyTensor):
     def _get_indices(self, left_indices, right_indices):
         return self.tensor[left_indices, right_indices]
 
-    def _preconditioner(self):
-        # For a NonLazyTensor, it is intended to not use preconditioning, even when called for.
-        return None, None
-
     def diag(self):
         if self.tensor.ndimension() < 3:
             return self.tensor.diag()

--- a/gpytorch/utils/qr.py
+++ b/gpytorch/utils/qr.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import torch
+
+
+def batch_qr(mat):
+    """
+    TODO: Replace with torch.qr once PyTorch implements a batch QR decomposition
+    """
+    mat_orig = mat
+    batch_shape = torch.Size(mat_orig.shape[:-2])
+    matrix_shape = torch.Size(mat_orig.shape[-2:])
+
+    # Smaller matrices are faster on the CPU than the GPU
+    if mat.size(-2) <= 32:
+        mat = mat.cpu()
+
+    mat = mat.view(-1, *matrix_shape)
+    q_mats = torch.empty(batch_shape.numel(), *matrix_shape)
+
+    for i in range(batch_shape.numel()):
+        q_mat, _ = torch.qr(mat[i])
+        q_mats[i] = q_mat
+
+    return q_mats.type_as(mat_orig).view_as(mat_orig)

--- a/gpytorch/utils/svd.py
+++ b/gpytorch/utils/svd.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import torch
+
+
+def batch_svd(mat):
+    """
+    TODO: Replace with torch.svd once PyTorch supports batch SVD
+    """
+    mat_orig = mat
+    batch_shape = torch.Size(mat_orig.shape[:-2])
+    matrix_shape = torch.Size(mat_orig.shape[-2:])
+
+    # Smaller matrices are faster on the CPU than the GPU
+    if mat.size(-1) <= 32:
+        mat = mat.cpu()
+
+    mat = mat.view(-1, *matrix_shape)
+    left_vecs = torch.empty(
+        batch_shape.numel(), *(mat_orig.size(-2), mat_orig.size(-2)), dtype=mat.dtype, device=mat.device
+    )
+
+    singular_values = torch.empty(batch_shape.numel(), mat_orig.size(-2), dtype=mat.dtype, device=mat.device)
+
+    right_vecs = torch.empty(
+        batch_shape.numel(), *(mat_orig.size(-1), mat_orig.size(-2)), dtype=mat.dtype, device=mat.device
+    )
+
+    for i in range(batch_shape.numel()):
+        left, sigma, right = mat[i].svd()
+        left_vecs[i] = left
+        singular_values[i] = sigma
+        right_vecs[i] = right
+
+    return (
+        left_vecs.type_as(mat_orig).view(*batch_shape, *(mat_orig.size(-2), mat_orig.size(-2))),
+        singular_values.type_as(mat_orig).view(*batch_shape, -1),
+        right_vecs.type_as(mat_orig).view(*batch_shape, *(mat_orig.size(-1), mat_orig.size(-2))),
+    )


### PR DESCRIPTION
This adds optional default preconditioning for `LazyTensor.inv_matmul` (doesn't work for log dets) based on a fast randomized SVD algorithm. In other words: a preconditioner that can function even for non `AddedDiagLazyTensors`. It works quite well on a variety of matrices we end up with in practice. For example:

```python 
# Works with just RBFKernel too
cov = GridInterpolationKernel(RBFKernel(), grid_size=100, num_dims=1)
n_x = 500
# Let's test in batch mode for fun
x = torch.randn(2, n_x, 1)

# No added jitter or diagonal component means solves with either CG
# or Cholesky will be terrible unless we precondition
K = cov(x).evaluate_kernel()

b = torch.randn(2, n_x, 1)

# No preconditioner
sv1 = K.inv_matmul(b)

# Shiny new default preconditioner
with gpytorch.beta_features.default_preconditioner():
    sv2 = K.inv_matmul(b)

print(torch.norm(K.matmul(sv1) - b) / b.norm()) # 146.1651
print(torch.norm(K.matmul(sv2) - b) / b.norm()) # 0.9936
```

I don't think this will have much of an impact on our actual models in GPyTorch, because we tend to `add_jitter` or use a GaussianLikelihood so that we can use the pivoted Cholesky preconditioner everywhere. However, as demonstrated above, this can have a significant impact for people using `gpytorch.lazy` as a standalone fast linear algebra package. 

Solves #313. Right now this is a safe PR because the added functionality is gated by a `beta_features` flag that is off by default.