### PR TITLE
If train_targets is a parameter, dont register it with Model

### DIFF
--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -29,6 +29,14 @@ class ExactGP(GP):
 
         self.prediction_strategy = None
 
+    @property
+    def train_targets(self):
+        return self._train_targets
+
+    @train_targets.setter
+    def train_targets(self, value):
+        object.__setattr__(self, '_train_targets', value)
+
     def _apply(self, fn):
         if self.train_inputs is not None:
             self.train_inputs = tuple(fn(train_input) for train_input in self.train_inputs)


### PR DESCRIPTION
Fixes a minor issue @keawang was having where if you make `train_x` and `train_y` parameters of a module before passing them in to the GP, doing `self.train_targets = train_targets` would also register them with the GP.

This doesn't happen for `train_inputs` because `train_inputs` is always a tuple, so doesn't trigger the special `torch.nn.Module.__setattr__` behavior.

I fixed this by creating a custom setter and getter for `train_targets`

cc/ @gpleiss 