### PR TITLE
Normalize error for pivoted Cholesky

### DIFF
--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -22,7 +22,7 @@ def pivoted_cholesky(matrix, max_iter, error_tol=1e-3):
 
     # What we're returning
     L = torch.zeros(*batch_shape, max_iter, matrix_shape[-1], dtype=matrix.dtype, device=matrix.device)
-    orig_error = torch.norm(matrix_diag, 1, dim=-1)
+    orig_error = torch.max(matrix_diag, dim=-1)[0]
     errors = torch.norm(matrix_diag, 1, dim=-1) / orig_error
 
     # The permutation
@@ -39,7 +39,7 @@ def pivoted_cholesky(matrix, max_iter, error_tol=1e-3):
     ]
 
     m = 0
-    while m < max_iter and torch.max(errors) > error_tol:
+    while (m == 0) or (m < max_iter and torch.max(errors) > error_tol):
         permuted_diags = torch.gather(matrix_diag, -1, permutation[..., m:])
         max_diag_values, max_diag_indices = torch.max(permuted_diags, -1)
 

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -22,7 +22,8 @@ def pivoted_cholesky(matrix, max_iter, error_tol=1e-3):
 
     # What we're returning
     L = torch.zeros(*batch_shape, max_iter, matrix_shape[-1], dtype=matrix.dtype, device=matrix.device)
-    errors = torch.norm(matrix_diag, 1, dim=-1)
+    orig_error = torch.norm(matrix_diag, 1, dim=-1)
+    errors = torch.norm(matrix_diag, 1, dim=-1) / orig_error
 
     # The permutation
     permutation = torch.arange(0, matrix_shape[-1], dtype=torch.long, device=matrix_diag.device)
@@ -75,7 +76,7 @@ def pivoted_cholesky(matrix, max_iter, error_tol=1e-3):
             matrix_diag.scatter_(-1, pi_i, matrix_diag_current - L_m_new ** 2)
             L[..., m, :] = L_m
 
-            errors = torch.norm(matrix_diag.gather(-1, pi_i), 1, dim=-1)
+            errors = torch.norm(matrix_diag.gather(-1, pi_i), 1, dim=-1) / orig_error
         m = m + 1
 
     return L[..., :m, :].contiguous()


### PR DESCRIPTION
Prevents pivoted Cholesky from terminating too soon on matrices with very small diagonals.