### PR TITLE
LazyTensor.__getitem__ supports ellipsis

### DIFF
--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -18,17 +18,11 @@ class BatchRepeatLazyTensor(LazyTensor):
         self.base_lazy_tensor = base_lazy_tensor
         self.batch_repeat = batch_repeat
 
-    def _batch_get_indices(self, batch_indices, row_indices, col_indices):
-        return self._get_indices(batch_indices, row_indices=row_indices, col_indices=col_indices)
-
-    def _get_indices(self, *batch_indices, row_indices, col_indices):
+    def _get_indices(self, row_indices, col_indices, *batch_indices):
         num_true_batch_dims = len(self.base_lazy_tensor.batch_shape)
         batch_indices = [index % size for index, size in zip(batch_indices, self._padded_base_batch_shape)]
         batch_indices = batch_indices[-num_true_batch_dims:] if num_true_batch_dims else []
-        if len(batch_indices) == 1:
-            return self.base_lazy_tensor._batch_get_indices(*batch_indices, row_indices, col_indices)
-        else:
-            return self.base_lazy_tensor._get_indices(*batch_indices, row_indices, col_indices)
+        return self.base_lazy_tensor._get_indices(row_indices, col_indices, *batch_indices)
 
     def _matmul(self, rhs):
         rhs = self._move_repeat_batches_to_columns(rhs)

--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -169,10 +169,6 @@ class BatchRepeatLazyTensor(LazyTensor):
         )
 
     def __getitem__(self, index):
-        """
-        Supports subindexing of the matrix this LazyTensor represents. This may return either another
-        :obj:`gpytorch.lazy.LazyTensor` or a :obj:`torch.tensor` depending on the exact implementation.
-        """
         args = []
         kwargs = self.base_lazy_tensor._kwargs
         num_base_batch_dims = len(self.base_lazy_tensor.batch_shape)

--- a/gpytorch/lazy/block_lazy_tensor.py
+++ b/gpytorch/lazy/block_lazy_tensor.py
@@ -139,14 +139,14 @@ class BlockLazyTensor(LazyTensor):
                                         batch_index.numel(), left_index.numel(), right_index.numel()
                                     )
                                 )
-                            return new_var._batch_get_indices(batch_index, left_index, right_index)
+                            return new_var._get_indices(left_index, right_index, batch_index)
                         else:
                             batch_size = batch_index.numel()
                             row_col_size = left_index.numel()
                             batch_index = batch_index.unsqueeze(1).repeat(1, row_col_size).view(-1)
                             left_index = left_index.unsqueeze(1).repeat(batch_size, 1).view(-1)
                             right_index = right_index.unsqueeze(1).repeat(batch_size, 1).view(-1)
-                            res = new_var._batch_get_indices(batch_index, left_index, right_index)
+                            res = new_var._get_indices(left_index, right_index, batch_index)
                             return res.view(batch_size, row_col_size)
 
                 # Normal case: we have to do some processing on eithe rthe rows or columns

--- a/gpytorch/lazy/constant_mul_lazy_tensor.py
+++ b/gpytorch/lazy/constant_mul_lazy_tensor.py
@@ -119,12 +119,8 @@ class ConstantMulLazyTensor(LazyTensor):
     def _transpose_nonbatch(self):
         return ConstantMulLazyTensor(self.base_lazy_tensor._transpose_nonbatch(), self.constant)
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
-        res = self.base_lazy_tensor._batch_get_indices(batch_indices, left_indices, right_indices)
-        return self.constant.expand_as(res) * res
-
-    def _get_indices(self, left_indices, right_indices):
-        res = self.base_lazy_tensor._get_indices(left_indices, right_indices)
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
+        res = self.base_lazy_tensor._get_indices(left_indices, right_indices, *batch_indices)
         return self.constant.expand_as(res) * res
 
     def _approx_diag(self):

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from itertools import product
-import warnings
 import torch
 from .lazy_tensor import LazyTensor
 from .root_lazy_tensor import RootLazyTensor
@@ -27,10 +26,6 @@ class DiagLazyTensor(LazyTensor):
         from .added_diag_lazy_tensor import AddedDiagLazyTensor
 
         return AddedDiagLazyTensor(other, self)
-
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
-        warnings.warn("_batch_get_indices is deprecated - use _get_indices instead", DeprecationWarning)
-        return self._get_indices(left_indices, right_indices, batch_indices)
 
     def _get_indices(self, left_indices, right_indices, *batch_indices):
         """Extract elements from the LazyTensor. Supports arbitrary batch sizes.

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -193,7 +193,7 @@ class KroneckerProductLazyTensor(LazyTensor):
     def _transpose_nonbatch(self):
         return self.__class__(*(lazy_tensor._transpose_nonbatch() for lazy_tensor in self.lazy_tensors), **self._kwargs)
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
         res = torch.ones(left_indices.size(), dtype=self.dtype, device=self.device)
         left_size = self.size(-2)
         right_size = self.size(-1)
@@ -203,22 +203,7 @@ class KroneckerProductLazyTensor(LazyTensor):
             left_indices_i = left_indices.div(left_size)
             right_indices_i = right_indices.div(right_size)
 
-            res = res * lazy_tensor._batch_get_indices(batch_indices, left_indices_i, right_indices_i)
-            left_indices = left_indices - (left_indices_i * left_size)
-            right_indices = right_indices - (right_indices_i * right_size)
-        return res
-
-    def _get_indices(self, left_indices, right_indices):
-        res = torch.ones(left_indices.size(), dtype=self.dtype, device=self.device)
-        left_size = self.size(-2)
-        right_size = self.size(-1)
-        for lazy_tensor in list(self.lazy_tensors)[::-1]:
-            left_size = left_size / lazy_tensor.size(-2)
-            right_size = right_size / lazy_tensor.size(-1)
-            left_indices_i = left_indices.div(left_size)
-            right_indices_i = right_indices.div(right_size)
-
-            res = res * lazy_tensor._get_indices(left_indices_i, right_indices_i)
+            res = res * lazy_tensor._get_indices(left_indices_i, right_indices_i, *batch_indices)
             left_indices = left_indices - (left_indices_i * left_size)
             right_indices = right_indices - (right_indices_i * right_size)
         return res

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -44,22 +44,11 @@ class LazyEvaluatedKernelTensor(LazyTensor):
     def _transpose_nonbatch(self):
         return self.__class__(self.kernel, self.x2, self.x1, **self.params)
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
         from ..kernels import Kernel
 
-        x1 = self.x1[batch_indices, left_indices, :].unsqueeze(0)
-        x2 = self.x2[batch_indices, right_indices, :].unsqueeze(0)
-        res = super(Kernel, self.kernel).__call__(x1.transpose(-1, -2), x2.transpose(-1, -2))
-        if isinstance(res, LazyTensor):
-            res = res.evaluate()
-        res = res.view(-1)
-        return res
-
-    def _get_indices(self, left_indices, right_indices):
-        from ..kernels import Kernel
-
-        x1 = self.x1[left_indices, :].unsqueeze(0)
-        x2 = self.x2[right_indices, :].unsqueeze(0)
+        x1 = self.x1.__getitem__((*batch_indices, left_indices)).unsqueeze(0)
+        x2 = self.x2.__getitem__((*batch_indices, right_indices)).unsqueeze(0)
         res = super(Kernel, self.kernel).__call__(x1.transpose(0, 1), x2.transpose(0, 1))
         if isinstance(res, LazyTensor):
             res = res.evaluate()

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -45,7 +45,7 @@ class LazyTensor(object):
     * :func:`~gpytorch.lazy.LazyTensor._transpose_nonbatch`, which returns a transposed version of the LazyTensor
 
     In addition to these, a LazyTensor may need to define the :func:`~gpytorch.lazy.LazyTensor._transpose_nonbatch`,
-    :func:`~gpytorch.lazy.LazyTensor._get_indices`, and :func:`~gpytorch.lazy.LazyTensor._batch_get_indices`
+    :func:`~gpytorch.lazy.LazyTensor._get_indices`, and :func:`~gpytorch.lazy.LazyTensor._get_indices`
     functions in special cases. See the documentation for these methods for details.
 
     .. note::
@@ -453,7 +453,7 @@ class LazyTensor(object):
             batch_iter = torch.arange(0, size[0], dtype=torch.long, device=self.device)
             batch_iter = batch_iter.unsqueeze(1).repeat(1, size[1]).view(-1)
             row_col_iter = row_col_iter.unsqueeze(1).repeat(size[0], 1).view(-1)
-            return self._batch_get_indices(batch_iter, row_col_iter, row_col_iter).view(size[0], size[1])
+            return self._get_indices(row_col_iter, row_col_iter, batch_iter).view(size[0], size[1])
         else:
             return self._get_indices(row_col_iter, row_col_iter)
 
@@ -1296,7 +1296,7 @@ class LazyTensor(object):
             return new_lazy_tensor
 
         # Special case: if both row and col are tensor indexed, then we use _get_indices
-        # or _batch_get_indices
+        # or _get_indices
         if torch.is_tensor(left_index) and torch.is_tensor(right_index):
             if left_index.numel() != right_index.numel():
                 raise RuntimeError(
@@ -1317,14 +1317,14 @@ class LazyTensor(object):
                                 batch_index.numel(), left_index.numel(), right_index.numel()
                             )
                         )
-                    return new_lazy_tensor._batch_get_indices(batch_index, left_index, right_index)
+                    return new_lazy_tensor._get_indices(left_index, right_index, batch_index)
                 else:
                     batch_size = batch_index.numel()
                     row_col_size = left_index.numel()
                     batch_index = batch_index.unsqueeze(1).repeat(1, row_col_size).view(-1)
                     left_index = left_index.unsqueeze(1).repeat(batch_size, 1).view(-1)
                     right_index = right_index.unsqueeze(1).repeat(batch_size, 1).view(-1)
-                    res = new_lazy_tensor._batch_get_indices(batch_index, left_index, right_index)
+                    res = new_lazy_tensor._get_indices(left_index, right_index, batch_index)
                     return res.view(batch_size, row_col_size)
 
         # Normal case: we have to do some processing on eithe rthe rows or columns

--- a/gpytorch/lazy/mul_lazy_tensor.py
+++ b/gpytorch/lazy/mul_lazy_tensor.py
@@ -224,17 +224,10 @@ class MulLazyTensor(LazyTensor):
     def _size(self):
         return self.lazy_tensors[0].size()
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
-        res = prod(
-            [
-                lazy_tensor._batch_get_indices(batch_indices, left_indices, right_indices)
-                for lazy_tensor in self.lazy_tensors
-            ]
-        )
-        return res
-
-    def _get_indices(self, left_indices, right_indices):
-        res = prod([lazy_tensor._get_indices(left_indices, right_indices) for lazy_tensor in self.lazy_tensors])
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
+        res = prod([
+            lazy_tensor._get_indices(left_indices, right_indices, *batch_indices) for lazy_tensor in self.lazy_tensors
+        ])
         return res
 
     def _transpose_nonbatch(self):

--- a/gpytorch/lazy/non_lazy_tensor.py
+++ b/gpytorch/lazy/non_lazy_tensor.py
@@ -34,11 +34,8 @@ class NonLazyTensor(LazyTensor):
     def _transpose_nonbatch(self):
         return NonLazyTensor(self.tensor.transpose(-1, -2))
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
-        return self.tensor[batch_indices, left_indices, right_indices]
-
-    def _get_indices(self, left_indices, right_indices):
-        return self.tensor[left_indices, right_indices]
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
+        return self.tensor.__getitem__((*batch_indices, left_indices, right_indices))
 
     def diag(self):
         if self.tensor.ndimension() < 3:

--- a/gpytorch/lazy/sum_lazy_tensor.py
+++ b/gpytorch/lazy/sum_lazy_tensor.py
@@ -37,14 +37,11 @@ class SumLazyTensor(LazyTensor):
         lazy_tensors_t = [lazy_tensor.transpose(-1, -2) for lazy_tensor in self.lazy_tensors]
         return SumLazyTensor(*lazy_tensors_t)
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
         return sum(
-            lazy_tensor._batch_get_indices(batch_indices, left_indices, right_indices)
+            lazy_tensor._get_indices(left_indices, right_indices, *batch_indices)
             for lazy_tensor in self.lazy_tensors
         )
-
-    def _get_indices(self, left_indices, right_indices):
-        return sum(lazy_tensor._get_indices(left_indices, right_indices) for lazy_tensor in self.lazy_tensors)
 
     def _exact_predictive_covar_inv_quad_form_cache(self, train_train_covar_inv_root, test_train_covar):
         return tuple(

--- a/gpytorch/lazy/sum_lazy_tensor.py
+++ b/gpytorch/lazy/sum_lazy_tensor.py
@@ -88,10 +88,3 @@ class SumLazyTensor(LazyTensor):
 
     def sum_batch(self, sum_batch_size=None):
         return self.__class__(*(lazy_tensor.sum_batch(sum_batch_size) for lazy_tensor in self.lazy_tensors))
-
-    def __getitem__(self, index):
-        results = tuple(lazy_tensor.__getitem__(index) for lazy_tensor in self.lazy_tensors)
-        if isinstance(results[0], LazyTensor):
-            return SumLazyTensor(*results)
-        else:
-            return sum(results)

--- a/gpytorch/lazy/toeplitz_lazy_tensor.py
+++ b/gpytorch/lazy/toeplitz_lazy_tensor.py
@@ -36,15 +36,10 @@ class ToeplitzLazyTensor(LazyTensor):
     def _transpose_nonbatch(self):
         return ToeplitzLazyTensor(self.column)
 
-    def _batch_get_indices(self, batch_indices, left_indices, right_indices):
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
         n_grid = self.column.size(-1)
         toeplitz_indices = (left_indices - right_indices).fmod(n_grid).abs().long()
-        return self.column[batch_indices, toeplitz_indices]
-
-    def _get_indices(self, left_indices, right_indices):
-        n_grid = self.column.size(-1)
-        toeplitz_indices = (left_indices - right_indices).fmod(n_grid).abs().long()
-        return self.column.index_select(0, toeplitz_indices)
+        return self.column.__getitem__((*batch_indices, toeplitz_indices))
 
     def add_jitter(self, jitter_val=1e-3):
         jitter = torch.zeros_like(self.column)

--- a/gpytorch/lazy/zero_lazy_tensor.py
+++ b/gpytorch/lazy/zero_lazy_tensor.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 import torch
-from . import LazyTensor
+from .lazy_tensor import LazyTensor
+from .. import settings
 
 
 class ZeroLazyTensor(LazyTensor):
@@ -144,8 +145,24 @@ class ZeroLazyTensor(LazyTensor):
         return self
 
     def __getitem__(self, index):
-        index = list(index) if isinstance(index, tuple) else [index]
         ndimension = self.ndimension()
+        index = list(index) if isinstance(index, tuple) else [index]
+
+        # Handle the ellipsis
+        # Find the index of the ellipsis
+        ellipsis_locs = [index for index, item in enumerate(index) if item is Ellipsis]
+        if settings.debug.on():
+            if len(ellipsis_locs) > 1:
+                raise RuntimeError(
+                    "Cannot have multiple ellipsis in a __getitem__ call. LazyTensor {} "
+                    " received index {}.".format(self, index)
+                )
+        if len(ellipsis_locs) == 1:
+            ellipsis_loc = ellipsis_locs[0]
+            num_to_fill_in = ndimension - (len(index) - 1)
+            index = index[:ellipsis_loc] + [slice(None, None, None)] * num_to_fill_in + index[ellipsis_loc + 1:]
+
+        # Pad the index with empty slices
         index += [slice(None, None, None)] * (ndimension - len(index))
 
         has_added_tensor_index = False

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -87,20 +87,12 @@ class VariationalStrategy(Module):
             full_output = self.model.forward(full_inputs)
             full_mean, full_covar = full_output.mean, full_output.lazy_covariance_matrix
 
-            if full_covar.dim() == 3:
-                test_mean = full_mean[:, n_induc:]
-                induc_mean = full_mean[:, :n_induc]
-                induc_induc_covar = full_covar[:, :n_induc, :n_induc].add_jitter()
-                induc_data_covar = full_covar[:, :n_induc, n_induc:]
-                data_data_covar = full_covar[:, n_induc:, n_induc:]
-                var_dist_mean = variational_dist.mean
-            else:
-                test_mean = full_mean[n_induc:]
-                induc_mean = full_mean[:n_induc]
-                induc_induc_covar = full_covar[:n_induc, :n_induc].add_jitter()
-                induc_data_covar = full_covar[:n_induc, n_induc:]
-                data_data_covar = full_covar[n_induc:, n_induc:]
-                var_dist_mean = variational_dist.mean
+            test_mean = full_mean[..., n_induc:]
+            induc_mean = full_mean[..., :n_induc]
+            induc_induc_covar = full_covar[..., :n_induc, :n_induc].add_jitter()
+            induc_data_covar = full_covar[..., :n_induc, n_induc:]
+            data_data_covar = full_covar[..., n_induc:, n_induc:]
+            var_dist_mean = variational_dist.mean
 
             # Cache the prior distribution, for faster training
             if self.training:

--- a/test/lazy/_lazy_tensor_test_case.py
+++ b/test/lazy/_lazy_tensor_test_case.py
@@ -91,6 +91,18 @@ class RectangularLazyTensorTestCase(object):
         res = lazy_tensor[0:2, :].evaluate()
         actual = evaluated[0:2, :]
         self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+        res = lazy_tensor[..., 0:2].evaluate()
+        actual = evaluated[..., 0:2]
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+        res = lazy_tensor[0:2, ...].evaluate()
+        actual = evaluated[0:2, ...]
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+        res = lazy_tensor[..., 0:2, 2]
+        actual = evaluated[..., 0:2, 2]
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+        res = lazy_tensor[0:2, ..., 2]
+        actual = evaluated[0:2, ..., 2]
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
 
     def test_getitem_tensor_index(self):
         lazy_tensor = self.create_lazy_tensor()
@@ -103,6 +115,15 @@ class RectangularLazyTensorTestCase(object):
         res, actual = lazy_tensor[index], evaluated[index]
         self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
         index = (slice(None, None, None), torch.tensor([0, 0, 1, 2]))
+        res, actual = lazy_tensor[index], evaluated[index]
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+        index = (torch.tensor([0, 0, 1, 2]), Ellipsis)
+        res, actual = lazy_tensor[index], evaluated[index]
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+        index = (Ellipsis, torch.tensor([0, 0, 1, 2]))
+        res, actual = lazy_tensor[index], evaluated[index]
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+        index = (Ellipsis, torch.tensor([0, 0, 1, 2]), torch.tensor([0, 1, 0, 2]))
         res, actual = lazy_tensor[index], evaluated[index]
         self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
 
@@ -307,6 +328,14 @@ class RectangularBatchLazyTensorTestCase(object):
             actual = evaluated.__getitem__((*batch_index, slice(1, None, None), 2))
             self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
 
+        # Ellipsis
+        res = lazy_tensor.__getitem__((Ellipsis, slice(1, None, None), 2))
+        actual = evaluated.__getitem__((Ellipsis, slice(1, None, None), 2))
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+        res = lazy_tensor.__getitem__((slice(1, None, None), Ellipsis, 2))
+        actual = evaluated.__getitem__((slice(1, None, None), Ellipsis, 2))
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+
     def test_getitem_tensor_index(self):
         lazy_tensor = self.create_lazy_tensor()
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)
@@ -326,6 +355,14 @@ class RectangularBatchLazyTensorTestCase(object):
             index = (*batch_index, slice(None, None, None), slice(None, None, None))
             res, actual = lazy_tensor[index].evaluate(), evaluated[index]
             self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+
+        # Ellipsis
+        res = lazy_tensor.__getitem__((Ellipsis, torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1])))
+        actual = evaluated.__getitem__((Ellipsis, torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1])))
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+        res = lazy_tensor.__getitem__((torch.tensor([0, 1, 0, 1]), Ellipsis, torch.tensor([1, 2, 0, 1])))
+        actual = evaluated.__getitem__((torch.tensor([0, 1, 0, 1]), Ellipsis, torch.tensor([1, 2, 0, 1])))
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
 
 
 class BatchLazyTensorTestCase(RectangularBatchLazyTensorTestCase):

--- a/test/lazy/test_zero_lazy_tensor.py
+++ b/test/lazy/test_zero_lazy_tensor.py
@@ -35,6 +35,17 @@ class TestZeroLazyTensor(unittest.TestCase):
         self.assertLess(torch.norm(res_two - torch.zeros(5, 2, 3)), 1e-4)
         self.assertLess(torch.norm(res_three - torch.zeros(5, 4, 2)), 1e-4)
 
+    def test_getitem_ellipsis(self):
+        lv = ZeroLazyTensor(5, 4, 3)
+
+        res_one = lv[[0, 1]].evaluate()
+        res_two = lv[:, [0, 1], ...].evaluate()
+        res_three = lv[..., [0, 2]].evaluate()
+
+        self.assertLess(torch.norm(res_one - torch.zeros(2, 4, 3)), 1e-4)
+        self.assertLess(torch.norm(res_two - torch.zeros(5, 2, 3)), 1e-4)
+        self.assertLess(torch.norm(res_three - torch.zeros(5, 4, 2)), 1e-4)
+
     def test_get_item_tensor_index(self):
         # Tests the default LV.__getitem__ behavior
         lazy_tensor = ZeroLazyTensor(5, 5)
@@ -45,6 +56,10 @@ class TestZeroLazyTensor(unittest.TestCase):
         index = (torch.tensor([0, 0, 1, 2]), slice(None, None, None))
         self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
         index = (slice(None, None, None), torch.tensor([0, 0, 1, 2]))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+        index = (Ellipsis, slice(None, None, None), torch.tensor([0, 0, 1, 2]))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+        index = (Ellipsis, torch.tensor([0, 0, 1, 2]))
         self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
 
     def test_get_item_tensor_index_on_batch(self):
@@ -67,6 +82,8 @@ class TestZeroLazyTensor(unittest.TestCase):
         index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), slice(None, None, None))
         self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
         index = (torch.tensor([0, 0, 1, 0]), slice(None, None, None), torch.tensor([0, 0, 1, 1]))
+        self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
+        index = (Ellipsis, torch.tensor([0, 1, 1, 0]))
         self.assertTrue(approx_equal(lazy_tensor[index], evaluated[index]))
 
     def test_add_diag(self):


### PR DESCRIPTION
**MERGE #394 FIRST**

We can now write calls like `lazy_tensor[..., 4:, 3]`. This reduces the amount of casing we do checking for batch dimensions. It will also make it much easier to write multi-batch functions for LazyTensors.

A step towards #369 