### PR TITLE
Refactor caches to live in PredictionStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/gpytorch/badge/?version=latest)](https://gpytorch.readthedocs.io/en/latest/?badge=latest)
 
 **News!**
- - The Beta release is currently out! Note that it **requires the PyTorch preview build** (pytorch-nightly, >= 1.0).
+ - The Beta release is currently out! Note that it **requires PyTorch >= 1.0.0**
  - If you need to install the alpha release (we recommend you use the latest version though!), check out [the alpha release](https://github.com/cornellius-gp/gpytorch/tree/alpha).
 
 GPyTorch is a Gaussian process library implemented using PyTorch. GPyTorch is designed for creating scalable, flexible, and modular Gaussian process models with ease. 
@@ -24,7 +24,7 @@ See our numerous [**examples and tutorials**](http://github.com/cornellius-gp/gp
 
 **N.B.** GPyTorch will not run on PyTorch 0.4.1 or earlier versions.
 
-The easiest way to install GPyTorch is by installing the **nightly PyTorch build** (`pytorch-nightly >= 1.0.0`) using the appropriate command from [here](https://pytorch.org/get-started/locally/).
+First make sure that you have PyTorch (`>= 1.0.0`) installed using the appropriate command from [here](https://pytorch.org/get-started/locally/).
 
 Then install GPyTorch using pip:
 

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -2,7 +2,7 @@ import torch
 from .. import beta_features
 from ..lazy import LazyTensor, InterpolatedLazyTensor, SumLazyTensor, MatmulLazyTensor, RootLazyTensor
 from ..utils.interpolation import left_interp, left_t_interp
-from ..utils.memoize import named_cached
+from ..utils.memoize import cached
 from ..distributions import MultivariateNormal
 
 _PREDICTION_STRATEGY_REGISTRY = {}
@@ -69,7 +69,7 @@ class DefaultPredictionStrategy(object):
         return test_train_covar.matmul(precomputed_cache)
 
     @property
-    @named_cached('mean_cache')
+    @cached(name='mean_cache')
     def mean_cache(self):
         train_mean = self.train_mean
         train_labels = self.train_labels
@@ -100,7 +100,7 @@ class DefaultPredictionStrategy(object):
         return mean_cache.detach()
 
     @property
-    @named_cached('covar_cache')
+    @cached(name='covar_cache')
     def covar_cache(self):
         train_train_covar = self.likelihood(
             MultivariateNormal(torch.zeros(1), self.train_train_covar), self.train_inputs
@@ -190,7 +190,7 @@ class InterpolatedPredictionStrategy(DefaultPredictionStrategy):
         return res
 
     @property
-    @named_cached('mean_cache')
+    @cached(name='mean_cache')
     def mean_cache(self):
         train_interp_indices = self.train_train_covar.left_interp_indices
         train_interp_values = self.train_train_covar.left_interp_values
@@ -210,7 +210,7 @@ class InterpolatedPredictionStrategy(DefaultPredictionStrategy):
         return mean_cache.detach()
 
     @property
-    @named_cached('covar_cache')
+    @cached(name='covar_cache')
     def covar_cache(self):
         # Get inverse root
         grv = MultivariateNormal(torch.zeros(1), self.train_train_covar)

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -2,6 +2,8 @@ import torch
 from .. import beta_features
 from ..lazy import LazyTensor, InterpolatedLazyTensor, SumLazyTensor, MatmulLazyTensor, RootLazyTensor
 from ..utils.interpolation import left_interp, left_t_interp
+from ..utils.memoize import named_cached
+from ..distributions import MultivariateNormal
 
 _PREDICTION_STRATEGY_REGISTRY = {}
 
@@ -17,14 +19,24 @@ def register_prediction_strategy(lazy_tsr_type):
     return decorator
 
 
-def prediction_strategy(train_train_covar):
+def prediction_strategy(
+    num_train, train_inputs, train_mean, train_train_covar, train_labels, likelihood, non_batch_train=False
+):
     cls = _PREDICTION_STRATEGY_REGISTRY.get(type(train_train_covar), DefaultPredictionStrategy)
-    return cls(train_train_covar)
+    return cls(num_train, train_inputs, train_mean, train_train_covar, train_labels, likelihood, non_batch_train)
 
 
 class DefaultPredictionStrategy(object):
-    def __init__(self, train_train_covar):
+    def __init__(
+        self, num_train, train_inputs, train_mean, train_train_covar, train_labels, likelihood, non_batch_train
+    ):
+        self.num_train = num_train
+        self.train_inputs = train_inputs
         self.train_train_covar = train_train_covar
+        self.train_mean = train_mean
+        self.train_labels = train_labels
+        self.likelihood = likelihood
+        self.non_batch_train = non_batch_train
 
     def _exact_predictive_covar_inv_quad_form_cache(self, train_train_covar_inv_root, test_train_covar):
         """
@@ -56,17 +68,52 @@ class DefaultPredictionStrategy(object):
         # where S S^T = (K_XX + sigma^2 I)^-1
         return test_train_covar.matmul(precomputed_cache)
 
-    def exact_predictive_mean(
-        self,
-        test_train_covar,
-        full_mean,
-        train_inputs,
-        train_labels,
-        num_train,
-        likelihood,
-        precomputed_cache=None,
-        non_batch_train=False,
-    ):
+    @property
+    @named_cached('mean_cache')
+    def mean_cache(self):
+        train_mean = self.train_mean
+        train_labels = self.train_labels
+
+        if self.non_batch_train and self.train_train_covar.dim() == 3:
+            train_train_covar = self.train_train_covar[0]
+        else:
+            train_train_covar = self.train_train_covar
+
+        if self.non_batch_train and train_mean.dim() == 2:
+            train_mean = train_mean[0]
+            train_labels = train_labels[0]
+
+        mvn = self.likelihood(MultivariateNormal(train_mean, train_train_covar), self.train_inputs)
+
+        train_mean, train_train_covar = mvn.mean, mvn.lazy_covariance_matrix
+
+        train_labels_offset = train_labels - train_mean
+
+        if self.train_train_covar.dim() == 3:
+            # Batch mode
+            train_labels_offset = train_labels_offset.unsqueeze(-1)
+            mean_cache = train_train_covar.inv_matmul(train_labels_offset).squeeze(-1)
+        else:
+            # Standard mode
+            mean_cache = train_train_covar.inv_matmul(train_labels_offset)
+
+        return mean_cache.detach()
+
+    @property
+    @named_cached('covar_cache')
+    def covar_cache(self):
+        train_train_covar = self.likelihood(
+            MultivariateNormal(torch.zeros(1), self.train_train_covar), self.train_inputs
+        ).lazy_covariance_matrix
+
+        if self.non_batch_train and train_train_covar.dim() == 3:
+            train_train_covar_inv_root = train_train_covar[0].root_inv_decomposition().root.evaluate()
+        else:
+            train_train_covar_inv_root = train_train_covar.root_inv_decomposition().root.evaluate()
+
+        return self._exact_predictive_covar_inv_quad_form_cache(train_train_covar_inv_root, self._last_test_train_covar)
+
+    def exact_predictive_mean(self, test_mean, test_train_covar):
         """
         Computes the posterior predictive covariance of a GP
 
@@ -81,57 +128,20 @@ class DefaultPredictionStrategy(object):
         Returns:
             :obj:`torch.tensor`: The predictive posterior mean of the test points
         """
-        from ..distributions import MultivariateNormal
-
-        if precomputed_cache is None:
-            train_mean = full_mean.narrow(-1, 0, num_train)
-
-            if non_batch_train and self.train_train_covar.dim() == 3:
-                train_train_covar = self.train_train_covar[0]
-            else:
-                train_train_covar = self.train_train_covar
-
-            train_mean = full_mean.narrow(-1, 0, train_train_covar.size(-1))
-            if non_batch_train and train_mean.dim() == 2:
-                train_mean = train_mean[0]
-                train_labels = train_labels[0]
-            mvn = likelihood(MultivariateNormal(train_mean, train_train_covar), train_inputs)
-
-            train_mean, train_train_covar = mvn.mean, mvn.lazy_covariance_matrix
-
-            train_labels_offset = train_labels - train_mean
-
-            if self.train_train_covar.dim() == 3:
-                # Batch mode
-                train_labels_offset = train_labels_offset.unsqueeze(-1)
-                precomputed_cache = train_train_covar.inv_matmul(train_labels_offset).squeeze(-1)
-            else:
-                # Standard mode
-                precomputed_cache = train_train_covar.inv_matmul(train_labels_offset)
-
-        test_mean = full_mean.narrow(-1, train_labels.size(-1), full_mean.size(-1) - train_labels.size(-1))
+        precomputed_cache = self.mean_cache
 
         if self.train_train_covar.dim() == 3:
             res = test_train_covar.matmul(precomputed_cache.unsqueeze(-1)).squeeze(-1)
         else:
-            if non_batch_train and precomputed_cache.dim() == 2:
+            if self.non_batch_train and precomputed_cache.dim() == 2:
                 precomputed_cache = precomputed_cache[0]
             res = test_train_covar.matmul(precomputed_cache)
 
         res = res + test_mean
 
-        return res, precomputed_cache.detach()
+        return res
 
-    def exact_predictive_covar(
-        self,
-        test_train_covar,
-        test_test_covar,
-        train_inputs,
-        num_train,
-        likelihood,
-        precomputed_cache=None,
-        non_batch_train=False,
-    ):
+    def exact_predictive_covar(self, test_test_covar, test_train_covar):
         """
         Computes the posterior predictive covariance of a GP
 
@@ -150,41 +160,26 @@ class DefaultPredictionStrategy(object):
         """
         from ..distributions import MultivariateNormal
 
-        train_train_covar = likelihood(
-            MultivariateNormal(torch.zeros(1), self.train_train_covar), train_inputs
-        ).lazy_covariance_matrix
         if not beta_features.fast_pred_var.on():
+            train_train_covar = self.likelihood(
+                MultivariateNormal(torch.zeros(1), self.train_train_covar), self.train_inputs
+            ).lazy_covariance_matrix
             test_train_covar = test_train_covar.evaluate()
             train_test_covar = test_train_covar.transpose(-1, -2)
             covar_correction_rhs = train_train_covar.inv_matmul(train_test_covar).mul(-1)
             res = test_test_covar + MatmulLazyTensor(test_train_covar, covar_correction_rhs)
-            return res, None
+            return res
 
-        if precomputed_cache is None:
-            if non_batch_train and train_train_covar.dim() == 3:
-                train_train_covar_inv_root = train_train_covar[0].root_inv_decomposition().root.evaluate()
-            else:
-                train_train_covar_inv_root = train_train_covar.root_inv_decomposition().root.evaluate()
-            precomputed_cache = self._exact_predictive_covar_inv_quad_form_cache(
-                train_train_covar_inv_root, test_train_covar
-            )
+        self._last_test_train_covar = test_train_covar
+        precomputed_cache = self.covar_cache
 
         covar_inv_quad_form_root = self._exact_predictive_covar_inv_quad_form_root(precomputed_cache, test_train_covar)
         res = test_test_covar + RootLazyTensor(covar_inv_quad_form_root).mul(-1)
-        return res, precomputed_cache
+        return res
 
 
 @register_prediction_strategy(InterpolatedLazyTensor)
 class InterpolatedPredictionStrategy(DefaultPredictionStrategy):
-    def __init__(self, train_train_covar):
-        if not isinstance(train_train_covar, InterpolatedLazyTensor):
-            raise TypeError(
-                "InterpolatedPredictionStrategy can only be used with InterpolatedLazyTensors, "
-                f"but got {type(train_train_covar)}"
-            )
-
-        super(InterpolatedPredictionStrategy, self).__init__(train_train_covar)
-
     def _exact_predictive_covar_inv_quad_form_cache(self, train_train_covar_inv_root, test_train_covar):
         train_interp_indices = test_train_covar.right_interp_indices
         train_interp_values = test_train_covar.right_interp_values
@@ -203,138 +198,118 @@ class InterpolatedPredictionStrategy(DefaultPredictionStrategy):
         res = left_interp(test_interp_indices, test_interp_values, precomputed_cache)
         return res
 
-    def exact_predictive_mean(
-        self,
-        test_train_covar,
-        full_mean,
-        train_inputs,
-        train_labels,
-        num_train,
-        likelihood,
-        precomputed_cache=None,
-        non_batch_train=False,
-    ):
-        from ..distributions import MultivariateNormal
+    @property
+    @named_cached('mean_cache')
+    def mean_cache(self):
+        train_interp_indices = self.train_train_covar.left_interp_indices
+        train_interp_values = self.train_train_covar.left_interp_values
 
-        if precomputed_cache is None:
-            train_interp_indices = self.train_train_covar.left_interp_indices
-            train_interp_values = self.train_train_covar.left_interp_values
+        mvn = self.likelihood(MultivariateNormal(self.train_mean, self.train_train_covar), self.train_inputs)
+        train_mean, train_train_covar = mvn.mean, mvn.lazy_covariance_matrix
 
-            train_mean = full_mean.narrow(-1, 0, train_labels.size(-1))
+        train_train_covar_inv_labels = train_train_covar.inv_matmul((self.train_labels - train_mean).unsqueeze(-1))
 
-            mvn = likelihood(MultivariateNormal(train_mean, self.train_train_covar), train_inputs)
-            train_mean, train_train_covar = mvn.mean, mvn.lazy_covariance_matrix
+        # New root factor
+        base_size = self.train_train_covar.base_lazy_tensor.size(-1)
+        mean_cache = self.train_train_covar.base_lazy_tensor.matmul(
+            left_t_interp(train_interp_indices, train_interp_values, train_train_covar_inv_labels, base_size)
+        )
 
-            train_train_covar_inv_labels = train_train_covar.inv_matmul((train_labels - train_mean).unsqueeze(-1))
+        # Prevent backprop through this variable
+        return mean_cache.detach()
 
-            # New root factor
-            base_size = self.train_train_covar.base_lazy_tensor.size(-1)
-            precomputed_cache = self.train_train_covar.base_lazy_tensor.matmul(
-                left_t_interp(train_interp_indices, train_interp_values, train_train_covar_inv_labels, base_size)
-            )
-
-            # Prevent backprop through this variable
-            precomputed_cache = precomputed_cache.detach()
-
-        # Compute the exact predictive posterior
-        n_test = test_train_covar.size(-2)
-
-        test_train_covar = test_train_covar.evaluate_kernel()
-
-        test_mean = full_mean.narrow(-1, num_train, n_test)
-        test_interp_indices = test_train_covar.left_interp_indices
-        test_interp_values = test_train_covar.left_interp_values
-        res = left_interp(test_interp_indices, test_interp_values, precomputed_cache).squeeze(-1) + test_mean
-        return res, precomputed_cache
-
-    def exact_predictive_covar(
-        self,
-        test_train_covar,
-        test_test_covar,
-        train_inputs,
-        num_train,
-        likelihood,
-        precomputed_cache=None,
-        non_batch_train=False,
-    ):
-        from ..distributions import MultivariateNormal
-
-        if not beta_features.fast_pred_var.on() and not beta_features.fast_pred_samples.on():
-            return super(InterpolatedPredictionStrategy, self).exact_predictive_covar(
-                test_train_covar, test_test_covar, train_inputs, num_train, likelihood, precomputed_cache
-            )
+    @property
+    @named_cached('covar_cache')
+    def covar_cache(self):
+        # Get inverse root
+        grv = MultivariateNormal(torch.zeros(1), self.train_train_covar)
+        train_train_covar = self.likelihood(grv, self.train_inputs).lazy_covariance_matrix
 
         train_interp_indices = self.train_train_covar.left_interp_indices
         train_interp_values = self.train_train_covar.left_interp_values
 
+        # Get probe vectors for inverse root
+        num_probe_vectors = beta_features.fast_pred_var.num_probe_vectors()
+        batch_size = train_interp_indices.size(0)
+        n_inducing = self.train_train_covar.base_lazy_tensor.size(-1)
+        vector_indices = torch.randperm(n_inducing).type_as(train_interp_indices)
+        probe_vector_indices = vector_indices[:num_probe_vectors]
+        test_vector_indices = vector_indices[num_probe_vectors : 2 * num_probe_vectors]
+
+        probe_interp_indices = probe_vector_indices.unsqueeze(1)
+        probe_test_interp_indices = test_vector_indices.unsqueeze(1)
+        dtype = self.train_train_covar.dtype
+        device = self.train_train_covar.device
+        probe_interp_values = torch.ones(num_probe_vectors, 1, dtype=dtype, device=device)
+        if train_interp_indices.ndimension() == 3:
+            probe_interp_indices = probe_interp_indices.unsqueeze(0).expand(batch_size, num_probe_vectors, 1)
+            probe_test_interp_indices = probe_test_interp_indices.unsqueeze(0)
+            probe_test_interp_indices = probe_test_interp_indices.expand(batch_size, num_probe_vectors, 1)
+            probe_interp_values = probe_interp_values.unsqueeze(0).expand(batch_size, num_probe_vectors, 1)
+
+        probe_vectors = InterpolatedLazyTensor(
+            self.train_train_covar.base_lazy_tensor,
+            train_interp_indices,
+            train_interp_values,
+            probe_interp_indices,
+            probe_interp_values,
+        ).evaluate()
+        test_vectors = InterpolatedLazyTensor(
+            self.train_train_covar.base_lazy_tensor,
+            train_interp_indices,
+            train_interp_values,
+            probe_test_interp_indices,
+            probe_interp_values,
+        ).evaluate()
+
+        # Get inverse root
+        train_train_covar_inv_root = train_train_covar.root_inv_decomposition(probe_vectors, test_vectors).root
+        train_train_covar_inv_root = train_train_covar_inv_root.evaluate()
+
+        # New root factor
+        root = self._exact_predictive_covar_inv_quad_form_cache(train_train_covar_inv_root, self._last_test_train_covar)
+
+        # Precomputed factor
+        if beta_features.fast_pred_samples.on():
+            inside = self.train_train_covar.base_lazy_tensor + RootLazyTensor(root).mul(-1)
+            inside_root = inside.root_decomposition().root.evaluate()
+            # Prevent backprop through this variable
+            inside_root = inside_root.detach()
+            covar_cache = inside_root, None
+        else:
+            # Prevent backprop through this variable
+            root = root.detach()
+            covar_cache = None, root
+
+        return covar_cache
+
+    def exact_predictive_mean(self, test_mean, test_train_covar):
+        precomputed_cache = self.mean_cache
+
         test_train_covar = test_train_covar.evaluate_kernel()
+
+        test_interp_indices = test_train_covar.left_interp_indices
+        test_interp_values = test_train_covar.left_interp_values
+        res = left_interp(test_interp_indices, test_interp_values, precomputed_cache).squeeze(-1) + test_mean
+        return res
+
+    def exact_predictive_covar(self, test_test_covar, test_train_covar):
+        if not beta_features.fast_pred_var.on() and not beta_features.fast_pred_samples.on():
+            return super(InterpolatedPredictionStrategy, self).exact_predictive_covar(test_test_covar, test_train_covar)
+
+        test_train_covar = test_train_covar.evaluate_kernel()
+        self._last_test_train_covar = test_train_covar
         test_test_covar = test_test_covar.evaluate_kernel()
 
         test_interp_indices = test_train_covar.left_interp_indices
         test_interp_values = test_train_covar.left_interp_values
 
-        if (
-            precomputed_cache is None
-            or (beta_features.fast_pred_samples.on() and precomputed_cache[0] is None)
-            or (not beta_features.fast_pred_samples.on() and precomputed_cache[1] is None)
+        precomputed_cache = self.covar_cache
+        if (beta_features.fast_pred_samples.on() and precomputed_cache[0] is None) or (
+            not beta_features.fast_pred_samples.on() and precomputed_cache[1] is None
         ):
-            # Get inverse root
-
-            grv = MultivariateNormal(torch.zeros(1), self.train_train_covar)
-            train_train_covar = likelihood(grv, train_inputs).lazy_covariance_matrix
-
-            # Get probe vectors for inverse root
-            num_probe_vectors = beta_features.fast_pred_var.num_probe_vectors()
-            batch_size = train_interp_indices.size(0)
-            n_inducing = self.train_train_covar.base_lazy_tensor.size(-1)
-            vector_indices = torch.randperm(n_inducing).type_as(train_interp_indices)
-            probe_vector_indices = vector_indices[:num_probe_vectors]
-            test_vector_indices = vector_indices[num_probe_vectors : 2 * num_probe_vectors]
-
-            probe_interp_indices = probe_vector_indices.unsqueeze(1)
-            probe_test_interp_indices = test_vector_indices.unsqueeze(1)
-            dtype = self.train_train_covar.dtype
-            device = self.train_train_covar.device
-            probe_interp_values = torch.ones(num_probe_vectors, 1, dtype=dtype, device=device)
-            if train_interp_indices.ndimension() == 3:
-                probe_interp_indices = probe_interp_indices.unsqueeze(0).expand(batch_size, num_probe_vectors, 1)
-                probe_test_interp_indices = probe_test_interp_indices.unsqueeze(0)
-                probe_test_interp_indices = probe_test_interp_indices.expand(batch_size, num_probe_vectors, 1)
-                probe_interp_values = probe_interp_values.unsqueeze(0).expand(batch_size, num_probe_vectors, 1)
-
-            probe_vectors = InterpolatedLazyTensor(
-                self.train_train_covar.base_lazy_tensor,
-                train_interp_indices,
-                train_interp_values,
-                probe_interp_indices,
-                probe_interp_values,
-            ).evaluate()
-            test_vectors = InterpolatedLazyTensor(
-                self.train_train_covar.base_lazy_tensor,
-                train_interp_indices,
-                train_interp_values,
-                probe_test_interp_indices,
-                probe_interp_values,
-            ).evaluate()
-
-            # Get inverse root
-            train_train_covar_inv_root = train_train_covar.root_inv_decomposition(probe_vectors, test_vectors).root
-            train_train_covar_inv_root = train_train_covar_inv_root.evaluate()
-
-            # New root factor
-            root = self._exact_predictive_covar_inv_quad_form_cache(train_train_covar_inv_root, test_train_covar)
-
-            # Precomputed factor
-            if beta_features.fast_pred_samples.on():
-                inside = self.train_train_covar.base_lazy_tensor + RootLazyTensor(root).mul(-1)
-                inside_root = inside.root_decomposition().root.evaluate()
-                # Prevent backprop through this variable
-                inside_root = inside_root.detach()
-                precomputed_cache = inside_root, None
-            else:
-                # Prevent backprop through this variable
-                root = root.detach()
-                precomputed_cache = None, root
+            self.__cache.pop('covar_cache')
+            precomputed_cache = self.covar_cache
 
         # Compute the exact predictive posterior
         if beta_features.fast_pred_samples.on():
@@ -343,18 +318,27 @@ class InterpolatedPredictionStrategy(DefaultPredictionStrategy):
         else:
             root = left_interp(test_interp_indices, test_interp_values, precomputed_cache[1])
             res = test_test_covar + RootLazyTensor(root).mul(-1)
-        return res, precomputed_cache
+        return res
 
 
 @register_prediction_strategy(SumLazyTensor)
 class SumPredictionStrategy(DefaultPredictionStrategy):
-    def __init__(self, train_train_covar):
-        if not isinstance(train_train_covar, SumLazyTensor):
-            raise TypeError(
-                f"SumPredictionStrategy can only be used with SumLazyTensors, but got {type(train_train_covar)}"
+    @property
+    def _sub_strategies(self):
+        sub_strategies = []
+        for lazy_tensor in self.train_train_covar.lazy_tensors:
+            pred_strat = prediction_strategy(
+                self.num_train,
+                self.train_inputs,
+                self.train_mean,
+                lazy_tensor,
+                self.train_labels,
+                self.likelihood,
+                self.non_batch_train,
             )
+            sub_strategies.append(pred_strat)
 
-        super(SumPredictionStrategy, self).__init__(train_train_covar)
+        return sub_strategies
 
     def _exact_predictive_covar_inv_quad_form_cache(self, train_train_covar_inv_root, test_train_covar):
         test_train_covar = test_train_covar.evaluate_kernel()
@@ -364,12 +348,8 @@ class SumPredictionStrategy(DefaultPredictionStrategy):
             )
         else:
             return tuple(
-                prediction_strategy(lazy_tensor)._exact_predictive_covar_inv_quad_form_cache(
-                    train_train_covar_inv_root, test_train_covar_comp
-                )
-                for lazy_tensor, test_train_covar_comp in zip(
-                    self.train_train_covar.lazy_tensors, test_train_covar.lazy_tensors
-                )
+                sub_strat._exact_predictive_covar_inv_quad_form_cache(train_train_covar_inv_root, test_train_covar_comp)
+                for sub_strat, test_train_covar_comp in zip(self._sub_strategies, test_train_covar.lazy_tensors)
             )
 
     def _exact_predictive_covar_inv_quad_form_root(self, precomputed_cache, test_train_covar):
@@ -382,11 +362,11 @@ class SumPredictionStrategy(DefaultPredictionStrategy):
             )
         else:
             return sum(
-                prediction_strategy(lazy_tensor)._exact_predictive_covar_inv_quad_form_root(
+                sub_strat._exact_predictive_covar_inv_quad_form_root(
                     cache_comp, test_train_covar_comp
                 )
-                for lazy_tensor, cache_comp, test_train_covar_comp in zip(
-                    self.train_train_covar.lazy_tensors,
+                for sub_strat, cache_comp, test_train_covar_comp in zip(
+                    self._sub_strategies,
                     precomputed_cache,
                     test_train_covar.evaluate_kernel().lazy_tensors,
                 )

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -118,12 +118,8 @@ class DefaultPredictionStrategy(object):
         Computes the posterior predictive covariance of a GP
 
         Args:
+            test_mean (:obj:`torch.tensor`): The test prior mean
             test_train_covar (:obj:`gpytorch.lazy.LazyTensor`): Covariance matrix between test and train inputs
-            full_mean (:obj:`torch.tensor`): the training and test prior means, stacked on top of each other
-            train_inputs (:obj:`torch.tensor`): The training data inputs
-            train_labels (:obj:`torch.tensor`): the training labels minus the training prior mean
-            noise (:obj:`torch.tensor`): the observed noise (from the likelihood)
-            precomputed_cache (optional): speeds up subsequent computations (default: None)
 
         Returns:
             :obj:`torch.tensor`: The predictive posterior mean of the test points
@@ -148,11 +144,6 @@ class DefaultPredictionStrategy(object):
         Args:
             test_train_covar (:obj:`gpytorch.lazy.LazyTensor`): Covariance matrix between test and train inputs
             test_test_covar (:obj:`gpytorch.lazy.LazyTensor`): Covariance matrix between test inputs
-            train_inputs (:obj:`torch.tensor`): The training data inputs
-            num_train (int): The number of training points in the full covariance matrix
-            noise (scalar): The observed noise (from the likelihood)
-            precomputed_cache (optional): speeds up subsequent computations (default: None)
-            non_batch_train (bool, optional): True if the training data was not batch mode.
 
         Returns:
             :obj:`gpytorch.lazy.LazyTensor`: A LazyTensor representing the predictive posterior covariance of the

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -3,31 +3,18 @@
 import functools
 
 
-def cached(f):
-    """A simple caching decorator for instance functions not taking any arguments"""
+def cached(method=None, name=None):
+    """A decorator allowing for specifying the name of a cache, allowing it to be modified elsewhere."""
+    if method is None:
+        return functools.partial(cached, name=name)
 
-    @functools.wraps(f)
+    @functools.wraps(method)
     def g(self):
         if not hasattr(self, "__cache"):
             self.__cache = dict()
-        if f not in self.__cache:
-            self.__cache[f] = f(self)
-        return self.__cache[f]
+        cache_name = name if name is None else method
+        if cache_name not in self.__cache:
+            self.__cache[cache_name] = method(self)
+        return self.__cache[cache_name]
 
     return g
-
-
-def named_cached(name):
-    """A decorator allowing for specifying the name of a cache, allowing it to be modified elsewhere."""
-    def named_cached_decorator(f):
-        @functools.wraps(f)
-        def g(self):
-            if not hasattr(self, "__cache"):
-                self.__cache = dict()
-            if name not in self.__cache:
-                self.__cache[name] = f(self)
-            return self.__cache[name]
-
-        return g
-
-    return named_cached_decorator

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -15,3 +15,19 @@ def cached(f):
         return self.__cache[f]
 
     return g
+
+
+def named_cached(name):
+    """A decorator allowing for specifying the name of a cache, allowing it to be modified elsewhere."""
+    def named_cached_decorator(f):
+        @functools.wraps(f)
+        def g(self):
+            if not hasattr(self, "__cache"):
+                self.__cache = dict()
+            if name not in self.__cache:
+                self.__cache[name] = f(self)
+            return self.__cache[name]
+
+        return g
+
+    return named_cached_decorator


### PR DESCRIPTION
Step two towards handling fantasy observations.

- `mean_cache` and `covar_cache` are now properties of `PredictionStrategies`, and `ExactGP` caches a prediction strategy rather than the mean and covariance caches.
- Introduces a new `named_cached` decorator that allows us to specify string names for the cache storage, which lets us modify the cache later. Right now, this is used once in `InterpolatedLazyTensor` to delete the covar cache if the beta features (`fast_pred_var` / `fast_pred_samples` have changed). 
- `PredictionStrategy` objects are now created using all relevant test independent items, simplifying the interface of `exact_predictive_mean` and `exact_predictive_covar`.
- `train_train_covar` is now also cached, avoiding computing the train-train covariance matrix a second time.

Eventually, I would like to additionally move the batch mode and multi task reshaping out of `ExactGP.__call__` and in to the creation of the prediction strategy.