### PR TITLE
Improve LazyTensor.__getitem__

### DIFF
--- a/gpytorch/lazy/constant_mul_lazy_tensor.py
+++ b/gpytorch/lazy/constant_mul_lazy_tensor.py
@@ -2,6 +2,7 @@
 
 import torch
 from .lazy_tensor import LazyTensor
+from .. import settings
 
 
 class ConstantMulLazyTensor(LazyTensor):
@@ -128,20 +129,42 @@ class ConstantMulLazyTensor(LazyTensor):
         constant = self.constant.view(*self.constant.shape, *[1 for i in res_mat_shape])
         return res * constant
 
-    def __getitem__(self, i):
-        # TODO: Fix to support ellipsis
-        constant = self.constant
-        if constant.numel() > 1:
-            first_index = i[0] if isinstance(i, tuple) else i
-            constant = constant[first_index]
+    def __getitem__(self, index):
+        # NOTE TO FUTURE SELF:
+        # This custom __getitem__ is actually very important!
+        # It prevents constructing an InterpolatedLazyTensor when one isn't needed
+        # This effects runntimes by up to 5x on simple exat GPs
 
-        base_lazy_tensor = self.base_lazy_tensor.__getitem__(i)
+        # Process the index
+        ndimension = self.ndimension()
+        index = list(index) if isinstance(index, tuple) else [index]
+        index = [torch.tensor(idx) if isinstance(idx, list) else idx for idx in index]
+
+        # Handle the ellipsis
+        # Find the index of the ellipsis
+        ellipsis_locs = [index for index, item in enumerate(index) if item is Ellipsis]
+        if settings.debug.on():
+            if len(ellipsis_locs) > 1:
+                raise RuntimeError(
+                    "Cannot have multiple ellipsis in a __getitem__ call. LazyTensor {} "
+                    " received index {}.".format(self, index)
+                )
+        if len(ellipsis_locs) == 1:
+            ellipsis_loc = ellipsis_locs[0]
+            num_to_fill_in = ndimension - (len(index) - 1)
+            index = index[:ellipsis_loc] + [slice(None, None, None)] * num_to_fill_in + index[ellipsis_loc + 1:]
+
+        # Pad the index with empty slices
+        index += [slice(None, None, None)] * (ndimension - len(index))
+
+        # Convert the index back to a tuple
+        index = tuple(index)
+
+        # Run __getitem__ on the base_lazy_tensor and the constant
+        base_lazy_tensor = self.base_lazy_tensor.__getitem__(index)
+        constant = self.constant[index[:-2]]
 
         if torch.is_tensor(base_lazy_tensor):
-            constant = constant.view(*constant.shape, *[1] * (len(base_lazy_tensor.shape) - len(constant.shape)))
-            return constant * base_lazy_tensor
-
-        if constant.numel() == 1:
-            constant = constant.squeeze()
+            constant = constant.view(*constant.shape, *[1] * (base_lazy_tensor.dim() - constant.dim()))
 
         return base_lazy_tensor * constant

--- a/gpytorch/lazy/sum_lazy_tensor.py
+++ b/gpytorch/lazy/sum_lazy_tensor.py
@@ -19,11 +19,21 @@ class SumLazyTensor(LazyTensor):
 
         self.lazy_tensors = lazy_tensors
 
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
+        return sum(
+            lazy_tensor._get_indices(left_indices, right_indices, *batch_indices)
+            for lazy_tensor in self.lazy_tensors
+        )
+
+    def _getitem(self, *indices):
+        results = tuple(lazy_tensor._getitem(*indices) for lazy_tensor in self.lazy_tensors)
+        if isinstance(results[0], LazyTensor):
+            return SumLazyTensor(*results)
+        else:
+            return sum(results)
+
     def _matmul(self, rhs):
         return sum(lazy_tensor._matmul(rhs) for lazy_tensor in self.lazy_tensors)
-
-    def _t_matmul(self, rhs):
-        return sum(lazy_tensor._t_matmul(rhs) for lazy_tensor in self.lazy_tensors)
 
     def _quad_form_derivative(self, left_vecs, right_vecs):
         return tuple(
@@ -33,15 +43,12 @@ class SumLazyTensor(LazyTensor):
     def _size(self):
         return self.lazy_tensors[0].size()
 
+    def _t_matmul(self, rhs):
+        return sum(lazy_tensor._t_matmul(rhs) for lazy_tensor in self.lazy_tensors)
+
     def _transpose_nonbatch(self):
         lazy_tensors_t = [lazy_tensor.transpose(-1, -2) for lazy_tensor in self.lazy_tensors]
         return SumLazyTensor(*lazy_tensors_t)
-
-    def _get_indices(self, left_indices, right_indices, *batch_indices):
-        return sum(
-            lazy_tensor._get_indices(left_indices, right_indices, *batch_indices)
-            for lazy_tensor in self.lazy_tensors
-        )
 
     def _exact_predictive_covar_inv_quad_form_cache(self, train_train_covar_inv_root, test_train_covar):
         return tuple(
@@ -88,10 +95,3 @@ class SumLazyTensor(LazyTensor):
 
     def sum_batch(self, sum_batch_size=None):
         return self.__class__(*(lazy_tensor.sum_batch(sum_batch_size) for lazy_tensor in self.lazy_tensors))
-
-    def __getitem__(self, index):
-        results = tuple(lazy_tensor.__getitem__(index) for lazy_tensor in self.lazy_tensors)
-        if isinstance(results[0], LazyTensor):
-            return SumLazyTensor(*results)
-        else:
-            return sum(results)

--- a/test/lazy/test_zero_lazy_tensor.py
+++ b/test/lazy/test_zero_lazy_tensor.py
@@ -28,8 +28,8 @@ class TestZeroLazyTensor(unittest.TestCase):
         lv = ZeroLazyTensor(5, 4, 3)
 
         res_one = lv[[0, 1]].evaluate()
-        res_two = lv[:, [0, 1], :].evaluate()
-        res_three = lv[:, :, [0, 2]].evaluate()
+        res_two = lv[:, [0, 1], :]
+        res_three = lv[:, :, [0, 2]]
 
         self.assertLess(torch.norm(res_one - torch.zeros(2, 4, 3)), 1e-4)
         self.assertLess(torch.norm(res_two - torch.zeros(5, 2, 3)), 1e-4)
@@ -39,8 +39,8 @@ class TestZeroLazyTensor(unittest.TestCase):
         lv = ZeroLazyTensor(5, 4, 3)
 
         res_one = lv[[0, 1]].evaluate()
-        res_two = lv[:, [0, 1], ...].evaluate()
-        res_three = lv[..., [0, 2]].evaluate()
+        res_two = lv[:, [0, 1], ...]
+        res_three = lv[..., [0, 2]]
 
         self.assertLess(torch.norm(res_one - torch.zeros(2, 4, 3)), 1e-4)
         self.assertLess(torch.norm(res_two - torch.zeros(5, 2, 3)), 1e-4)


### PR DESCRIPTION
A more stable version of yesterday's hotfix.

`LazyTensor.__getitem__` now calls a `LazyTensor._getitem` helper (similar to how `LazyTensor.size` calls `LazyTensor._size`). When `LazyTensor._getitem` is called, there is:
- One index per dimension (unsupplied indices are filled with `slice(None, None, None)`.
- Each index is an int, a slice, or a LongTensor (all lists, Ellipsis have been processed out).

LTs that had custom `__getitem__`s now have custom `_getitem`s. This is a pure refactor - no new functionality (except for `ConstantMulLazyTensor`, which is now a bit more stable). This significantly reduces repeated code.