### PR TITLE
Simplify and fix batch mode checks

### DIFF
--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -85,7 +85,6 @@ class ExactGP(GP):
             return full_output
         # Posterior mode
         else:
-            inputs = list(i.squeeze(0) if i.ndimension() == 3 else i for i in inputs)
             if settings.debug.on():
                 if all(torch.equal(train_input, input) for train_input, input in zip(train_inputs, inputs)):
                     warnings.warn(

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -153,7 +153,14 @@ class ExactGP(GP):
                 batch_shape = train_inputs[0].shape[:-2]
                 train_train_covar = self.prediction_strategy.train_train_covar
                 if len(batch_shape) > len(train_train_covar.batch_shape):
+                    # Expanding to add more batches
                     expanded_covar = train_train_covar.expand(*batch_shape, *train_train_covar.matrix_shape)
+                elif (
+                    len(batch_shape) == len(train_train_covar.batch_shape)
+                    and batch_shape.numel() != train_train_covar.batch_shape.numel()
+                ):
+                    # The test batch size has changed, we need to repeat it to a new batch size.
+                    expanded_covar = train_train_covar[0].expand(*batch_shape, *train_train_covar.matrix_shape)
                 else:
                     # We are leaving batch mode, not entering it.
                     expanded_covar = train_train_covar[0]

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -85,6 +85,7 @@ class ExactGP(GP):
             return full_output
         # Posterior mode
         else:
+            inputs = list(i.squeeze(0) if i.ndimension() == 3 else i for i in inputs)
             if settings.debug.on():
                 if all(torch.equal(train_input, input) for train_input, input in zip(train_inputs, inputs)):
                     warnings.warn(

--- a/test/examples/test_batch_gp_regression.py
+++ b/test/examples/test_batch_gp_regression.py
@@ -97,6 +97,12 @@ class TestBatchGPRegression(unittest.TestCase):
         gp_model.eval()
         likelihood.eval()
 
+        # First test on non-batch
+        non_batch_predictions = likelihood(gp_model(test_x1))
+        preds1 = non_batch_predictions.mean
+        mean_abs_error1 = torch.mean(torch.abs(test_y1 - preds1))
+        self.assertLess(mean_abs_error1.squeeze().item(), 0.1)
+
         # Make predictions for both sets of test points, and check MAEs.
         batch_predictions = likelihood(gp_model(test_x12))
         preds1 = batch_predictions.mean[0]
@@ -105,6 +111,12 @@ class TestBatchGPRegression(unittest.TestCase):
         mean_abs_error2 = torch.mean(torch.abs(test_y2 - preds2))
         self.assertLess(mean_abs_error1.squeeze().item(), 0.1)
         self.assertLess(mean_abs_error2.squeeze().item(), 0.1)
+
+        # Smoke test for batch mode derivatives failing
+        test_x_param = torch.nn.Parameter(test_x12.data)
+        batch_predictions = likelihood(gp_model(test_x_param))
+        batch_predictions.mean.sum().backward()
+        self.assertTrue(test_x_param.grad is not None)
 
     def test_train_on_batch_test_on_batch(self):
         # We're manually going to set the hyperparameters to something they shouldn't be

--- a/test/examples/test_batch_gp_regression.py
+++ b/test/examples/test_batch_gp_regression.py
@@ -112,6 +112,12 @@ class TestBatchGPRegression(unittest.TestCase):
         self.assertLess(mean_abs_error1.squeeze().item(), 0.1)
         self.assertLess(mean_abs_error2.squeeze().item(), 0.1)
 
+        # Smoke test for non-batch mode derivatives failing
+        test_x_param = torch.nn.Parameter(test_x1.data)
+        batch_predictions = likelihood(gp_model(test_x_param))
+        batch_predictions.mean.sum().backward()
+        self.assertTrue(test_x_param.grad is not None)
+
         # Smoke test for batch mode derivatives failing
         test_x_param = torch.nn.Parameter(test_x12.data)
         batch_predictions = likelihood(gp_model(test_x_param))
@@ -148,6 +154,12 @@ class TestBatchGPRegression(unittest.TestCase):
         gp_model.eval()
         likelihood.eval()
 
+        # First test on non-batch
+        non_batch_predictions = likelihood(gp_model(test_x1))
+        preds1 = non_batch_predictions.mean
+        mean_abs_error1 = torch.mean(torch.abs(test_y1 - preds1[0]))
+        self.assertLess(mean_abs_error1.squeeze().item(), 0.1)
+
         # Make predictions for both sets of test points, and check MAEs.
         batch_predictions = likelihood(gp_model(test_x12))
         preds1 = batch_predictions.mean[0]
@@ -156,6 +168,18 @@ class TestBatchGPRegression(unittest.TestCase):
         mean_abs_error2 = torch.mean(torch.abs(test_y2 - preds2))
         self.assertLess(mean_abs_error1.squeeze().item(), 0.1)
         self.assertLess(mean_abs_error2.squeeze().item(), 0.1)
+
+        # Smoke test for batch mode derivatives failing
+        test_x_param = torch.nn.Parameter(test_x12.data)
+        batch_predictions = likelihood(gp_model(test_x_param))
+        batch_predictions.mean.sum().backward()
+        self.assertTrue(test_x_param.grad is not None)
+
+        # Smoke test for non-batch mode derivatives failing
+        test_x_param = torch.nn.Parameter(test_x1.data)
+        batch_predictions = likelihood(gp_model(test_x_param))
+        batch_predictions.mean.sum().backward()
+        self.assertTrue(test_x_param.grad is not None)
 
     def test_train_on_batch_test_on_batch_shared_hypers_over_batch(self):
         # We're manually going to set the hyperparameters to something they shouldn't be
@@ -187,6 +211,12 @@ class TestBatchGPRegression(unittest.TestCase):
         gp_model.eval()
         likelihood.eval()
 
+        # First test on non-batch
+        non_batch_predictions = likelihood(gp_model(test_x1))
+        preds1 = non_batch_predictions.mean
+        mean_abs_error1 = torch.mean(torch.abs(test_y1 - preds1[0]))
+        self.assertLess(mean_abs_error1.squeeze().item(), 0.1)
+
         # Make predictions for both sets of test points, and check MAEs.
         batch_predictions = likelihood(gp_model(test_x12))
         preds1 = batch_predictions.mean[0]
@@ -195,6 +225,18 @@ class TestBatchGPRegression(unittest.TestCase):
         mean_abs_error2 = torch.mean(torch.abs(test_y2 - preds2))
         self.assertLess(mean_abs_error1.squeeze().item(), 0.1)
         self.assertLess(mean_abs_error2.squeeze().item(), 0.1)
+
+        # Smoke test for batch mode derivatives failing
+        test_x_param = torch.nn.Parameter(test_x12.data)
+        batch_predictions = likelihood(gp_model(test_x_param))
+        batch_predictions.mean.sum().backward()
+        self.assertTrue(test_x_param.grad is not None)
+
+        # Smoke test for non-batch mode derivatives failing
+        test_x_param = torch.nn.Parameter(test_x1.data)
+        batch_predictions = likelihood(gp_model(test_x_param))
+        batch_predictions.mean.sum().backward()
+        self.assertTrue(test_x_param.grad is not None)
 
 
 if __name__ == "__main__":

--- a/test/models/test_exact_gp.py
+++ b/test/models/test_exact_gp.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import torch
+import gpytorch
+import unittest
+from gpytorch.models import ExactGP
+from test.models._model_test_case import _ModelTestCase
+
+
+class ExactGPModel(ExactGP):
+    def __init__(self, train_x, train_y, likelihood):
+        super(ExactGPModel, self).__init__(train_x, train_y, likelihood)
+        self.mean_module = gpytorch.means.ConstantMean()
+        self.covar_module = gpytorch.kernels.ScaleKernel(gpytorch.kernels.RBFKernel())
+
+    def forward(self, x):
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
+        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+
+
+class TestVariationalGP(_ModelTestCase, unittest.TestCase):
+    def create_model(self, train_x, train_y, likelihood):
+        model = ExactGPModel(train_x, train_y, likelihood)
+        return model
+
+    def create_test_data(self):
+        return torch.randn(50, 1)
+
+    def create_likelihood_and_labels(self):
+        likelihood = gpytorch.likelihoods.GaussianLikelihood()
+        labels = torch.randn(50) + 2
+        return likelihood, labels
+
+    def create_batch_test_data(self, batch_size=3):
+        return torch.randn(batch_size, 50, 1)
+
+    def create_batch_likelihood_and_labels(self, batch_size=3):
+        likelihood = gpytorch.likelihoods.GaussianLikelihood(batch_size=batch_size)
+        labels = torch.randn(batch_size, 50) + 2
+        return likelihood, labels
+
+    def test_batch_forward_then_nonbatch_forward_eval(self):
+        batch_data = self.create_batch_test_data()
+        likelihood, labels = self.create_batch_likelihood_and_labels()
+        model = self.create_model(batch_data, labels, likelihood)
+        model.eval()
+        output = model(batch_data)
+
+        # Smoke test derivatives working
+        output.mean.sum().backward()
+
+        self.assertTrue(output.lazy_covariance_matrix.dim() == 3)
+        self.assertTrue(output.lazy_covariance_matrix.size(-1) == batch_data.size(-2))
+        self.assertTrue(output.lazy_covariance_matrix.size(-2) == batch_data.size(-2))
+
+        # Create non-batch data
+        data = self.create_test_data()
+        output = model(data)
+        self.assertTrue(output.lazy_covariance_matrix.dim() == 3)
+        self.assertTrue(output.lazy_covariance_matrix.size(-1) == data.size(-2))
+        self.assertTrue(output.lazy_covariance_matrix.size(-2) == data.size(-2))
+
+        # Smoke test derivatives working
+        output.mean.sum().backward()
+
+    def test_batch_forward_then_different_batch_forward_eval(self):
+
+        non_batch_data = self.create_test_data()
+        likelihood, labels = self.create_likelihood_and_labels()
+        model = self.create_model(non_batch_data, labels, likelihood)
+        model.eval()
+
+        # Batch size 3
+        batch_data = self.create_batch_test_data()
+        output = model(batch_data)
+        self.assertTrue(output.lazy_covariance_matrix.dim() == 3)
+        self.assertTrue(output.lazy_covariance_matrix.size(-1) == batch_data.size(-2))
+        self.assertTrue(output.lazy_covariance_matrix.size(-2) == batch_data.size(-2))
+
+        # Now Batch size 2
+        batch_data = self.create_batch_test_data(batch_size=2)
+        output = model(batch_data)
+        self.assertTrue(output.lazy_covariance_matrix.dim() == 3)
+        self.assertTrue(output.lazy_covariance_matrix.size(-1) == batch_data.size(-2))
+        self.assertTrue(output.lazy_covariance_matrix.size(-2) == batch_data.size(-2))
+
+        # Now 3 again
+        batch_data = self.create_batch_test_data()
+        output = model(batch_data)
+        self.assertTrue(output.lazy_covariance_matrix.dim() == 3)
+        self.assertTrue(output.lazy_covariance_matrix.size(-1) == batch_data.size(-2))
+        self.assertTrue(output.lazy_covariance_matrix.size(-2) == batch_data.size(-2))
+
+        # Now 1
+        batch_data = self.create_batch_test_data(batch_size=1)
+        output = model(batch_data)
+        self.assertTrue(output.lazy_covariance_matrix.dim() == 3)
+        self.assertTrue(output.lazy_covariance_matrix.size(-1) == batch_data.size(-2))
+        self.assertTrue(output.lazy_covariance_matrix.size(-2) == batch_data.size(-2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/models/test_variational_gp.py
+++ b/test/models/test_variational_gp.py
@@ -28,8 +28,8 @@ class GPClassificationModel(AbstractVariationalGP):
 
 
 class TestVariationalGP(VariationalModelTestCase, unittest.TestCase):
-    def create_model(self, train_data):
-        model = GPClassificationModel(train_data)
+    def create_model(self, train_x, train_y, likelihood):
+        model = GPClassificationModel(train_x)
         return model
 
     def create_test_data(self):
@@ -40,12 +40,12 @@ class TestVariationalGP(VariationalModelTestCase, unittest.TestCase):
         labels = torch.randn(50) + 2
         return likelihood, labels
 
-    def create_batch_test_data(self):
-        return torch.randn(3, 50, 1)
+    def create_batch_test_data(self, batch_size=3):
+        return torch.randn(batch_size, 50, 1)
 
-    def create_batch_likelihood_and_labels(self):
-        likelihood = gpytorch.likelihoods.GaussianLikelihood(batch_size=3)
-        labels = torch.randn(3, 50) + 2
+    def create_batch_likelihood_and_labels(self, batch_size=3):
+        likelihood = gpytorch.likelihoods.GaussianLikelihood(batch_size=batch_size)
+        labels = torch.randn(batch_size, 50) + 2
         return likelihood, labels
 
 


### PR DESCRIPTION
This PR dramatically simplifies the batch + multitask checks we did in `ExactGP.__call__` to three lines of code. In addition, it makes progress on handling arbitrary batch dimensions by not explicitly assuming only the first dimension is a batch dimension.

This also fixes a bug where we need to update the PredictiveStrategy objects if we expand the train objects to match batch mode test data. We also now use a BatchRepeatLazyTensor to expand `train_train_covar` if needed.

I also added unit test coverage to `test_batch_gp_regerssion` to make sure this doesn't happen again.
