### PR TITLE
Handle NaN gracefully in loss computation.

### DIFF
--- a/gpytorch/functions/_inv_quad_log_det.py
+++ b/gpytorch/functions/_inv_quad_log_det.py
@@ -123,15 +123,18 @@ class InvQuadLogDet(Function):
 
         # Compute log_det from tridiagonalization
         if self.log_det:
-            if self.batch_shape is None:
-                t_mat = t_mat.unsqueeze(1)
-            eigenvalues, eigenvectors = lanczos_tridiag_to_diag(t_mat)
-            slq = StochasticLQ()
-            log_det_term, = slq.evaluate(self.matrix_shape, eigenvalues, eigenvectors, [lambda x: x.log()])
+            if torch.any(torch.isnan(t_mat)).item():
+                log_det_term = float("nan")
+            else:
+                if self.batch_shape is None:
+                    t_mat = t_mat.unsqueeze(1)
+                eigenvalues, eigenvectors = lanczos_tridiag_to_diag(t_mat)
+                slq = StochasticLQ()
+                log_det_term, = slq.evaluate(self.matrix_shape, eigenvalues, eigenvectors, [lambda x: x.log()])
 
-            # Add correction
-            if self.log_det_correction is not None:
-                log_det_term = log_det_term + self.log_det_correction
+                # Add correction
+                if self.log_det_correction is not None:
+                    log_det_term = log_det_term + self.log_det_correction
 
         # Extract inv_quad solves from all the solves
         if self.inv_quad:

--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import torch
+import warnings
 from .non_lazy_tensor import NonLazyTensor
 from .sum_lazy_tensor import SumLazyTensor
 from .diag_lazy_tensor import DiagLazyTensor
@@ -53,6 +54,11 @@ class AddedDiagLazyTensor(SumLazyTensor):
         if not hasattr(self, "_woodbury_cache"):
             max_iter = settings.max_preconditioner_size.value()
             self._piv_chol_self = pivoted_cholesky.pivoted_cholesky(self._lazy_tensor, max_iter)
+            if torch.any(torch.isnan(self._piv_chol_self)).item():
+                warnings.warn(
+                    "NaNs encountered in preconditioner computation. Attempting to continue without " "preconditioning."
+                )
+                return None, None
             self._woodbury_cache = pivoted_cholesky.woodbury_factor(self._piv_chol_self, self._diag_tensor.diag())
 
         # preconditioner


### PR DESCRIPTION
This PR makes the GPyTorch internals handle NaNs that occur due to round-off from terrible hyperparameter values more gracefully. In particular:

- If the preconditioner contains NaNs, we throw a warning and attempt to continue without preconditioning. 
    - In testing these NaNs appear somewhat intermittently such that even if one iteration fails due to it the next will often succeed. In @bletham's notebook this avoids crashing with learning rates well up in to the thousands (when combined with `param_transform=softplus` of course).
- If NaNs are encountered from CG outputs, these are handled more gracefully. 
    - The linear solves already handle these gracefully in the sense that we don't try to do anything more than basic operations, so the inv quad term will already show up as NaN. All that was needed was a check for the tridiagonal matrices used for log det calculations.

In my opinion, this closes #370 in combination with #371.