### PR TITLE
LazyTensor.detach, LazyTensor.requires_grad, refactor tests

### DIFF
--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -9,7 +9,9 @@ def cached(f):
     @functools.wraps(f)
     def g(self):
         if not hasattr(self, "__cache"):
-            self.__cache = f(self)
-        return self.__cache
+            self.__cache = dict()
+        if f not in self.__cache:
+            self.__cache[f] = f(self)
+        return self.__cache[f]
 
     return g

--- a/test/lazy/_lazy_tensor_test_case.py
+++ b/test/lazy/_lazy_tensor_test_case.py
@@ -33,8 +33,8 @@ class RectangularLazyTensorTestCase(object):
             torch.set_rng_state(self.rng_state)
 
     def test_matmul_vec(self):
-        lazy_tensor = self.create_lazy_tensor()
-        lazy_tensor_copy = lazy_tensor.clone()
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
         evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
 
         test_vector = torch.randn(lazy_tensor.size(-1))
@@ -52,8 +52,8 @@ class RectangularLazyTensorTestCase(object):
                 )
 
     def test_matmul_matrix(self):
-        lazy_tensor = self.create_lazy_tensor()
-        lazy_tensor_copy = lazy_tensor.clone()
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
         evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
 
         test_vector = torch.randn(lazy_tensor.size(-1), 5)
@@ -132,12 +132,13 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
     should_test_sample = False
 
     def test_quad_form_derivative(self):
-        lazy_tensor = self.create_lazy_tensor()
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_clone = lazy_tensor.clone().detach_().requires_grad_(True)
         left_vecs = torch.randn(lazy_tensor.size(-1), 2)
         right_vecs = torch.randn(lazy_tensor.size(-1), 2)
 
         deriv_custom = lazy_tensor._quad_form_derivative(left_vecs, right_vecs)
-        deriv_auto = gpytorch.lazy.LazyTensor._quad_form_derivative(lazy_tensor, left_vecs, right_vecs)
+        deriv_auto = gpytorch.lazy.LazyTensor._quad_form_derivative(lazy_tensor_clone, left_vecs, right_vecs)
 
         for dc, da in zip(deriv_custom, deriv_auto):
             self.assertLess(torch.norm(dc - da), 1e-1)
@@ -190,8 +191,8 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
         self.assertLess(torch.norm(res - actual) / actual.norm(), 0.1)
 
     def test_inv_matmul_vec(self):
-        lazy_tensor = self.create_lazy_tensor()
-        lazy_tensor_copy = lazy_tensor.clone()
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
         evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
 
         test_vector = torch.randn(lazy_tensor.size(-1))
@@ -210,8 +211,8 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
                 )
 
     def test_inv_matmul_matrix(self):
-        lazy_tensor = self.create_lazy_tensor()
-        lazy_tensor_copy = lazy_tensor.clone()
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
         evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
 
         test_vector = torch.randn(lazy_tensor.size(-1), 5)
@@ -244,7 +245,7 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)
 
         vecs = torch.randn(lazy_tensor.size(1), 3, requires_grad=True)
-        vecs_copy = vecs.clone()
+        vecs_copy = vecs.clone().detach_().requires_grad_(True)
 
         with gpytorch.settings.num_trace_samples(128):
             res_inv_quad, res_log_det = lazy_tensor.inv_quad_log_det(inv_quad_rhs=vecs, log_det=True)
@@ -262,7 +263,7 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)
 
         vecs = torch.randn(lazy_tensor.size(1), 3, requires_grad=True)
-        vecs_copy = vecs.clone()
+        vecs_copy = vecs.clone().detach_().requires_grad_(True)
 
         with gpytorch.settings.num_trace_samples(128):
             res_inv_quad, res_log_det = lazy_tensor.inv_quad_log_det(
@@ -288,8 +289,8 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
 
 class RectangularBatchLazyTensorTestCase(object):
     def test_matmul_matrix(self):
-        lazy_tensor = self.create_lazy_tensor()
-        lazy_tensor_copy = lazy_tensor.clone()
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
         evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
 
         test_vector = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 5)
@@ -385,12 +386,13 @@ class BatchLazyTensorTestCase(RectangularBatchLazyTensorTestCase):
         raise NotImplementedError()
 
     def test_quad_form_derivative(self):
-        lazy_tensor = self.create_lazy_tensor()
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_clone = lazy_tensor.clone().detach_().requires_grad_(True)
         left_vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 2)
         right_vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 2)
 
         deriv_custom = lazy_tensor._quad_form_derivative(left_vecs, right_vecs)
-        deriv_auto = gpytorch.lazy.LazyTensor._quad_form_derivative(lazy_tensor, left_vecs, right_vecs)
+        deriv_auto = gpytorch.lazy.LazyTensor._quad_form_derivative(lazy_tensor_clone, left_vecs, right_vecs)
 
         for dc, da in zip(deriv_custom, deriv_auto):
             self.assertLess(torch.norm(dc - da), 1e-1)
@@ -442,8 +444,8 @@ class BatchLazyTensorTestCase(RectangularBatchLazyTensorTestCase):
             self.assertTrue(approx_equal(res, actual))
 
     def test_inv_matmul_matrix(self):
-        lazy_tensor = self.create_lazy_tensor()
-        lazy_tensor_copy = lazy_tensor.clone()
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
         evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
         flattened_evaluated = evaluated.view(-1, *lazy_tensor.matrix_shape)
 
@@ -486,7 +488,7 @@ class BatchLazyTensorTestCase(RectangularBatchLazyTensorTestCase):
         flattened_evaluated = evaluated.view(-1, *lazy_tensor.matrix_shape)
 
         vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 3, requires_grad=True)
-        vecs_copy = vecs.clone()
+        vecs_copy = vecs.clone().detach_().requires_grad_(True)
 
         with gpytorch.settings.num_trace_samples(128):
             res_inv_quad, res_log_det = lazy_tensor.inv_quad_log_det(inv_quad_rhs=vecs, log_det=True)
@@ -515,7 +517,7 @@ class BatchLazyTensorTestCase(RectangularBatchLazyTensorTestCase):
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)
 
         vecs = torch.randn(lazy_tensor.size(0), lazy_tensor.size(1), 3, requires_grad=True)
-        vecs_copy = vecs.clone()
+        vecs_copy = vecs.clone().detach_().requires_grad_(True)
 
         with gpytorch.settings.num_trace_samples(128):
             res_inv_quad, res_log_det = lazy_tensor.inv_quad_log_det(

--- a/test/lazy/_lazy_tensor_test_case.py
+++ b/test/lazy/_lazy_tensor_test_case.py
@@ -3,6 +3,7 @@
 import gpytorch
 import torch
 import os
+import math
 import random
 from abc import abstractmethod
 from itertools import product
@@ -34,6 +35,12 @@ class RectangularLazyTensorTestCase(object):
 
     def test_matmul_vec(self):
         lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+
+        # We skip this test if we're dealing with batch LazyTensors
+        # They shouldn't multiply by a vec
+        if lazy_tensor.ndimension() > 2:
+            return
+
         lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
         evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
 
@@ -51,243 +58,6 @@ class RectangularLazyTensorTestCase(object):
                     ((arg.grad - arg_copy.grad).abs() / arg_copy.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
                 )
 
-    def test_matmul_matrix(self):
-        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
-        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
-        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
-
-        test_vector = torch.randn(lazy_tensor.size(-1), 5)
-        res = lazy_tensor.matmul(test_vector)
-        actual = evaluated.matmul(test_vector)
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 3e-1)
-
-        grad = torch.randn_like(res)
-        res.backward(gradient=grad)
-        actual.backward(gradient=grad)
-        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
-            if arg_copy.grad is not None:
-                self.assertLess(
-                    ((arg.grad - arg_copy.grad).abs() / arg_copy.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
-                )
-
-    def test_evaluate(self):
-        lazy_tensor = self.create_lazy_tensor()
-        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
-        self.assertTrue(approx_equal(lazy_tensor.evaluate(), evaluated))
-
-    def test_getitem(self):
-        lazy_tensor = self.create_lazy_tensor()
-        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
-
-        res = lazy_tensor[1]
-        actual = evaluated[1]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        res = lazy_tensor[0:2].evaluate()
-        actual = evaluated[0:2]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        res = lazy_tensor[:, 0:2].evaluate()
-        actual = evaluated[:, 0:2]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        res = lazy_tensor[0:2, :].evaluate()
-        actual = evaluated[0:2, :]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        res = lazy_tensor[..., 0:2].evaluate()
-        actual = evaluated[..., 0:2]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        res = lazy_tensor[0:2, ...].evaluate()
-        actual = evaluated[0:2, ...]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        res = lazy_tensor[..., 0:2, 2]
-        actual = evaluated[..., 0:2, 2]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        res = lazy_tensor[0:2, ..., 2]
-        actual = evaluated[0:2, ..., 2]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-
-    def test_getitem_tensor_index(self):
-        lazy_tensor = self.create_lazy_tensor()
-        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
-
-        index = (torch.tensor([0, 0, 1, 2]), torch.tensor([0, 1, 0, 2]))
-        res, actual = lazy_tensor[index], evaluated[index]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        index = (torch.tensor([0, 0, 1, 2]), slice(None, None, None))
-        res, actual = lazy_tensor[index], evaluated[index]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        index = (slice(None, None, None), torch.tensor([0, 0, 1, 2]))
-        res, actual = lazy_tensor[index], evaluated[index]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        index = (torch.tensor([0, 0, 1, 2]), Ellipsis)
-        res, actual = lazy_tensor[index], evaluated[index]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        index = (Ellipsis, torch.tensor([0, 0, 1, 2]))
-        res, actual = lazy_tensor[index], evaluated[index]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        index = (Ellipsis, torch.tensor([0, 0, 1, 2]), torch.tensor([0, 1, 0, 2]))
-        res, actual = lazy_tensor[index], evaluated[index]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-
-
-class LazyTensorTestCase(RectangularLazyTensorTestCase):
-    should_test_sample = False
-
-    def test_quad_form_derivative(self):
-        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
-        lazy_tensor_clone = lazy_tensor.clone().detach_().requires_grad_(True)
-        left_vecs = torch.randn(lazy_tensor.size(-1), 2)
-        right_vecs = torch.randn(lazy_tensor.size(-1), 2)
-
-        deriv_custom = lazy_tensor._quad_form_derivative(left_vecs, right_vecs)
-        deriv_auto = gpytorch.lazy.LazyTensor._quad_form_derivative(lazy_tensor_clone, left_vecs, right_vecs)
-
-        for dc, da in zip(deriv_custom, deriv_auto):
-            self.assertLess(torch.norm(dc - da), 1e-1)
-
-    def test_add_diag(self):
-        lazy_tensor = self.create_lazy_tensor()
-        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
-
-        other_diag = torch.tensor(1.5)
-        res = lazy_tensor.add_diag(other_diag).evaluate()
-        actual = evaluated + torch.eye(evaluated.size(-1)).mul(1.5)
-        self.assertTrue(approx_equal(res, actual))
-
-        other_diag = torch.tensor([1.5])
-        res = lazy_tensor.add_diag(other_diag).evaluate()
-        actual = evaluated + torch.eye(evaluated.size(-1)).mul(1.5)
-        self.assertTrue(approx_equal(res, actual))
-
-        other_diag = torch.randn(lazy_tensor.size(-1)).pow(2)
-        res = lazy_tensor.add_diag(other_diag).evaluate()
-        actual = evaluated + other_diag.diag()
-        self.assertTrue(approx_equal(res, actual))
-
-    def test_root_decomposition(self):
-        # Test with Cholesky
-        lazy_tensor = self.create_lazy_tensor()
-        test_mat = torch.randn(lazy_tensor.size(-1))
-        with gpytorch.settings.max_cholesky_numel(lazy_tensor.matrix_shape.numel() + 1):
-            root_approx = lazy_tensor.root_decomposition()
-            res = root_approx.matmul(test_mat)
-            actual = lazy_tensor.matmul(test_mat)
-            self.assertLess(torch.norm(res - actual) / actual.norm(), 0.1)
-
-        # Test with Lanczos
-        lazy_tensor = self.create_lazy_tensor()
-        with gpytorch.settings.max_cholesky_numel(lazy_tensor.matrix_shape.numel() - 1):
-            root_approx = lazy_tensor.root_decomposition()
-            res = root_approx.matmul(test_mat)
-            actual = lazy_tensor.matmul(test_mat)
-            self.assertLess(torch.norm(res - actual) / actual.norm(), 0.1)
-
-    def test_root_inv_decomposition(self):
-        lazy_tensor = self.create_lazy_tensor()
-        root_approx = lazy_tensor.root_inv_decomposition()
-
-        test_mat = torch.randn(lazy_tensor.size(-1))
-
-        res = root_approx.matmul(test_mat)
-        actual = lazy_tensor.inv_matmul(test_mat)
-        self.assertLess(torch.norm(res - actual) / actual.norm(), 0.1)
-
-    def test_inv_matmul_vec(self):
-        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
-        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
-        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
-
-        test_vector = torch.randn(lazy_tensor.size(-1))
-        with gpytorch.settings.max_cg_iterations(200):
-            res = lazy_tensor.inv_matmul(test_vector)
-        actual = evaluated.inverse().matmul(test_vector)
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 3e-1)
-
-        grad = torch.randn_like(res)
-        res.backward(gradient=grad)
-        actual.backward(gradient=grad)
-        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
-            if arg_copy.grad is not None:
-                self.assertLess(
-                    ((arg.grad - arg_copy.grad).abs() / arg_copy.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
-                )
-
-    def test_inv_matmul_matrix(self):
-        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
-        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
-        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
-
-        test_vector = torch.randn(lazy_tensor.size(-1), 5)
-        with gpytorch.settings.max_cg_iterations(100):
-            res = lazy_tensor.inv_matmul(test_vector)
-        actual = evaluated.inverse().matmul(test_vector)
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 3e-1)
-
-        grad = torch.randn_like(res)
-        res.backward(gradient=grad)
-        actual.backward(gradient=grad)
-        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
-            if arg_copy.grad is not None:
-                self.assertLess(
-                    ((arg.grad - arg_copy.grad).abs() / arg_copy.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
-                )
-
-    def test_diag(self):
-        lazy_tensor = self.create_lazy_tensor()
-        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
-
-        res = lazy_tensor.diag()
-        actual = evaluated.diag()
-        self.assertEqual(res.size(), lazy_tensor.size()[:-1])
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 3e-1)
-
-    def test_inv_quad_log_det(self):
-        # Forward
-        lazy_tensor = self.create_lazy_tensor()
-        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
-
-        vecs = torch.randn(lazy_tensor.size(1), 3, requires_grad=True)
-        vecs_copy = vecs.clone().detach_().requires_grad_(True)
-
-        with gpytorch.settings.num_trace_samples(128):
-            res_inv_quad, res_log_det = lazy_tensor.inv_quad_log_det(inv_quad_rhs=vecs, log_det=True)
-        res = res_inv_quad + res_log_det
-
-        actual_inv_quad = evaluated.inverse().matmul(vecs_copy).mul(vecs_copy).sum()
-        actual = actual_inv_quad + torch.logdet(evaluated)
-
-        diff = (res - actual).abs() / actual.abs().clamp(1, 1e10)
-        self.assertLess(diff.item(), 15e-2)
-
-    def test_inv_quad_log_det_no_reduce(self):
-        # Forward
-        lazy_tensor = self.create_lazy_tensor()
-        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
-
-        vecs = torch.randn(lazy_tensor.size(1), 3, requires_grad=True)
-        vecs_copy = vecs.clone().detach_().requires_grad_(True)
-
-        with gpytorch.settings.num_trace_samples(128):
-            res_inv_quad, res_log_det = lazy_tensor.inv_quad_log_det(
-                inv_quad_rhs=vecs, log_det=True, reduce_inv_quad=False
-            )
-        res = res_inv_quad.sum(-1) + res_log_det
-
-        actual_inv_quad = evaluated.inverse().matmul(vecs_copy).mul(vecs_copy).sum()
-        actual = actual_inv_quad + torch.logdet(evaluated)
-
-        diff = (res - actual).abs() / actual.abs().clamp(1, 1e10)
-        self.assertLess(diff.item(), 15e-2)
-
-    def test_sample(self):
-        if self.__class__.should_test_sample:
-            lazy_tensor = self.create_lazy_tensor()
-            evaluated = self.evaluate_lazy_tensor(lazy_tensor)
-
-            samples = lazy_tensor.zero_mean_mvn_samples(10000)
-            sample_covar = samples.unsqueeze(-1).matmul(samples.unsqueeze(-2)).mean(0)
-            self.assertLess(((sample_covar - evaluated).abs() / evaluated.abs().clamp(1, 1e5)).max().item(), 3e-1)
-
-
-class RectangularBatchLazyTensorTestCase(object):
     def test_matmul_matrix(self):
         lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
         lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
@@ -316,74 +86,118 @@ class RectangularBatchLazyTensorTestCase(object):
         lazy_tensor = self.create_lazy_tensor()
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)
 
-        res = lazy_tensor[1].evaluate()
-        actual = evaluated[1]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        res = lazy_tensor[0:2].evaluate()
-        actual = evaluated[0:2]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        res = lazy_tensor[:, 0:2].evaluate()
-        actual = evaluated[:, 0:2]
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+        # Non-batch case
+        if lazy_tensor.ndimension() == 2:
+            res = lazy_tensor[1]
+            actual = evaluated[1]
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            res = lazy_tensor[0:2].evaluate()
+            actual = evaluated[0:2]
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            res = lazy_tensor[:, 0:2].evaluate()
+            actual = evaluated[:, 0:2]
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            res = lazy_tensor[0:2, :].evaluate()
+            actual = evaluated[0:2, :]
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            res = lazy_tensor[..., 0:2].evaluate()
+            actual = evaluated[..., 0:2]
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            res = lazy_tensor[0:2, ...].evaluate()
+            actual = evaluated[0:2, ...]
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            res = lazy_tensor[..., 0:2, 2]
+            actual = evaluated[..., 0:2, 2]
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            res = lazy_tensor[0:2, ..., 2]
+            actual = evaluated[0:2, ..., 2]
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
 
-        for batch_index in product([1, slice(0, 2, None)], repeat=(lazy_tensor.dim() - 2)):
-            res = lazy_tensor.__getitem__((*batch_index, slice(0, 1, None), slice(0, 2, None))).evaluate()
-            actual = evaluated.__getitem__((*batch_index, slice(0, 1, None), slice(0, 2, None)))
+        # Batch case
+        else:
+            res = lazy_tensor[1].evaluate()
+            actual = evaluated[1]
             self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-            res = lazy_tensor.__getitem__((*batch_index, 1, slice(0, 2, None)))
-            actual = evaluated.__getitem__((*batch_index, 1, slice(0, 2, None)))
+            res = lazy_tensor[0:2].evaluate()
+            actual = evaluated[0:2]
             self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-            res = lazy_tensor.__getitem__((*batch_index, slice(1, None, None), 2))
-            actual = evaluated.__getitem__((*batch_index, slice(1, None, None), 2))
+            res = lazy_tensor[:, 0:2].evaluate()
+            actual = evaluated[:, 0:2]
             self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
 
-        # Ellipsis
-        res = lazy_tensor.__getitem__((Ellipsis, slice(1, None, None), 2))
-        actual = evaluated.__getitem__((Ellipsis, slice(1, None, None), 2))
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        res = lazy_tensor.__getitem__((slice(1, None, None), Ellipsis, 2))
-        actual = evaluated.__getitem__((slice(1, None, None), Ellipsis, 2))
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            for batch_index in product([1, slice(0, 2, None)], repeat=(lazy_tensor.dim() - 2)):
+                res = lazy_tensor.__getitem__((*batch_index, slice(0, 1, None), slice(0, 2, None))).evaluate()
+                actual = evaluated.__getitem__((*batch_index, slice(0, 1, None), slice(0, 2, None)))
+                self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+                res = lazy_tensor.__getitem__((*batch_index, 1, slice(0, 2, None)))
+                actual = evaluated.__getitem__((*batch_index, 1, slice(0, 2, None)))
+                self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+                res = lazy_tensor.__getitem__((*batch_index, slice(1, None, None), 2))
+                actual = evaluated.__getitem__((*batch_index, slice(1, None, None), 2))
+                self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+
+            # Ellipsis
+            res = lazy_tensor.__getitem__((Ellipsis, slice(1, None, None), 2))
+            actual = evaluated.__getitem__((Ellipsis, slice(1, None, None), 2))
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            res = lazy_tensor.__getitem__((slice(1, None, None), Ellipsis, 2))
+            actual = evaluated.__getitem__((slice(1, None, None), Ellipsis, 2))
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
 
     def test_getitem_tensor_index(self):
         lazy_tensor = self.create_lazy_tensor()
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)
 
-        for batch_index in product(
-            [torch.tensor([0, 1, 1, 0]), slice(None, None, None)], repeat=(lazy_tensor.dim() - 2)
-        ):
-            index = (*batch_index, torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1]))
+        # Non-batch case
+        if lazy_tensor.ndimension() == 2:
+            index = (torch.tensor([0, 0, 1, 2]), torch.tensor([0, 1, 0, 2]))
             res, actual = lazy_tensor[index], evaluated[index]
             self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-            index = (*batch_index, torch.tensor([0, 1, 0, 2]), slice(None, None, None))
+            index = (torch.tensor([0, 0, 1, 2]), slice(None, None, None))
             res, actual = lazy_tensor[index], evaluated[index]
             self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-            index = (*batch_index, slice(None, None, None), torch.tensor([0, 1, 2, 1]))
+            index = (slice(None, None, None), torch.tensor([0, 0, 1, 2]))
             res, actual = lazy_tensor[index], evaluated[index]
             self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-            index = (*batch_index, slice(None, None, None), slice(None, None, None))
-            res, actual = lazy_tensor[index].evaluate(), evaluated[index]
+            index = (torch.tensor([0, 0, 1, 2]), Ellipsis)
+            res, actual = lazy_tensor[index], evaluated[index]
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            index = (Ellipsis, torch.tensor([0, 0, 1, 2]))
+            res, actual = lazy_tensor[index], evaluated[index]
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            index = (Ellipsis, torch.tensor([0, 0, 1, 2]), torch.tensor([0, 1, 0, 2]))
+            res, actual = lazy_tensor[index], evaluated[index]
             self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
 
-        # Ellipsis
-        res = lazy_tensor.__getitem__((Ellipsis, torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1])))
-        actual = evaluated.__getitem__((Ellipsis, torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1])))
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
-        res = lazy_tensor.__getitem__((torch.tensor([0, 1, 0, 1]), Ellipsis, torch.tensor([1, 2, 0, 1])))
-        actual = evaluated.__getitem__((torch.tensor([0, 1, 0, 1]), Ellipsis, torch.tensor([1, 2, 0, 1])))
-        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+        # Batch case
+        else:
+            for batch_index in product(
+                [torch.tensor([0, 1, 1, 0]), slice(None, None, None)], repeat=(lazy_tensor.dim() - 2)
+            ):
+                index = (*batch_index, torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1]))
+                res, actual = lazy_tensor[index], evaluated[index]
+                self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+                index = (*batch_index, torch.tensor([0, 1, 0, 2]), slice(None, None, None))
+                res, actual = lazy_tensor[index], evaluated[index]
+                self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+                index = (*batch_index, slice(None, None, None), torch.tensor([0, 1, 2, 1]))
+                res, actual = lazy_tensor[index], evaluated[index]
+                self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+                index = (*batch_index, slice(None, None, None), slice(None, None, None))
+                res, actual = lazy_tensor[index].evaluate(), evaluated[index]
+                self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+
+            # Ellipsis
+            res = lazy_tensor.__getitem__((Ellipsis, torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1])))
+            actual = evaluated.__getitem__((Ellipsis, torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1])))
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
+            res = lazy_tensor.__getitem__((torch.tensor([0, 1, 0, 1]), Ellipsis, torch.tensor([1, 2, 0, 1])))
+            actual = evaluated.__getitem__((torch.tensor([0, 1, 0, 1]), Ellipsis, torch.tensor([1, 2, 0, 1])))
+            self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 1e-1)
 
 
-class BatchLazyTensorTestCase(RectangularBatchLazyTensorTestCase):
+class LazyTensorTestCase(RectangularLazyTensorTestCase):
     should_test_sample = False
-
-    @abstractmethod
-    def create_lazy_tensor(self):
-        raise NotImplementedError()
-
-    @abstractmethod
-    def evaluate_lazy_tensor(self):
-        raise NotImplementedError()
 
     def test_quad_form_derivative(self):
         lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
@@ -396,20 +210,6 @@ class BatchLazyTensorTestCase(RectangularBatchLazyTensorTestCase):
 
         for dc, da in zip(deriv_custom, deriv_auto):
             self.assertLess(torch.norm(dc - da), 1e-1)
-
-    def setUp(self):
-        if hasattr(self.__class__, "seed"):
-            seed = self.__class__.seed
-            if os.getenv("UNLOCK_SEED") is None or os.getenv("UNLOCK_SEED").lower() == "false":
-                self.rng_state = torch.get_rng_state()
-                torch.manual_seed(seed)
-                if torch.cuda.is_available():
-                    torch.cuda.manual_seed_all(seed)
-                random.seed(seed)
-
-    def tearDown(self):
-        if hasattr(self, "rng_state"):
-            torch.set_rng_state(self.rng_state)
 
     def test_add_diag(self):
         lazy_tensor = self.create_lazy_tensor()
@@ -443,22 +243,69 @@ class BatchLazyTensorTestCase(RectangularBatchLazyTensorTestCase):
                 actual[..., i, i] = actual[..., i, i] + other_diag[..., i]
             self.assertTrue(approx_equal(res, actual))
 
+    def test_root_decomposition(self):
+        # Test with Cholesky
+        lazy_tensor = self.create_lazy_tensor()
+        test_mat = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 5)
+        with gpytorch.settings.max_cholesky_numel(lazy_tensor.matrix_shape.numel() + 1):
+            root_approx = lazy_tensor.root_decomposition()
+            res = root_approx.matmul(test_mat)
+            actual = lazy_tensor.matmul(test_mat)
+            self.assertLess(torch.norm(res - actual) / actual.norm(), 0.1)
+
+        # Test with Lanczos
+        lazy_tensor = self.create_lazy_tensor()
+        with gpytorch.settings.max_cholesky_numel(lazy_tensor.matrix_shape.numel() - 1):
+            root_approx = lazy_tensor.root_decomposition()
+            res = root_approx.matmul(test_mat)
+            actual = lazy_tensor.matmul(test_mat)
+            self.assertLess(torch.norm(res - actual) / actual.norm(), 0.1)
+
+    def test_root_inv_decomposition(self):
+        lazy_tensor = self.create_lazy_tensor()
+        root_approx = lazy_tensor.root_inv_decomposition()
+
+        test_mat = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 5)
+
+        res = root_approx.matmul(test_mat)
+        actual = lazy_tensor.inv_matmul(test_mat)
+        self.assertLess(torch.norm(res - actual) / actual.norm(), 0.1)
+
+    def test_inv_matmul_vec(self):
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+
+        # We skip this test if we're dealing with batch LazyTensors
+        # They shouldn't multiply by a vec
+        if lazy_tensor.ndimension() > 2:
+            return
+
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+
+        test_vector = torch.randn(lazy_tensor.size(-1))
+        with gpytorch.settings.max_cg_iterations(200):
+            res = lazy_tensor.inv_matmul(test_vector)
+        actual = evaluated.inverse().matmul(test_vector)
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 3e-1)
+
+        grad = torch.randn_like(res)
+        res.backward(gradient=grad)
+        actual.backward(gradient=grad)
+        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+            if arg_copy.grad is not None:
+                self.assertLess(
+                    ((arg.grad - arg_copy.grad).abs() / arg_copy.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
+                )
+
     def test_inv_matmul_matrix(self):
         lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
         lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
         evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
-        flattened_evaluated = evaluated.view(-1, *lazy_tensor.matrix_shape)
 
         test_vector = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 5)
-        with gpytorch.settings.max_cg_iterations(200):
+        with gpytorch.settings.max_cg_iterations(100):
             res = lazy_tensor.inv_matmul(test_vector)
-        actual = torch.cat(
-            [
-                flattened_evaluated[i].inverse().matmul(test_vector[i]).unsqueeze(0)
-                for i in range(lazy_tensor.batch_shape.numel())
-            ]
-        )
-        actual = actual.view_as(test_vector)
+        actual = evaluated.inverse().matmul(test_vector)
         self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 3e-1)
 
         grad = torch.randn_like(res)
@@ -487,36 +334,29 @@ class BatchLazyTensorTestCase(RectangularBatchLazyTensorTestCase):
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)
         flattened_evaluated = evaluated.view(-1, *lazy_tensor.matrix_shape)
 
-        vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 3, requires_grad=True)
+        vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(1), 3, requires_grad=True)
         vecs_copy = vecs.clone().detach_().requires_grad_(True)
 
         with gpytorch.settings.num_trace_samples(128):
             res_inv_quad, res_log_det = lazy_tensor.inv_quad_log_det(inv_quad_rhs=vecs, log_det=True)
         res = res_inv_quad + res_log_det
 
-        actual_inv_quad = torch.cat(
-            [
-                flattened_evaluated[i].inverse().matmul(vecs_copy[i]).mul(vecs_copy[i]).sum().unsqueeze(0)
-                for i in range(lazy_tensor.batch_shape.numel())
-            ]
-        )
-        actual = actual_inv_quad + torch.cat(
+        actual_inv_quad = evaluated.inverse().matmul(vecs_copy).mul(vecs_copy).sum(-2).sum(-1)
+        actual_log_det = torch.cat(
             [torch.logdet(flattened_evaluated[i]).unsqueeze(0) for i in range(lazy_tensor.batch_shape.numel())]
-        )
-        actual = actual.view(*lazy_tensor.batch_shape)
+        ).view(lazy_tensor.batch_shape)
+        actual = actual_inv_quad + actual_log_det
 
-        self.assertEqual(actual.shape, res.shape)
-
-        diffs = (res - actual).abs() / actual.abs().clamp(1, 1e10).view(-1)
-        for i in range(diffs.numel()):
-            self.assertLess(diffs[i].item(), 15e-2)
+        diff = (res - actual).abs() / actual.abs().clamp(1, math.inf)
+        self.assertLess(diff.max().item(), 15e-2)
 
     def test_inv_quad_log_det_no_reduce(self):
         # Forward
         lazy_tensor = self.create_lazy_tensor()
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+        flattened_evaluated = evaluated.view(-1, *lazy_tensor.matrix_shape)
 
-        vecs = torch.randn(lazy_tensor.size(0), lazy_tensor.size(1), 3, requires_grad=True)
+        vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(1), 3, requires_grad=True)
         vecs_copy = vecs.clone().detach_().requires_grad_(True)
 
         with gpytorch.settings.num_trace_samples(128):
@@ -525,18 +365,14 @@ class BatchLazyTensorTestCase(RectangularBatchLazyTensorTestCase):
             )
         res = res_inv_quad.sum(-1) + res_log_det
 
-        actual_inv_quad = torch.cat(
-            [
-                evaluated[i].inverse().matmul(vecs_copy[i]).mul(vecs_copy[i]).sum().unsqueeze(0)
-                for i in range(lazy_tensor.size(0))
-            ]
-        )
-        actual = actual_inv_quad + torch.cat(
-            [torch.logdet(evaluated[i]).unsqueeze(0) for i in range(lazy_tensor.size(0))]
-        )
-        diffs = (res - actual).abs() / actual.abs().clamp(1, 1e10)
-        for i in range(lazy_tensor.size(0)):
-            self.assertLess(diffs[i].item(), 15e-2)
+        actual_inv_quad = evaluated.inverse().matmul(vecs_copy).mul(vecs_copy).sum(-2).sum(-1)
+        actual_log_det = torch.cat(
+            [torch.logdet(flattened_evaluated[i]).unsqueeze(0) for i in range(lazy_tensor.batch_shape.numel())]
+        ).view(lazy_tensor.batch_shape)
+        actual = actual_inv_quad + actual_log_det
+
+        diff = (res - actual).abs() / actual.abs().clamp(1, math.inf)
+        self.assertLess(diff.max().item(), 15e-2)
 
     def test_sample(self):
         if self.__class__.should_test_sample:
@@ -545,4 +381,12 @@ class BatchLazyTensorTestCase(RectangularBatchLazyTensorTestCase):
 
             samples = lazy_tensor.zero_mean_mvn_samples(50000)
             sample_covar = samples.unsqueeze(-1).matmul(samples.unsqueeze(-2)).mean(0)
-            self.assertLess(((sample_covar - evaluated).abs() / evaluated.abs().clamp(1, 1e5)).max().item(), 3e-1)
+            self.assertLess(((sample_covar - evaluated).abs() / evaluated.abs().clamp(1, math.inf)).max().item(), 3e-1)
+
+
+class RectangularBatchLazyTensorTestCase(RectangularLazyTensorTestCase):
+    pass
+
+
+class BatchLazyTensorTestCase(LazyTensorTestCase):
+    pass

--- a/test/lazy/_lazy_tensor_test_case.py
+++ b/test/lazy/_lazy_tensor_test_case.py
@@ -382,11 +382,3 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
             samples = lazy_tensor.zero_mean_mvn_samples(50000)
             sample_covar = samples.unsqueeze(-1).matmul(samples.unsqueeze(-2)).mean(0)
             self.assertLess(((sample_covar - evaluated).abs() / evaluated.abs().clamp(1, math.inf)).max().item(), 3e-1)
-
-
-class RectangularBatchLazyTensorTestCase(RectangularLazyTensorTestCase):
-    pass
-
-
-class BatchLazyTensorTestCase(LazyTensorTestCase):
-    pass

--- a/test/lazy/test_added_diag_lazy_tensor.py
+++ b/test/lazy/test_added_diag_lazy_tensor.py
@@ -3,7 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import NonLazyTensor, DiagLazyTensor, AddedDiagLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestAddedDiagLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -23,7 +23,7 @@ class TestAddedDiagLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return tensor + diag.diag()
 
 
-class TestAddedDiagLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestAddedDiagLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 4
     should_test_sample = True
 

--- a/test/lazy/test_batch_repeat_lazy_tensor.py
+++ b/test/lazy/test_batch_repeat_lazy_tensor.py
@@ -3,10 +3,10 @@
 import torch
 import unittest
 from gpytorch.lazy import ToeplitzLazyTensor, BatchRepeatLazyTensor
-from test.lazy._lazy_tensor_test_case import BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
-class TestBatchRepeatLazyTensor(BatchLazyTensorTestCase, unittest.TestCase):
+class TestBatchRepeatLazyTensor(LazyTensorTestCase, unittest.TestCase):
     seed = 0
     should_test_sample = True
 
@@ -19,7 +19,7 @@ class TestBatchRepeatLazyTensor(BatchLazyTensorTestCase, unittest.TestCase):
         return evaluated.repeat(*lazy_tensor.batch_repeat, 1, 1)
 
 
-class TestBatchRepeatLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestBatchRepeatLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 0
     should_test_sample = True
 

--- a/test/lazy/test_block_diag_lazy_tensor.py
+++ b/test/lazy/test_block_diag_lazy_tensor.py
@@ -3,7 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import BlockDiagLazyTensor, NonLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestBlockDiagLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -25,7 +25,7 @@ class TestBlockDiagLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return actual
 
 
-class TestBlockDiagLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestBlockDiagLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 0
     should_test_sample = True
 

--- a/test/lazy/test_chol_lazy_tensor.py
+++ b/test/lazy/test_chol_lazy_tensor.py
@@ -3,7 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import CholLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestCholLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -31,7 +31,7 @@ class TestCholLazyTensor(LazyTensorTestCase, unittest.TestCase):
         pass
 
 
-class TestCholLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestCholLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 0
     should_test_sample = True
 

--- a/test/lazy/test_constant_mul_lazy_tensor.py
+++ b/test/lazy/test_constant_mul_lazy_tensor.py
@@ -4,7 +4,7 @@ import torch
 import unittest
 from gpytorch.lazy import ToeplitzLazyTensor
 from gpytorch.utils.toeplitz import sym_toeplitz
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestConstantMulLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -21,7 +21,7 @@ class TestConstantMulLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return sym_toeplitz(column) * constant
 
 
-class TestConstantMulLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestConstantMulLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 0
 
     def create_lazy_tensor(self):

--- a/test/lazy/test_diag_lazy_tensor.py
+++ b/test/lazy/test_diag_lazy_tensor.py
@@ -3,7 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import DiagLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestDiagLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -19,7 +19,7 @@ class TestDiagLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return diag.diag()
 
 
-class TestDiagLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestDiagLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 0
     should_test_sample = True
 

--- a/test/lazy/test_interpolated_lazy_tensor.py
+++ b/test/lazy/test_interpolated_lazy_tensor.py
@@ -3,7 +3,7 @@
 import unittest
 import torch
 from gpytorch.lazy import NonLazyTensor, InterpolatedLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestInterpolatedLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -43,7 +43,7 @@ class TestInterpolatedLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return actual
 
 
-class TestInterpolatedLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestInterpolatedLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 0
     should_test_sample = True
 

--- a/test/lazy/test_kronecker_product_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_lazy_tensor.py
@@ -3,8 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import KroneckerProductLazyTensor, NonLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
-from test.lazy._lazy_tensor_test_case import RectangularLazyTensorTestCase, RectangularBatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, RectangularLazyTensorTestCase
 
 
 def kron(a, b):
@@ -42,7 +41,7 @@ class TestKroneckerProductLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return res
 
 
-class TestKroneckerProductLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestKroneckerProductLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float).repeat(3, 1, 1)
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float).repeat(3, 1, 1)
@@ -73,7 +72,7 @@ class TestKroneckerProductLazyTensorRectangular(RectangularLazyTensorTestCase, u
         return res
 
 
-class TestKroneckerProductLazyTensorRectangularBatch(RectangularBatchLazyTensorTestCase, unittest.TestCase):
+class TestKroneckerProductLazyTensorRectangularBatch(RectangularLazyTensorTestCase, unittest.TestCase):
     def create_lazy_tensor(self):
         a = torch.randn(4, 2, 3, requires_grad=True)
         b = torch.randn(4, 5, 2, requires_grad=True)

--- a/test/lazy/test_matmul_lazy_tensor.py
+++ b/test/lazy/test_matmul_lazy_tensor.py
@@ -3,8 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import MatmulLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
-from test.lazy._lazy_tensor_test_case import RectangularLazyTensorTestCase, RectangularBatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, RectangularLazyTensorTestCase
 
 
 class TestMatmulLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -20,7 +19,7 @@ class TestMatmulLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return lazy_tensor.left_lazy_tensor.tensor.matmul(lazy_tensor.right_lazy_tensor.tensor)
 
 
-class TestMatmulLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestMatmulLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 3
 
     def create_lazy_tensor(self):
@@ -44,7 +43,7 @@ class TestMatmulLazyTensorRectangular(RectangularLazyTensorTestCase, unittest.Te
         return lazy_tensor.left_lazy_tensor.tensor.matmul(lazy_tensor.right_lazy_tensor.tensor)
 
 
-class TestMatmulLazyTensorRectangularBatch(RectangularBatchLazyTensorTestCase, unittest.TestCase):
+class TestMatmulLazyTensorRectangularBatch(RectangularLazyTensorTestCase, unittest.TestCase):
     def create_lazy_tensor(self):
         lhs = torch.randn(3, 5, 3, requires_grad=True)
         rhs = torch.randn(3, 3, 6, requires_grad=True)

--- a/test/lazy/test_mul_lazy_tensor.py
+++ b/test/lazy/test_mul_lazy_tensor.py
@@ -3,7 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import MulLazyTensor, RootLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 def make_random_mat(size, rank, batch_size=None):
@@ -65,7 +65,7 @@ class TestMulLazyTensorMulti(LazyTensorTestCase, unittest.TestCase):
         return res
 
 
-class TestMulLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestMulLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 2
 
     def create_lazy_tensor(self):
@@ -84,7 +84,7 @@ class TestMulLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
         return res
 
 
-class TestMulLazyTensorMultiBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestMulLazyTensorMultiBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 3
 
     def test_quad_form_derivative(self):
@@ -113,7 +113,7 @@ class TestMulLazyTensorMultiBatch(BatchLazyTensorTestCase, unittest.TestCase):
         return res
 
 
-class TestMulLazyTensorWithConstantMul(BatchLazyTensorTestCase, unittest.TestCase):
+class TestMulLazyTensorWithConstantMul(LazyTensorTestCase, unittest.TestCase):
     seed = 2
 
     def test_quad_form_derivative(self):

--- a/test/lazy/test_non_lazy_tensor.py
+++ b/test/lazy/test_non_lazy_tensor.py
@@ -3,7 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import NonLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestNonLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -19,7 +19,7 @@ class TestNonLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return lazy_tensor.tensor
 
 
-class TestNonLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestNonLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 0
 
     def create_lazy_tensor(self):

--- a/test/lazy/test_psd_sum_lazy_tensor.py
+++ b/test/lazy/test_psd_sum_lazy_tensor.py
@@ -3,7 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import ToeplitzLazyTensor, PsdSumLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestPsdSumLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -22,7 +22,7 @@ class TestPsdSumLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return sum(tensors)
 
 
-class TestPsdSumLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestPsdSumLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 0
     should_test_sample = True
 

--- a/test/lazy/test_root_lazy_tensor.py
+++ b/test/lazy/test_root_lazy_tensor.py
@@ -3,7 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import RootLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestRootLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -19,7 +19,7 @@ class TestRootLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return res
 
 
-class TestRootLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestRootLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 1
 
     def create_lazy_tensor(self):

--- a/test/lazy/test_root_lazy_tensor.py
+++ b/test/lazy/test_root_lazy_tensor.py
@@ -10,19 +10,13 @@ class TestRootLazyTensor(LazyTensorTestCase, unittest.TestCase):
     seed = 0
 
     def create_lazy_tensor(self):
-        root = torch.randn(5, 3, requires_grad=True)
-        return RootLazyTensor(root).add_diag(torch.tensor(1.0))
+        root = torch.randn(3, 5, requires_grad=True)
+        return RootLazyTensor(root)
 
     def evaluate_lazy_tensor(self, lazy_tensor):
-        diag_tensor = lazy_tensor._diag_tensor.evaluate()
-        root = lazy_tensor._lazy_tensor.root.tensor
+        root = lazy_tensor.root.tensor
         res = root.matmul(root.transpose(-1, -2))
-        res = res + diag_tensor
         return res
-
-    def test_root_inv_decomposition(self):
-        # Trying to decompose the inverse of a low rank matrix is a recipe for disaster.
-        pass
 
 
 class TestRootLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):

--- a/test/lazy/test_sum_batch_lazy_tensor.py
+++ b/test/lazy/test_sum_batch_lazy_tensor.py
@@ -3,7 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import SumBatchLazyTensor, NonLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestSumBatchLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -21,7 +21,7 @@ class TestSumBatchLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return blocks.sum(0)
 
 
-class TestSumBatchLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestSumBatchLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 6
     should_test_sample = True
 

--- a/test/lazy/test_sum_lazy_tensor.py
+++ b/test/lazy/test_sum_lazy_tensor.py
@@ -3,7 +3,7 @@
 import torch
 import unittest
 from gpytorch.lazy import ToeplitzLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestSumLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -21,7 +21,7 @@ class TestSumLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return sum(tensors)
 
 
-class TestSumLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestSumLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 0
 
     def create_lazy_tensor(self):

--- a/test/lazy/test_toeplitz_lazy_tensor.py
+++ b/test/lazy/test_toeplitz_lazy_tensor.py
@@ -4,7 +4,7 @@ import torch
 import unittest
 import gpytorch.utils.toeplitz as toeplitz
 from gpytorch.lazy import ToeplitzLazyTensor
-from test.lazy._lazy_tensor_test_case import LazyTensorTestCase, BatchLazyTensorTestCase
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
 
 
 class TestToeplitzLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -18,7 +18,7 @@ class TestToeplitzLazyTensor(LazyTensorTestCase, unittest.TestCase):
         return toeplitz.sym_toeplitz(lazy_tensor.column)
 
 
-class TestToeplitzLazyTensorBatch(BatchLazyTensorTestCase, unittest.TestCase):
+class TestToeplitzLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 0
 
     def create_lazy_tensor(self):


### PR DESCRIPTION
- LazyTensors now have the methods `detach()`, `detach_()`, and `requires_grad_()`
- LazyTensors now have the property `requires_grad` (and setter), which returns if any of the associated tensors have a gradient required. The setter affects all associated tensors
- LazyTensorTestCase and BatchLazyTensorTestCase are now the same thing.