### PR TITLE
Track inverse parameter transforms

### DIFF
--- a/gpytorch/kernels/cosine_kernel.py
+++ b/gpytorch/kernels/cosine_kernel.py
@@ -7,7 +7,6 @@ import math
 import torch
 from .kernel import Kernel
 from ..utils.deprecation import _deprecate_kwarg
-from ..utils.transforms import _get_inv_param_transform
 
 
 class CosineKernel(Kernel):
@@ -38,6 +37,9 @@ class CosineKernel(Kernel):
             (prevents divide by zero errors). Default: `1e-6`.
         :attr:`param_transform` (function, optional):
             Set this if you want to use something other than torch.exp to ensure positiveness of parameters.
+        :attr:`inv_param_transform` (function, optional):
+            Set this to allow setting parameters directly in transformed space and sampling from priors.
+            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
 
     Attributes:
         :attr:`period_length` (Tensor):

--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -33,6 +33,9 @@ class IndexKernel(Kernel):
             Prior for :math:`B` matrix.
         :attr:`param_transform` (function, optional):
             Set this if you want to use something other than torch.exp to ensure positiveness of parameters.
+        :attr:`inv_param_transform` (function, optional):
+            Set this to allow setting parameters directly in transformed space and sampling from priors.
+            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
 
     Attributes:
         covar_factor:

--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -41,10 +41,12 @@ class IndexKernel(Kernel):
             The element-wise log of the :math:`\mathbf v` vector.
     """
 
-    def __init__(self, num_tasks, rank=1, batch_size=1, prior=None, param_transform=torch.exp):
+    def __init__(
+        self, num_tasks, rank=1, batch_size=1, prior=None, param_transform=torch.exp, inv_param_transform=None
+    ):
         if rank > num_tasks:
             raise RuntimeError("Cannot create a task covariance matrix larger than the number of tasks")
-        super(IndexKernel, self).__init__(param_transform=param_transform)
+        super(IndexKernel, self).__init__(param_transform=param_transform, inv_param_transform=inv_param_transform)
         self.register_parameter(
             name="covar_factor", parameter=torch.nn.Parameter(torch.randn(batch_size, num_tasks, rank))
         )
@@ -56,11 +58,17 @@ class IndexKernel(Kernel):
     def var(self):
         return self._param_transform(self.log_var)
 
+    @var.setter
+    def var(self, value):
+        self._set_var(value)
+
+    def _set_var(self, value):
+        self.initialize(log_var=self._inv_param_transform(value))
+
     def _eval_covar_matrix(self):
-        covar_factor, variance = self.covar_factor, self.var
-        return covar_factor.matmul(covar_factor.transpose(-1, -2)) + variance.diag()
-        # D = var * torch.eye(var.shape[-1], dtype=var.dytpe, device=var.device)
-        # return self.covar_factor.matmul(self.covar_factor.transpose(-1, -2)) + D
+        var = self.var
+        D = var * torch.eye(var.shape[-1], dtype=var.dtype, device=var.device)
+        return self.covar_factor.matmul(self.covar_factor.transpose(-1, -2)) + D
 
     @property
     def covar_matrix(self):

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -10,6 +10,7 @@ from ..lazy import LazyEvaluatedKernelTensor, ZeroLazyTensor
 from ..module import Module
 from .. import settings
 from ..utils.deprecation import _deprecate_kwarg
+from ..utils.transforms import _get_inv_param_transform
 
 
 class Kernel(Module):
@@ -93,6 +94,7 @@ class Kernel(Module):
         active_dims=None,
         lengthscale_prior=None,
         param_transform=torch.exp,
+        inv_param_transform=None,
         eps=1e-6,
         **kwargs
     ):
@@ -105,6 +107,7 @@ class Kernel(Module):
         self.batch_size = batch_size
         self.__has_lengthscale = has_lengthscale
         self._param_transform = param_transform
+        self._inv_param_transform = _get_inv_param_transform(param_transform, inv_param_transform)
         if has_lengthscale:
             self.eps = eps
             lengthscale_num_dims = 1 if ard_num_dims is None else ard_num_dims
@@ -112,7 +115,9 @@ class Kernel(Module):
                 name="log_lengthscale", parameter=torch.nn.Parameter(torch.zeros(batch_size, 1, lengthscale_num_dims))
             )
             if lengthscale_prior is not None:
-                self.register_prior("lengthscale_prior", lengthscale_prior, lambda: self.lengthscale)
+                self.register_prior(
+                    "lengthscale_prior", lengthscale_prior, lambda: self.lengthscale, lambda v: self._set_lengthscale(v)
+                )
 
     @property
     def has_lengthscale(self):
@@ -124,6 +129,15 @@ class Kernel(Module):
             return self._param_transform(self.log_lengthscale).clamp(self.eps, 1e5)
         else:
             return None
+
+    @lengthscale.setter
+    def lengthscale(self, value):
+        self._set_lengthscale(value)
+
+    def _set_lengthscale(self, value):
+        if not self.has_lengthscale:
+            raise RuntimeError("Kernel has no lengthscale.")
+        self.initialize(log_lengthscale=self._inv_param_transform(value))
 
     @property
     def has_custom_exact_predictions(self):

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -71,6 +71,9 @@ class Kernel(Module):
             Set this if you want to apply a prior to the lengthscale parameter.  Default: `None`
         :attr:`param_transform` (function, optional):
             Set this if you want to use something other than torch.exp to ensure positiveness of parameters.
+        :attr:`inv_param_transform` (function, optional):
+            Set this to allow setting parameters directly in transformed space and sampling from priors.
+            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
         :attr:`eps` (float):
             The minimum value that the lengthscale can take (prevents divide by zero errors). Default: `1e-6`.
 

--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -53,11 +53,13 @@ class MaternKernel(Kernel):
         :attr:`log_lengthscale_prior` (Prior, optional):
             Set this if you want
             to apply a prior to the lengthscale parameter.  Default: `None`
-        :attr:`eps` (float):
-            The minimum value that the lengthscale can take
-            (prevents divide by zero errors). Default: `1e-6`.
         :attr:`param_transform` (function, optional):
             Set this if you want to use something other than torch.exp to ensure positiveness of parameters.
+        :attr:`inv_param_transform` (function, optional):
+            Set this to allow setting parameters directly in transformed space and sampling from priors.
+            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
+        :attr:`eps` (float):
+            The minimum value that the lengthscale can take (prevents divide by zero errors). Default: `1e-6`.
 
     Attributes:
         :attr:`lengthscale` (Tensor):
@@ -87,9 +89,9 @@ class MaternKernel(Kernel):
         batch_size=1,
         active_dims=None,
         lengthscale_prior=None,
-        eps=1e-6,
         param_transform=torch.exp,
         inv_param_transform=None,
+        eps=1e-6,
         **kwargs
     ):
         _deprecate_kwarg(kwargs, "log_lengthscale_prior", "lengthscale_prior", lengthscale_prior)

--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -89,6 +89,7 @@ class MaternKernel(Kernel):
         lengthscale_prior=None,
         eps=1e-6,
         param_transform=torch.exp,
+        inv_param_transform=None,
         **kwargs
     ):
         _deprecate_kwarg(kwargs, "log_lengthscale_prior", "lengthscale_prior", lengthscale_prior)
@@ -101,6 +102,7 @@ class MaternKernel(Kernel):
             active_dims=active_dims,
             lengthscale_prior=lengthscale_prior,
             param_transform=param_transform,
+            inv_param_transform=inv_param_transform,
             eps=eps,
         )
         self.nu = nu

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -38,17 +38,19 @@ class PeriodicKernel(Kernel):
     Args:
         :attr:`batch_size` (int, optional):
             Set this if you want a separate lengthscale for each
-            batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `1`
+            batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `1`.
         :attr:`active_dims` (tuple of ints, optional):
-            Set this if you want to
-            compute the covariance of only a few input dimensions. The ints
+            Set this if you want to compute the covariance of only a few input dimensions. The ints
             corresponds to the indices of the dimensions. Default: `None`.
         :attr:`period_length_prior` (Prior, optional):
-            Set this if you want
-            to apply a prior to the period length parameter.  Default: `None`
-        :attr:`log_lengthscale_prior` (Prior, optional):
-            Set this if you want
-            to apply a prior to the lengthscale parameter.  Default: `None`
+            Set this if you want to apply a prior to the period length parameter.  Default: `None`.
+        :attr:`lengthscale_prior` (Prior, optional):
+            Set this if you want to apply a prior to the lengthscale parameter.  Default: `None`.
+        :attr:`param_transform` (function, optional):
+            Set this if you want to use something other than torch.exp to ensure positiveness of parameters.
+        :attr:`inv_param_transform` (function, optional):
+            Set this to allow setting parameters directly in transformed space and sampling from priors.
+            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
         :attr:`eps` (float):
             The minimum value that the lengthscale/period length can take
             (prevents divide by zero errors). Default: `1e-6`.
@@ -76,11 +78,11 @@ class PeriodicKernel(Kernel):
         self,
         active_dims=None,
         batch_size=1,
-        eps=1e-6,
         lengthscale_prior=None,
         period_length_prior=None,
         param_transform=torch.exp,
         inv_param_transform=None,
+        eps=1e-6,
         **kwargs
     ):
         lengthscale_prior = _deprecate_kwarg(kwargs, "log_lengthscale_prior", "lengthscale_prior", lengthscale_prior)

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -34,19 +34,19 @@ class RBFKernel(Kernel):
             input dimension. It should be `d` if :attr:`x1` is a `n x d` matrix. Default: `None`
         :attr:`batch_size` (int, optional):
             Set this if you want a separate lengthscale for each
-            batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `1`
+            batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `1`.
         :attr:`active_dims` (tuple of ints, optional):
-            Set this if you want to
-            compute the covariance of only a few input dimensions. The ints
+            Set this if you want to compute the covariance of only a few input dimensions. The ints
             corresponds to the indices of the dimensions. Default: `None`.
         :attr:`lengthscale_prior` (Prior, optional):
-            Set this if you want
-            to apply a prior to the lengthscale parameter.  Default: `None`
-        :attr:`eps` (float):
-            The minimum value that the lengthscale can take
-            (prevents divide by zero errors). Default: `1e-6`.
+            Set this if you want to apply a prior to the lengthscale parameter.  Default: `None`.
         :attr:`param_transform` (function, optional):
             Set this if you want to use something other than torch.exp to ensure positiveness of parameters.
+        :attr:`inv_param_transform` (function, optional):
+            Set this to allow setting parameters directly in transformed space and sampling from priors.
+            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
+        :attr:`eps` (float):
+            The minimum value that the lengthscale can take (prevents divide by zero errors). Default: `1e-6`.
 
     Attributes:
         :attr:`lengthscale` (Tensor):
@@ -72,12 +72,12 @@ class RBFKernel(Kernel):
     def __init__(
         self,
         ard_num_dims=None,
-        lengthscale_prior=None,
-        eps=1e-6,
-        active_dims=None,
         batch_size=1,
+        active_dims=None,
+        lengthscale_prior=None,
         param_transform=torch.exp,
         inv_param_transform=None,
+        eps=1e-6,
         **kwargs
     ):
         _deprecate_kwarg(kwargs, "log_lengthscale_prior", "lengthscale_prior", lengthscale_prior)

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -77,6 +77,7 @@ class RBFKernel(Kernel):
         active_dims=None,
         batch_size=1,
         param_transform=torch.exp,
+        inv_param_transform=None,
         **kwargs
     ):
         _deprecate_kwarg(kwargs, "log_lengthscale_prior", "lengthscale_prior", lengthscale_prior)
@@ -87,6 +88,7 @@ class RBFKernel(Kernel):
             active_dims=active_dims,
             lengthscale_prior=lengthscale_prior,
             param_transform=param_transform,
+            inv_param_transform=inv_param_transform,
             eps=eps,
         )
 

--- a/gpytorch/kernels/scale_kernel.py
+++ b/gpytorch/kernels/scale_kernel.py
@@ -30,16 +30,20 @@ class ScaleKernel(Kernel):
         You can set a prior on this parameter using the :attr:`outputscale_prior` argument.
 
     Args:
-        - :attr:`batch_size` (int, optional): Set this if you want a separate outputscale for each
+        :attr:`base_kernel` (Kernel): The base kernel to be scaled.
+        :attr:`batch_size` (int, optional): Set this if you want a separate outputscale for each
             batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `1`
-        - :attr:`outputscale_prior` (Prior, optional): Set this if you want
+        :attr:`outputscale_prior` (Prior, optional): Set this if you want
             to apply a prior to the outputscale parameter.  Default: `None`
-        - :attr:`param_transform` (function, optional):
+        :attr:`param_transform` (function, optional):
             Set this if you want to use something other than torch.exp to ensure positiveness of parameters.
+        :attr:`inv_param_transform` (function, optional):
+            Set this to allow setting parameters directly in transformed space and sampling from priors.
+            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
 
     Attributes:
-        - :attr:`base_kernel` (Kernel): The kernel module to be scaled.
-        - :attr:`outputscale` (Tensor): The outputscale parameter. Size/shape of parameter depends on the
+        :attr:`base_kernel` (Kernel): The kernel module to be scaled.
+        :attr:`outputscale` (Tensor): The outputscale parameter. Size/shape of parameter depends on the
             :attr:`batch_size` arguments.
 
     Example:

--- a/gpytorch/kernels/scale_kernel.py
+++ b/gpytorch/kernels/scale_kernel.py
@@ -30,11 +30,13 @@ class ScaleKernel(Kernel):
         You can set a prior on this parameter using the :attr:`outputscale_prior` argument.
 
     Args:
-        :attr:`base_kernel` (Kernel): The base kernel to be scaled.
-        :attr:`batch_size` (int, optional): Set this if you want a separate outputscale for each
-            batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `1`
-        :attr:`outputscale_prior` (Prior, optional): Set this if you want
-            to apply a prior to the outputscale parameter.  Default: `None`
+        :attr:`base_kernel` (Kernel):
+            The base kernel to be scaled.
+        :attr:`batch_size` (int, optional):
+            Set this if you want a separate outputscale for each batch of input data. It should be `b`
+            if :attr:`x1` is a `b x n x d` tensor. Default: `1`
+        :attr:`outputscale_prior` (Prior, optional): Set this if you want to apply a prior to the outputscale
+            parameter.  Default: `None`
         :attr:`param_transform` (function, optional):
             Set this if you want to use something other than torch.exp to ensure positiveness of parameters.
         :attr:`inv_param_transform` (function, optional):
@@ -42,9 +44,10 @@ class ScaleKernel(Kernel):
             Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
 
     Attributes:
-        :attr:`base_kernel` (Kernel): The kernel module to be scaled.
-        :attr:`outputscale` (Tensor): The outputscale parameter. Size/shape of parameter depends on the
-            :attr:`batch_size` arguments.
+        :attr:`base_kernel` (Kernel):
+            The kernel module to be scaled.
+        :attr:`outputscale` (Tensor):
+            The outputscale parameter. Size/shape of parameter depends on the :attr:`batch_size` arguments.
 
     Example:
         >>> x = torch.randn(10, 5)

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -35,19 +35,20 @@ class SpectralMixtureKernel(Kernel):
             Set this if the data is
             batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `1`
         :attr:`active_dims` (tuple of ints, optional):
-            Set this if you want to
-            compute the covariance of only a few input dimensions. The ints
+            Set this if you want to compute the covariance of only a few input dimensions. The ints
             corresponds to the indices of the dimensions. Default: `None`.
-        :attr:`eps` (float):
-            The minimum value that the lengthscale can take
-            (prevents divide by zero errors). Default: `1e-6`.
         :attr:`param_transform` (function, optional):
             Set this if you want to use something other than torch.exp to ensure positiveness of parameters.
+        :attr:`inv_param_transform` (function, optional):
+            Set this to allow setting parameters directly in transformed space and sampling from priors.
+            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
+        :attr:`eps` (float):
+            The minimum value that the lengthscale can take (prevents divide by zero errors). Default: `1e-6`.
 
     Attributes:
         :attr:`mixture_lengthscale` (Tensor):
-            The lengthscale parameter. Given `k` mixture components,
-            and `b x n x d` data, this will be of size `b x k x 1 x d`.
+            The lengthscale parameter. Given `k` mixture components, and `b x n x d` data, this will be of
+            size `b x k x 1 x d`.
         :attr:`mixture_means` (Tensor):
             The mixture mean parameters (`b x k x 1 x d`).
         :attr:`mixture_weights` (Tensor):

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -81,6 +81,7 @@ class SpectralMixtureKernel(Kernel):
         mixture_means_prior=None,
         mixture_weights_prior=None,
         param_transform=torch.exp,
+        inv_param_transform=None,
         **kwargs
     ):
         mixture_scales_prior = _deprecate_kwarg(
@@ -99,7 +100,9 @@ class SpectralMixtureKernel(Kernel):
             logger.warning("Priors not implemented for SpectralMixtureKernel")
 
         # This kernel does not use the default lengthscale
-        super(SpectralMixtureKernel, self).__init__(active_dims=active_dims)
+        super(SpectralMixtureKernel, self).__init__(
+            active_dims=active_dims, param_transform=param_transform, inv_param_transform=inv_param_transform
+        )
         self.num_mixtures = num_mixtures
         self.batch_size = batch_size
         self.ard_num_dims = ard_num_dims

--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -8,23 +8,32 @@ from ..likelihoods import Likelihood
 from ..lazy import DiagLazyTensor
 from .. import settings
 from ..utils.deprecation import _deprecate_kwarg
+from ..utils.transforms import _get_inv_param_transform
 
 
 class GaussianLikelihood(Likelihood):
     r"""
     """
 
-    def __init__(self, noise_prior=None, batch_size=1, param_transform=torch.exp, **kwargs):
+    def __init__(self, noise_prior=None, batch_size=1, param_transform=torch.exp, inv_param_transform=None, **kwargs):
         noise_prior = _deprecate_kwarg(kwargs, "log_noise_prior", "noise_prior", noise_prior)
         super(GaussianLikelihood, self).__init__()
         self._param_transform = param_transform
+        self._inv_param_transform = _get_inv_param_transform(param_transform, inv_param_transform)
         self.register_parameter(name="log_noise", parameter=torch.nn.Parameter(torch.zeros(batch_size, 1)))
         if noise_prior is not None:
-            self.register_prior("noise_prior", noise_prior, lambda: self.noise)
+            self.register_prior("noise_prior", noise_prior, lambda: self.noise, lambda v: self._set_noise(v))
 
     @property
     def noise(self):
         return self._param_transform(self.log_noise)
+
+    @noise.setter
+    def noise(self, value):
+        self._set_noise(value)
+
+    def _set_noise(self, value):
+        self.initialize(log_noise=self._inv_param_transform(value))
 
     def forward(self, input):
         if not isinstance(input, MultivariateNormal):

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -19,7 +19,15 @@ class MultitaskGaussianLikelihood(GaussianLikelihood):
     """
 
     def __init__(
-        self, num_tasks, rank=0, task_prior=None, batch_size=1, noise_prior=None, param_transform=torch.exp, **kwargs
+        self,
+        num_tasks,
+        rank=0,
+        task_prior=None,
+        batch_size=1,
+        noise_prior=None,
+        param_transform=torch.exp,
+        inv_param_transform=None,
+        **kwargs
     ):
         """
         Args:
@@ -34,13 +42,15 @@ class MultitaskGaussianLikelihood(GaussianLikelihood):
         """
         noise_prior = _deprecate_kwarg(kwargs, "log_noise_prior", "noise_prior", noise_prior)
         super(MultitaskGaussianLikelihood, self).__init__(
-            batch_size=batch_size, noise_prior=noise_prior, param_transform=param_transform
+            batch_size=batch_size,
+            noise_prior=noise_prior,
+            param_transform=param_transform,
+            inv_param_transform=inv_param_transform,
         )
 
         if rank == 0:
             self.register_parameter(
-                name="log_task_noises",
-                parameter=torch.nn.Parameter(torch.zeros(batch_size, num_tasks)),
+                name="log_task_noises", parameter=torch.nn.Parameter(torch.zeros(batch_size, num_tasks))
             )
             if task_prior is not None:
                 raise RuntimeError("Cannot set a `task_prior` if rank=0")

--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -38,7 +38,7 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
         res = res.add(0.5, added_loss)
 
         # Add log probs of priors on the (functions of) parameters
-        for _, prior, closure in self.named_priors():
+        for _, prior, closure, _ in self.named_priors():
             res.add_(prior.log_prob(closure()).sum())
 
         # Scale by the amount of data we have

--- a/gpytorch/mlls/variational_elbo.py
+++ b/gpytorch/mlls/variational_elbo.py
@@ -44,12 +44,12 @@ class VariationalELBO(MarginalLogLikelihood):
 
         if self.combine_terms:
             res = log_likelihood - kl_divergence
-            for _, prior, closure in self.named_priors():
+            for _, prior, closure, _ in self.named_priors():
                 res.add_(prior.log_prob(closure()).sum().div(self.num_data))
             return res
         else:
             log_prior = torch.zeros_like(log_likelihood)
-            for _, prior, closure in self.named_priors():
+            for _, prior, closure, _ in self.named_priors():
                 log_prior.add_(prior.log_prob(closure()).sum())
             return log_likelihood, kl_divergence, log_prior.div(self.num_data)
 
@@ -83,6 +83,6 @@ class VariationalELBOEmpirical(VariationalELBO):
         kl_divergence = kl_divergence.div(self.num_data)
 
         res = log_likelihood - kl_divergence
-        for _, prior, closure in self.named_priors():
+        for _, prior, closure, _ in self.named_priors():
             res.add_(prior.log_prob(closure()).sum().div(self.num_data))
         return res

--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -80,7 +80,7 @@ class Module(nn.Module):
             # Ensure value is contained in support of prior (if present)
             prior_name = "_".join([name, "prior"])
             if prior_name in self._priors:
-                prior, closure = self._priors[prior_name]
+                prior, closure, _ = self._priors[prior_name]
                 try:
                     prior._validate_sample(closure())
                 except ValueError as e:
@@ -144,7 +144,7 @@ class Module(nn.Module):
             raise AttributeError("Cannot assign parameter before Module.__init__() call")
         super(Module, self).register_parameter(name, parameter)
 
-    def register_prior(self, name, prior, arg):
+    def register_prior(self, name, prior, param_or_closure, setting_closure=None):
         """
         Adds a prior to the module. The prior can be accessed as an attribute using the given name.
 
@@ -153,7 +153,7 @@ class Module(nn.Module):
                 The name of the prior
             :attr:`prior` (Prior):
                 The prior to be registered`
-            :attr:`arg` (string or callable):
+            :attr:`param_or_closure` (string or callable):
                 Either the name of the parameter, or a closure (which upon calling evalutes a function on
                 one or more parameters):
                 single parameter without a transform: `.register_prior("foo_prior", foo_prior, "foo_param")`
@@ -161,21 +161,38 @@ class Module(nn.Module):
                 `.register_prior("foo_prior", NormalPrior(0, 1), lambda: torch.log(self.foo_param))`
                 function of multiple parameters:
                 `.register_prior("foo2_prior", foo2_prior, lambda: f(self.param1, self.param2)))`
+            :attr:`setting_closure` (callable, optional):
+                A
         """
-        if isinstance(arg, str):
-            if arg not in self._parameters:
+        if isinstance(param_or_closure, str):
+            if param_or_closure not in self._parameters:
                 raise AttributeError(
-                    "Unknown parameter {name} for {module}".format(name=arg, module=self.__class__.__name__)
+                    "Unknown parameter {name} for {module}".format(
+                        name=param_or_closure, module=self.__class__.__name__
+                    )
                     + "Make sure the parameter is registered before registering a prior."
                 )
 
             def closure():
-                return self._parameters[arg]
+                return self._parameters[param_or_closure]
+
+            if setting_closure is not None:
+                raise RuntimeError("Must specify a closure instead of a parameter name when providing setting_closure")
+
+            def setting_closure(val):
+                return self.initialize(**{param_or_closure: val})
 
         else:
-            closure = arg
+            closure = param_or_closure
         self.add_module(name, prior)
-        self._priors[name] = (prior, closure)
+        self._priors[name] = (prior, closure, setting_closure)
+
+    def sample_from_prior(self, prior_name):
+        """Sample parameter values from prior"""
+        if prior_name not in self._priors:
+            raise RuntimeError("Unknown prior name '{}'".format(prior_name))
+        prior, _, setting_closure = self._priors[prior_name]
+        setting_closure(prior.sample())
 
     def update_added_loss_term(self, name, added_loss_term):
         from .mlls import AddedLossTerm
@@ -209,12 +226,12 @@ def _extract_named_priors(module, memo=None, prefix=""):
     if memo is None:
         memo = set()
     if hasattr(module, "_priors"):
-        for name, (prior, closure) in module._priors.items():
+        for name, (prior, closure, inv_closure) in module._priors.items():
             if prior is not None and prior not in memo:
                 memo.add(prior)
                 full_name = ("." if prefix else "").join([prefix, name])
-                yield full_name, prior, closure
+                yield full_name, prior, closure, inv_closure
     for mname, module_ in module.named_children():
         submodule_prefix = prefix + ("." if prefix else "") + mname
-        for name, prior, closure in _extract_named_priors(module_, memo=memo, prefix=submodule_prefix):
-            yield name, prior, closure
+        for name, prior, closure, inv_closure in _extract_named_priors(module_, memo=memo, prefix=submodule_prefix):
+            yield name, prior, closure, inv_closure

--- a/gpytorch/utils/transforms.py
+++ b/gpytorch/utils/transforms.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+import torch
+
+
+def inv_softplus(x):
+    return torch.log(torch.exp(x) - 1)
+
+
+def _get_inv_param_transform(param_transform, inv_param_transform=None):
+    reg_inv_tf = TRANSFORM_REGISTRY.get(param_transform, None)
+    if reg_inv_tf is None:
+        if inv_param_transform is None:
+            raise RuntimeError("Must specify inv_param_transform for custom param_transforms")
+        return inv_param_transform
+    elif inv_param_transform is not None and reg_inv_tf != inv_param_transform:
+        raise RuntimeError("TODO")
+    return reg_inv_tf
+
+
+TRANSFORM_REGISTRY = {torch.exp: torch.log, torch.nn.functional.softplus: inv_softplus}


### PR DESCRIPTION
This adds the ability to specify inverse parameter transforms, which allows setting parameters in the transformed space. 

This is also needed for sampling parameter values from their associated priors (see #381).

Main changes:
- many constructors take an (optional) arg `inv_param_transform`. For the basic ones like `torch.exp` and `torch.nn.functional.softplus`, there is a mapping the looks up the inverse transform if not specified. This can easily be extended to other common transforms. The inverse transform can always be passed in manually
- modules such as kernels and likelihoods now also have setters for their respective properties that take in a parameter value in transformed space, apply the inverse transform, and set the internal parameter represenation
- `register_prior` now also takes an (optional)`inv_closure` arg, which is a function taking in a tensor (parameter value) in the transformed space, and sets the internal parameter representation appropriately
- modules now have a `sample_from_prior` method that allows sampling parameter values and initializing the respective parameters with the sampled value.

This is not extensively tested yet, and also requires updates to the docstrings.

Finally, this should also soft-deprecate the `log`-version of parameters by adding respective `@properties` and associated setters.