### PR TITLE
Add option to not detach test caches

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -52,7 +52,10 @@ class DefaultPredictionStrategy(object):
         Returns
             - A precomputed cache
         """
-        return train_train_covar_inv_root.detach()
+        if settings.detach_test_caches.on():
+            return train_train_covar_inv_root.detach()
+        else:
+            return train_train_covar_inv_root
 
     def _exact_predictive_covar_inv_quad_form_root(self, precomputed_cache, test_train_covar):
         """
@@ -101,7 +104,10 @@ class DefaultPredictionStrategy(object):
             # Standard mode
             mean_cache = train_train_covar.inv_matmul(train_labels_offset)
 
-        return mean_cache.detach()
+        if settings.detach_test_caches.on():
+            return mean_cache.detach()
+        else:
+            return mean_cache
 
     @property
     @cached(name="covar_cache")
@@ -213,7 +219,10 @@ class InterpolatedPredictionStrategy(DefaultPredictionStrategy):
         )
 
         # Prevent backprop through this variable
-        return mean_cache.detach()
+        if settings.detach_test_caches.on():
+            return mean_cache.detach()
+        else:
+            return mean_cache
 
     @property
     @cached(name="covar_cache")
@@ -271,11 +280,13 @@ class InterpolatedPredictionStrategy(DefaultPredictionStrategy):
             inside = self.train_train_covar.base_lazy_tensor + RootLazyTensor(root).mul(-1)
             inside_root = inside.root_decomposition().root.evaluate()
             # Prevent backprop through this variable
-            inside_root = inside_root.detach()
+            if settings.detach_test_caches.on():
+                inside_root = inside_root.detach()
             covar_cache = inside_root, None
         else:
             # Prevent backprop through this variable
-            root = root.detach()
+            if settings.detach_test_caches.on():
+                root = root.detach()
             covar_cache = None, root
 
         return covar_cache

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -59,6 +59,17 @@ class check_training_data(_feature_flag):
     _state = True
 
 
+class detach_test_caches(_feature_flag):
+    """
+    Whether or not to detach caches computed for making predictions. In most cases, you will want this,
+    as this will speed up derivative computations of the predictions with respect to test inputs. However,
+    if you also need derivatives with respect to training inputs (e.g., because you have fantasy observations),
+    then you must disable this.
+    """
+
+    _state = True
+
+
 class debug(_feature_flag):
     """
     Whether or not to perform "safety" checks on the supplied data.


### PR DESCRIPTION
On master, if you ever need derivatives with respect to *training* inputs at test time, that will not work properly because we detach the training dependent caches we use for predictions. Derivatives with respect to test inputs work just fine.

On the other hand, not detaching the caches by default can lead to performance issues and issues with needing to retain the graph unnecessarily.

To solve this, I've introduced a `detach_test_caches` option that is enabled by default. By disabling this, it is possible to get derivatives with respect to training inputs.

To allow derivatives with respect to the training inputs, just do:
```python
with gpytorch.settings.detach_test_caches(False):
    ...
```

@Balandat This was actually broken before the predictions got moved out: we still detached the caches, but we did so *after* the first set of predictions. Thus, while we got derivatives correctly the first time predictions were made, any subsequent predictions after the first would not get appropriate derivatives. This option fixes that issue.