### PR TITLE
Pyro can handle batch models

### DIFF
--- a/gpytorch/lazy/block_diag_lazy_tensor.py
+++ b/gpytorch/lazy/block_diag_lazy_tensor.py
@@ -97,6 +97,21 @@ class BlockDiagLazyTensor(BlockLazyTensor):
             res = res.view(-1)
         return res
 
+    def inv_quad_log_det(self, inv_quad_rhs=None, log_det=False, reduce_inv_quad=True):
+        if inv_quad_rhs is not None:
+            inv_quad_rhs = inv_quad_rhs.view(-1, self.base_lazy_tensor.size(-1), inv_quad_rhs.size(-1))
+        inv_quad_res, log_det_res = self.base_lazy_tensor.inv_quad_log_det(
+            inv_quad_rhs, log_det, reduce_inv_quad=reduce_inv_quad
+        )
+        if inv_quad_res is not None and inv_quad_res.numel():
+            if reduce_inv_quad:
+                inv_quad_res = inv_quad_res.view(*self.batch_shape, -1).sum(-1)
+            else:
+                inv_quad_res = inv_quad_res.view(*self.batch_shape, -1, inv_quad_res.size(-1)).sum(-2)
+        if log_det_res is not None and log_det_res.numel():
+            log_det_res = log_det_res.view(*self.batch_shape, -1).sum(-1)
+        return inv_quad_res, log_det_res
+
     def zero_mean_mvn_samples(self, num_samples):
         res = self.base_lazy_tensor.zero_mean_mvn_samples(num_samples)
         if self.num_blocks is None:

--- a/gpytorch/models/pyro_variational_gp.py
+++ b/gpytorch/models/pyro_variational_gp.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from .abstract_variational_gp import AbstractVariationalGP
+from ..lazy import BlockDiagLazyTensor
 import pyro
 
 
@@ -13,12 +14,22 @@ class PyroVariationalGP(AbstractVariationalGP):
 
     def guide(self, x, y):
         variational_dist = self.variational_strategy.variational_distribution.variational_distribution
+        if len(variational_dist.batch_shape):
+            variational_dist = variational_dist.__class__(
+                variational_dist.mean.contiguous().view(-1),
+                BlockDiagLazyTensor(variational_dist.lazy_covariance_matrix),
+            )
         pyro.sample(self.name_prefix + "._inducing_values", variational_dist)
 
     def model(self, x, y):
         pyro.module(self.name_prefix + ".gp_prior", self)
         variational_dist_f = self(x)
         prior_dist = self.variational_strategy.prior_distribution
+        if len(prior_dist.batch_shape):
+            prior_dist = prior_dist.__class__(
+                prior_dist.mean.contiguous().view(-1),
+                BlockDiagLazyTensor(prior_dist.lazy_covariance_matrix),
+            )
         inducing_value_samples = pyro.sample(self.name_prefix + "._inducing_values", prior_dist)
         sample_shape = inducing_value_samples.shape[: inducing_value_samples.dim() - len(prior_dist.shape())]
 

--- a/gpytorch/variational/cholesky_variational_distribution.py
+++ b/gpytorch/variational/cholesky_variational_distribution.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 import torch
-from ..lazy import CholLazyTensor, DiagLazyTensor, NonLazyTensor
+from ..functions import add_diag
+from ..lazy import CholLazyTensor, NonLazyTensor
 from ..distributions import MultivariateNormal
 from .variational_distribution import VariationalDistribution
 
@@ -47,16 +48,16 @@ class CholeskyVariationalDistribution(VariationalDistribution):
         that the diagonal remains positive.
         """
         chol_variational_covar = self.chol_variational_covar
+        diagonal = NonLazyTensor(chol_variational_covar).diag()
         dtype = chol_variational_covar.dtype
         device = chol_variational_covar.device
-        mask = torch.ones(self.chol_variational_covar.shape[-2:], dtype=dtype, device=device).triu()
-        chol_variational_covar = chol_variational_covar.mul(mask)
 
-        # Make sure that the diagonal is positive
-        diagonal = NonLazyTensor(chol_variational_covar).diag()
-        diag_correction = torch.clamp(diagonal, 1e-6, 1e10)
-        chol_variational_covar = chol_variational_covar + DiagLazyTensor(diag_correction - diagonal).evaluate()
+        # First make the cholesky factor is upper triangular
+        # And has a positive diagonal
+        strictly_lower_mask = torch.ones(self.chol_variational_covar.shape[-2:], dtype=dtype, device=device).triu(1)
+        diagonal = torch.nn.functional.softplus(diagonal)
+        chol_variational_covar = add_diag(chol_variational_covar.mul(strictly_lower_mask), diagonal)
 
-        # NOw construct the actual matrix
+        # Now construct the actual matrix
         variational_covar = CholLazyTensor(chol_variational_covar.transpose(-1, -2))
         return MultivariateNormal(self.variational_mean, variational_covar)


### PR DESCRIPTION
There is a better fix for batch VGP models with Pyro, but this is a simple solution for right now.

All batch Gaussian distributions touched by Pyro (`p_u`, `q_u`, `q_f`) are all converted into non-batch variational distributions using a BlockDiagLazyTensor. This has no effect on the `log_prob` or `kl_divergence` terms in the equations.