### PR TITLE
Subset base_samples if required by rank of root_decompisition

### DIFF
--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -150,6 +150,11 @@ class _MultivariateNormalBase(TMultivariateNormal, Distribution):
 
             # Now reparameterize those base samples
             covar_root = covar.root_decomposition().root
+            # If necessary, adjust base_samples for rank of root decomposition
+            if covar_root.shape[-1] < base_samples.shape[-2]:
+                base_samples = base_samples[..., : covar_root.shape[-1], :]
+            elif covar_root.shape[-1] > base_samples.shape[-2]:
+                raise RuntimeError("Incompatible dimension of `base_samples`")
             res = covar_root.matmul(base_samples) + self.loc.unsqueeze(-1)
 
             # Permute and reshape new samples to be original size


### PR DESCRIPTION
The high-level goal of this PR is to allow using deterministic optimization algorithms on a MC-sampled objective in BayesOpt. Our acquisition functions just depend on calls to `rsample` of a posterior that is a function of varying `X`. By utilizing a fixed base_samples this function can be made deterministic with respect to `X`.  Since the `root_decomposition` generated is a low-rank approximation with dynamic rank, we need to make sure matrix dimensions agree when we correlate the samples. This is what this PR does.

With this change things are deterministic w.r.t. `X` conditional on the initial draw of `base_samples`, but may not be truly differentiable with respect to `X` since the covariance root rank is determined dynamically. This might be acceptable though since if the covariance approximation is accurate the derivative approximation should be accurate with regardless of whether the rank is off by a bit.