### PR TITLE
Fix inconsistent LazyTensor.__getitem__ with list vs tensor indices

### DIFF
--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1205,6 +1205,7 @@ class LazyTensor(object):
         :obj:`gpytorch.lazy.LazyTensor` or a :obj:`torch.tensor` depending on the exact implementation.
         """
         index = list(index) if isinstance(index, tuple) else [index]
+        index = [torch.tensor(idx) if isinstance(idx, list) else idx for idx in index]
         ndimension = self.ndimension()
         index += [slice(None, None, None)] * (ndimension - len(index))
         components = list(self._args)


### PR DESCRIPTION
See my comment in #362. Right now, `__getitem__` has different behavior when indexing with lists instead of tensors:

```python
import torch
from gpytorch.lazy import ToeplitzLazyTensor
toep_lt = ToeplitzLazyTensor(torch.randn(3, 5))

print(toep_lt[[0, 1], [0, 0], [0, 1]].shape)  # torch.Size([2, 2, 2]) -- Bad!
a = torch.tensor([0, 1])
b = torch.tensor([0, 0])
print(toep_lt[a, b, a].shape)  # torch.Size([2]) -- Good!
```

This PR fixes this so that indexing with lists has the same behavior as indexing with tensors did (which mirrors the behavior of indexing a `torch.Tensor` with either a list or a tensor).