### PR TITLE
Catch an edge case with batch-> non-batch eval

### DIFF
--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -675,6 +675,8 @@ class LazyTensor(object):
             res = test_train_covar.matmul(precomputed_cache.unsqueeze(-1)).squeeze(-1)
         else:
             test_train_covar = self[num_train:, :num_train]
+            if non_batch_train and precomputed_cache.dim() == 2:
+                precomputed_cache = precomputed_cache[0]
             res = test_train_covar.matmul(precomputed_cache)
 
         res = res + test_mean


### PR DESCRIPTION
This fixes an edge case in which the sequence of operations `batch eval -> non-batch eval` on a non-batch model failed (the reverse sequence succeeded).

This special casing is starting to get a little hairy... Not sure if there is a good way of simplifying this. Maybe one way would be to factor out all these check into some utility that takes the `precomputed_cache` and does the appropriate things to it, so the rest of the code can remain relatively clean? 

cc @sdaulton, @bkarrer