### PR TITLE
Fix shaping of noise_covar in GaussianLikelihood

### DIFF
--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -7,6 +7,7 @@ from .sum_lazy_tensor import SumLazyTensor
 from .diag_lazy_tensor import DiagLazyTensor
 from ..utils import pivoted_cholesky
 from .. import settings
+from ..utils import broadcasting
 
 
 class AddedDiagLazyTensor(SumLazyTensor):
@@ -20,6 +21,8 @@ class AddedDiagLazyTensor(SumLazyTensor):
         super(AddedDiagLazyTensor, self).__init__(*lazy_tensors)
         if len(lazy_tensors) > 2:
             raise RuntimeError("An AddedDiagLazyTensor can only have two components")
+
+        broadcasting._mul_broadcast_shape(lazy_tensors[0].shape, lazy_tensors[1].shape)
 
         if isinstance(lazy_tensors[0], DiagLazyTensor) and isinstance(lazy_tensors[1], DiagLazyTensor):
             raise RuntimeError("Trying to lazily add two DiagLazyTensors. " "Create a single DiagLazyTensor instead.")

--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -28,7 +28,7 @@ class _GaussianLikelihoodBase(Likelihood):
             shape = None
         else:
             # here shape[:-1] is the batch shape requested, and shape[-1] is `n`, the number of points
-            shape = mean.shape if len(mean.shape) == 1 else mean.shape[:-1]
+            shape = mean.shape
         noise_covar = self.noise_covar(*params, shape=shape)
         full_covar = covar + noise_covar
         return input.__class__(mean, full_covar)


### PR DESCRIPTION
My attempt at addressing #398, plus adding a check in AddedDiagLazyTensor that will fail if this ever happens again.

I think the issue is multi-task vs not: in Multitask the mean is `b x n x t` but in standard GP regression the mean is `b x n`.

cc/ @Balandat if you have a better solution, feel free to close this or add on to it.