### PR TITLE
Simple decorator for caching instance methods w/o args

### DIFF
--- a/gpytorch/lazy/constant_mul_lazy_tensor.py
+++ b/gpytorch/lazy/constant_mul_lazy_tensor.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import torch
+
+from ..utils.memoize import cached
 from .lazy_tensor import LazyTensor
 
 
@@ -136,6 +138,7 @@ class ConstantMulLazyTensor(LazyTensor):
         constant = self.constant.view(*self.constant.shape, *[1 for i in res_mat_shape])
         return res * constant
 
+    @cached
     def evaluate(self):
         res = self.base_lazy_tensor.evaluate()
         res_mat_shape = res.shape[len(self.base_lazy_tensor.batch_shape) :]

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 
 from itertools import product
+
 import torch
+
+from ..utils.memoize import cached
 from .lazy_tensor import LazyTensor
-from .root_lazy_tensor import RootLazyTensor
 from .non_lazy_tensor import NonLazyTensor
+from .root_lazy_tensor import RootLazyTensor
 
 
 class DiagLazyTensor(LazyTensor):
@@ -109,6 +112,7 @@ class DiagLazyTensor(LazyTensor):
     def diag(self):
         return self._diag
 
+    @cached
     def evaluate(self):
         return self._diag.unsqueeze(-1) * torch.eye(self._diag.shape[-1], dtype=self.dtype, device=self.device)
 

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
 import torch
-from .lazy_tensor import LazyTensor
-from .non_lazy_tensor import NonLazyTensor
-from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
+
 from .. import settings
+from ..utils.memoize import cached
+from .lazy_tensor import LazyTensor
+from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
+from .non_lazy_tensor import NonLazyTensor
 
 
 LAZY_KERNEL_TENSOR_WARNING = (
@@ -212,6 +214,7 @@ class LazyEvaluatedKernelTensor(LazyTensor):
                 self._cached_kernel_eval = NonLazyTensor(self._cached_kernel_eval)
             return self._cached_kernel_eval
 
+    @cached
     def evaluate(self):
         return self.evaluate_kernel().evaluate()
 

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -679,6 +679,8 @@ class LazyTensor(object):
             res = test_train_covar.matmul(precomputed_cache.unsqueeze(-1)).squeeze(-1)
         else:
             test_train_covar = self[num_train:, :num_train]
+            if non_batch_train and precomputed_cache.dim() == 2:
+                precomputed_cache = precomputed_cache[0]
             res = test_train_covar.matmul(precomputed_cache)
 
         res = res + test_mean

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 
 import math
+
 import gpytorch
 import torch
+
+from .. import beta_features, settings
 from ..functions._inv_matmul import InvMatmul
 from ..functions._inv_quad_log_det import InvQuadLogDet
-from ..functions._root_decomposition import RootDecomposition
 from ..functions._matmul import Matmul
-from .. import beta_features, settings
-from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
+from ..functions._root_decomposition import RootDecomposition
 from ..utils.broadcasting import _matmul_broadcast_shape
+from ..utils.memoize import cached
 from ..utils.qr import batch_qr
 from ..utils.svd import batch_svd
+from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
 
 
 class LazyTensor(object):
@@ -489,7 +492,7 @@ class LazyTensor(object):
         """
         Returns the shape over which the tensor is batched.
         """
-        return torch.Size(self.shape[:-2])
+        return self.shape[:-2]
 
     def clone(self):
         """
@@ -593,6 +596,7 @@ class LazyTensor(object):
         )
         return self.repeat(*repeat_shape)
 
+    @cached
     def evaluate(self):
         """
         Explicitly evaluates the matrix this LazyTensor represents. This function
@@ -675,8 +679,6 @@ class LazyTensor(object):
             res = test_train_covar.matmul(precomputed_cache.unsqueeze(-1)).squeeze(-1)
         else:
             test_train_covar = self[num_train:, :num_train]
-            if non_batch_train and precomputed_cache.dim() == 2:
-                precomputed_cache = precomputed_cache[0]
             res = test_train_covar.matmul(precomputed_cache)
 
         res = res + test_mean

--- a/gpytorch/lazy/mul_lazy_tensor.py
+++ b/gpytorch/lazy/mul_lazy_tensor.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
 import torch
+
+from ..utils import prod
+from ..utils.memoize import cached
 from .lazy_tensor import LazyTensor
 from .non_lazy_tensor import NonLazyTensor
 from .root_lazy_tensor import RootLazyTensor
-from ..utils import prod
 
 
 class MulLazyTensor(LazyTensor):
@@ -200,9 +202,9 @@ class MulLazyTensor(LazyTensor):
         res = prod([lazy_tensor.diag() for lazy_tensor in self.lazy_tensors])
         return res
 
+    @cached
     def evaluate(self):
-        res = prod([lazy_tensor.evaluate() for lazy_tensor in self.lazy_tensors])
-        return res
+        return prod([lazy_tensor.evaluate() for lazy_tensor in self.lazy_tensors])
 
     def mul(self, other):
         if isinstance(other, int) or isinstance(other, float) or (torch.is_tensor(other) and other.numel() == 1):

--- a/gpytorch/lazy/sum_lazy_tensor.py
+++ b/gpytorch/lazy/sum_lazy_tensor.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import torch
+
+from ..utils.memoize import cached
 from .lazy_tensor import LazyTensor
 from .non_lazy_tensor import NonLazyTensor
 from .zero_lazy_tensor import ZeroLazyTensor
@@ -67,6 +69,7 @@ class SumLazyTensor(LazyTensor):
             )
         )
 
+    @cached
     def evaluate(self):
         return sum(lazy_tensor.evaluate() for lazy_tensor in self.lazy_tensors)
 

--- a/gpytorch/lazy/zero_lazy_tensor.py
+++ b/gpytorch/lazy/zero_lazy_tensor.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import torch
+
+from ..utils.memoize import cached
 from .lazy_tensor import LazyTensor
 
 
@@ -113,6 +115,7 @@ class ZeroLazyTensor(LazyTensor):
             raise RuntimeError("diag works on square matrices (or batches)")
         return torch.zeros(shape[:-1], dtype=self.dtype, device=self.device)
 
+    @cached
     def evaluate(self):
         return torch.zeros(*self.sizes)
 

--- a/gpytorch/utils/__init__.py
+++ b/gpytorch/utils/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from .memoize import cached
 from .linear_cg import linear_cg
 from .stochastic_lq import StochasticLQ
 from . import cholesky
@@ -25,6 +26,7 @@ def prod(items):
 
 
 __all__ = [
+    "cached",
     "linear_cg",
     "StochasticLQ",
     "cholesky",

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+
+import functools
+
+
+def cached(f):
+    """A simple caching decorator for instance functions not taking any arguments"""
+
+    @functools.wraps(f)
+    def g(self, *args, **kwargs):
+        if not hasattr(self, "__cache"):
+            self.__cache = f(self)
+        return self.__cache
+
+    return g

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-
 import functools
 
 
@@ -8,7 +7,7 @@ def cached(f):
     """A simple caching decorator for instance functions not taking any arguments"""
 
     @functools.wraps(f)
-    def g(self, *args, **kwargs):
+    def g(self):
         if not hasattr(self, "__cache"):
             self.__cache = f(self)
         return self.__cache


### PR DESCRIPTION
Useful for things like `evaluate()` etc.

See discussion here: https://github.com/cornellius-gp/gpytorch/commit/7570ee1d758c93dd4054009fc12be6cc31b54031#r31576790

We can extend this to other cases where want to do caching, we just need to be careful about not messing with autograd by doing that.

