### PR TITLE
Remove _batch_get_indices function from LazyTensors

### DIFF
--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -18,17 +18,11 @@ class BatchRepeatLazyTensor(LazyTensor):
         self.base_lazy_tensor = base_lazy_tensor
         self.batch_repeat = batch_repeat
 
-    def _batch_get_indices(self, batch_indices, row_indices, col_indices):
-        return self._get_indices(batch_indices, row_indices=row_indices, col_indices=col_indices)
-
-    def _get_indices(self, *batch_indices, row_indices, col_indices):
+    def _get_indices(self, row_indices, col_indices, *batch_indices):
         num_true_batch_dims = len(self.base_lazy_tensor.batch_shape)
         batch_indices = [index % size for index, size in zip(batch_indices, self._padded_base_batch_shape)]
         batch_indices = batch_indices[-num_true_batch_dims:] if num_true_batch_dims else []
-        if len(batch_indices) == 1:
-            return self.base_lazy_tensor._batch_get_indices(*batch_indices, row_indices, col_indices)
-        else:
-            return self.base_lazy_tensor._get_indices(*batch_indices, row_indices, col_indices)
+        return self.base_lazy_tensor._get_indices(row_indices, col_indices, *batch_indices)
 
     def _matmul(self, rhs):
         rhs = self._move_repeat_batches_to_columns(rhs)

--- a/gpytorch/lazy/block_lazy_tensor.py
+++ b/gpytorch/lazy/block_lazy_tensor.py
@@ -139,14 +139,14 @@ class BlockLazyTensor(LazyTensor):
                                         batch_index.numel(), left_index.numel(), right_index.numel()
                                     )
                                 )
-                            return new_var._batch_get_indices(batch_index, left_index, right_index)
+                            return new_var._get_indices(left_index, right_index, batch_index)
                         else:
                             batch_size = batch_index.numel()
                             row_col_size = left_index.numel()
                             batch_index = batch_index.unsqueeze(1).repeat(1, row_col_size).view(-1)
                             left_index = left_index.unsqueeze(1).repeat(batch_size, 1).view(-1)
                             right_index = right_index.unsqueeze(1).repeat(batch_size, 1).view(-1)
-                            res = new_var._batch_get_indices(batch_index, left_index, right_index)
+                            res = new_var._get_indices(left_index, right_index, batch_index)
                             return res.view(batch_size, row_col_size)
 
                 # Normal case: we have to do some processing on eithe rthe rows or columns

--- a/gpytorch/lazy/constant_mul_lazy_tensor.py
+++ b/gpytorch/lazy/constant_mul_lazy_tensor.py
@@ -119,12 +119,8 @@ class ConstantMulLazyTensor(LazyTensor):
     def _transpose_nonbatch(self):
         return ConstantMulLazyTensor(self.base_lazy_tensor._transpose_nonbatch(), self.constant)
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
-        res = self.base_lazy_tensor._batch_get_indices(batch_indices, left_indices, right_indices)
-        return self.constant.expand_as(res) * res
-
-    def _get_indices(self, left_indices, right_indices):
-        res = self.base_lazy_tensor._get_indices(left_indices, right_indices)
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
+        res = self.base_lazy_tensor._get_indices(left_indices, right_indices, *batch_indices)
         return self.constant.expand_as(res) * res
 
     def _approx_diag(self):

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from itertools import product
-import warnings
 import torch
 from .lazy_tensor import LazyTensor
 from .root_lazy_tensor import RootLazyTensor
@@ -27,10 +26,6 @@ class DiagLazyTensor(LazyTensor):
         from .added_diag_lazy_tensor import AddedDiagLazyTensor
 
         return AddedDiagLazyTensor(other, self)
-
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
-        warnings.warn("_batch_get_indices is deprecated - use _get_indices instead", DeprecationWarning)
-        return self._get_indices(left_indices, right_indices, batch_indices)
 
     def _get_indices(self, left_indices, right_indices, *batch_indices):
         """Extract elements from the LazyTensor. Supports arbitrary batch sizes.

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -193,7 +193,7 @@ class KroneckerProductLazyTensor(LazyTensor):
     def _transpose_nonbatch(self):
         return self.__class__(*(lazy_tensor._transpose_nonbatch() for lazy_tensor in self.lazy_tensors), **self._kwargs)
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
         res = torch.ones(left_indices.size(), dtype=self.dtype, device=self.device)
         left_size = self.size(-2)
         right_size = self.size(-1)
@@ -203,22 +203,7 @@ class KroneckerProductLazyTensor(LazyTensor):
             left_indices_i = left_indices.div(left_size)
             right_indices_i = right_indices.div(right_size)
 
-            res = res * lazy_tensor._batch_get_indices(batch_indices, left_indices_i, right_indices_i)
-            left_indices = left_indices - (left_indices_i * left_size)
-            right_indices = right_indices - (right_indices_i * right_size)
-        return res
-
-    def _get_indices(self, left_indices, right_indices):
-        res = torch.ones(left_indices.size(), dtype=self.dtype, device=self.device)
-        left_size = self.size(-2)
-        right_size = self.size(-1)
-        for lazy_tensor in list(self.lazy_tensors)[::-1]:
-            left_size = left_size / lazy_tensor.size(-2)
-            right_size = right_size / lazy_tensor.size(-1)
-            left_indices_i = left_indices.div(left_size)
-            right_indices_i = right_indices.div(right_size)
-
-            res = res * lazy_tensor._get_indices(left_indices_i, right_indices_i)
+            res = res * lazy_tensor._get_indices(left_indices_i, right_indices_i, *batch_indices)
             left_indices = left_indices - (left_indices_i * left_size)
             right_indices = right_indices - (right_indices_i * right_size)
         return res

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -44,22 +44,11 @@ class LazyEvaluatedKernelTensor(LazyTensor):
     def _transpose_nonbatch(self):
         return self.__class__(self.kernel, self.x2, self.x1, **self.params)
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
         from ..kernels import Kernel
 
-        x1 = self.x1[batch_indices, left_indices, :].unsqueeze(0)
-        x2 = self.x2[batch_indices, right_indices, :].unsqueeze(0)
-        res = super(Kernel, self.kernel).__call__(x1.transpose(-1, -2), x2.transpose(-1, -2))
-        if isinstance(res, LazyTensor):
-            res = res.evaluate()
-        res = res.view(-1)
-        return res
-
-    def _get_indices(self, left_indices, right_indices):
-        from ..kernels import Kernel
-
-        x1 = self.x1[left_indices, :].unsqueeze(0)
-        x2 = self.x2[right_indices, :].unsqueeze(0)
+        x1 = self.x1.__getitem__((*batch_indices, left_indices)).unsqueeze(0)
+        x2 = self.x2.__getitem__((*batch_indices, right_indices)).unsqueeze(0)
         res = super(Kernel, self.kernel).__call__(x1.transpose(0, 1), x2.transpose(0, 1))
         if isinstance(res, LazyTensor):
             res = res.evaluate()

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1296,7 +1296,6 @@ class LazyTensor(object):
             return new_lazy_tensor
 
         # Special case: if both row and col are tensor indexed, then we use _get_indices
-        # or _get_indices
         if torch.is_tensor(left_index) and torch.is_tensor(right_index):
             if left_index.numel() != right_index.numel():
                 raise RuntimeError(

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -45,7 +45,7 @@ class LazyTensor(object):
     * :func:`~gpytorch.lazy.LazyTensor._transpose_nonbatch`, which returns a transposed version of the LazyTensor
 
     In addition to these, a LazyTensor may need to define the :func:`~gpytorch.lazy.LazyTensor._transpose_nonbatch`,
-    :func:`~gpytorch.lazy.LazyTensor._get_indices`, and :func:`~gpytorch.lazy.LazyTensor._batch_get_indices`
+    :func:`~gpytorch.lazy.LazyTensor._get_indices`, and :func:`~gpytorch.lazy.LazyTensor._get_indices`
     functions in special cases. See the documentation for these methods for details.
 
     .. note::
@@ -453,7 +453,7 @@ class LazyTensor(object):
             batch_iter = torch.arange(0, size[0], dtype=torch.long, device=self.device)
             batch_iter = batch_iter.unsqueeze(1).repeat(1, size[1]).view(-1)
             row_col_iter = row_col_iter.unsqueeze(1).repeat(size[0], 1).view(-1)
-            return self._batch_get_indices(batch_iter, row_col_iter, row_col_iter).view(size[0], size[1])
+            return self._get_indices(row_col_iter, row_col_iter, batch_iter).view(size[0], size[1])
         else:
             return self._get_indices(row_col_iter, row_col_iter)
 
@@ -1296,7 +1296,7 @@ class LazyTensor(object):
             return new_lazy_tensor
 
         # Special case: if both row and col are tensor indexed, then we use _get_indices
-        # or _batch_get_indices
+        # or _get_indices
         if torch.is_tensor(left_index) and torch.is_tensor(right_index):
             if left_index.numel() != right_index.numel():
                 raise RuntimeError(
@@ -1317,14 +1317,14 @@ class LazyTensor(object):
                                 batch_index.numel(), left_index.numel(), right_index.numel()
                             )
                         )
-                    return new_lazy_tensor._batch_get_indices(batch_index, left_index, right_index)
+                    return new_lazy_tensor._get_indices(left_index, right_index, batch_index)
                 else:
                     batch_size = batch_index.numel()
                     row_col_size = left_index.numel()
                     batch_index = batch_index.unsqueeze(1).repeat(1, row_col_size).view(-1)
                     left_index = left_index.unsqueeze(1).repeat(batch_size, 1).view(-1)
                     right_index = right_index.unsqueeze(1).repeat(batch_size, 1).view(-1)
-                    res = new_lazy_tensor._batch_get_indices(batch_index, left_index, right_index)
+                    res = new_lazy_tensor._get_indices(left_index, right_index, batch_index)
                     return res.view(batch_size, row_col_size)
 
         # Normal case: we have to do some processing on eithe rthe rows or columns

--- a/gpytorch/lazy/mul_lazy_tensor.py
+++ b/gpytorch/lazy/mul_lazy_tensor.py
@@ -224,17 +224,10 @@ class MulLazyTensor(LazyTensor):
     def _size(self):
         return self.lazy_tensors[0].size()
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
-        res = prod(
-            [
-                lazy_tensor._batch_get_indices(batch_indices, left_indices, right_indices)
-                for lazy_tensor in self.lazy_tensors
-            ]
-        )
-        return res
-
-    def _get_indices(self, left_indices, right_indices):
-        res = prod([lazy_tensor._get_indices(left_indices, right_indices) for lazy_tensor in self.lazy_tensors])
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
+        res = prod([
+            lazy_tensor._get_indices(left_indices, right_indices, *batch_indices) for lazy_tensor in self.lazy_tensors
+        ])
         return res
 
     def _transpose_nonbatch(self):

--- a/gpytorch/lazy/non_lazy_tensor.py
+++ b/gpytorch/lazy/non_lazy_tensor.py
@@ -34,11 +34,8 @@ class NonLazyTensor(LazyTensor):
     def _transpose_nonbatch(self):
         return NonLazyTensor(self.tensor.transpose(-1, -2))
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
-        return self.tensor[batch_indices, left_indices, right_indices]
-
-    def _get_indices(self, left_indices, right_indices):
-        return self.tensor[left_indices, right_indices]
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
+        return self.tensor.__getitem__((*batch_indices, left_indices, right_indices))
 
     def diag(self):
         if self.tensor.ndimension() < 3:

--- a/gpytorch/lazy/sum_lazy_tensor.py
+++ b/gpytorch/lazy/sum_lazy_tensor.py
@@ -37,14 +37,11 @@ class SumLazyTensor(LazyTensor):
         lazy_tensors_t = [lazy_tensor.transpose(-1, -2) for lazy_tensor in self.lazy_tensors]
         return SumLazyTensor(*lazy_tensors_t)
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
         return sum(
-            lazy_tensor._batch_get_indices(batch_indices, left_indices, right_indices)
+            lazy_tensor._get_indices(left_indices, right_indices, *batch_indices)
             for lazy_tensor in self.lazy_tensors
         )
-
-    def _get_indices(self, left_indices, right_indices):
-        return sum(lazy_tensor._get_indices(left_indices, right_indices) for lazy_tensor in self.lazy_tensors)
 
     def _exact_predictive_covar_inv_quad_form_cache(self, train_train_covar_inv_root, test_train_covar):
         return tuple(

--- a/gpytorch/lazy/toeplitz_lazy_tensor.py
+++ b/gpytorch/lazy/toeplitz_lazy_tensor.py
@@ -36,15 +36,10 @@ class ToeplitzLazyTensor(LazyTensor):
     def _transpose_nonbatch(self):
         return ToeplitzLazyTensor(self.column)
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
         n_grid = self.column.size(-1)
         toeplitz_indices = (left_indices - right_indices).fmod(n_grid).abs().long()
-        return self.column[batch_indices, toeplitz_indices]
-
-    def _get_indices(self, left_indices, right_indices):
-        n_grid = self.column.size(-1)
-        toeplitz_indices = (left_indices - right_indices).fmod(n_grid).abs().long()
-        return self.column.index_select(0, toeplitz_indices)
+        return self.column.__getitem__((*batch_indices, toeplitz_indices))
 
     def add_jitter(self, jitter_val=1e-3):
         jitter = torch.zeros_like(self.column)


### PR DESCRIPTION
`_get_indices` now (in theory) supports an arbitrary number of batch dimensions. This PR uses `_get_indices` everywhere now, and remove the `_batch_get_indices` method from LazyTensors.

In practice, most LazyTensors only support 0 or 1 batch dimensions. However, this sets the infrastructure up for future LazyTensors that use multiple batch dimensions.

A step towards achieving #369 