### PR TITLE
Add interface for fantasy observations and efficient cache updates

### DIFF
--- a/gpytorch/functions/_matmul.py
+++ b/gpytorch/functions/_matmul.py
@@ -50,7 +50,13 @@ class Matmul(Function):
                 lazy_tsr = self._lazy_tsr
             else:
                 lazy_tsr = self.representation_tree(*matrix_args)
-            rhs_grad = lazy_tsr._t_matmul(grad_output)
+
+            if grad_output.dim() == 1:
+                # Confusing Cublas_Sgemv bug when grad_output is single dimensional on GPU.
+                rhs_grad = lazy_tsr._t_matmul(grad_output.unsqueeze(-1)).squeeze(-1)
+            else:
+                rhs_grad = lazy_tsr._t_matmul(grad_output)
+
             rhs_grad = rhs_grad.view(rhs_shape)
 
         return tuple([rhs_grad] + list(arg_grads))

--- a/gpytorch/functions/_root_decomposition.py
+++ b/gpytorch/functions/_root_decomposition.py
@@ -38,6 +38,7 @@ class RootDecomposition(Function):
         - (Tensor) R_inv, such that R_inv R_inv^T \approx A^{-1} (will only be populated if self.inverse = True)
         """
         from ..lazy import NonLazyTensor
+
         # Get closure for matmul
         lazy_tsr = self.representation_tree(*matrix_args)
         matmul_closure = lazy_tsr._matmul
@@ -61,7 +62,9 @@ class RootDecomposition(Function):
         n_probes = t_mat.size(0)
 
         mins = NonLazyTensor(t_mat).diag().min(dim=-1, keepdim=True)[0].unsqueeze(-1)
-        jitter_mat = (1e-6 * mins) * torch.eye(t_mat.size(-1)).type_as(t_mat).expand_as(t_mat)
+        jitter_mat = (settings.tridiagonal_jitter.value() * mins) * torch.eye(t_mat.size(-1)).type_as(t_mat).expand_as(
+            t_mat
+        )
         eigenvalues, eigenvectors = lanczos_tridiag_to_diag(t_mat + jitter_mat)
 
         # Get orthogonal matrix and eigenvalue roots

--- a/gpytorch/functions/_root_decomposition.py
+++ b/gpytorch/functions/_root_decomposition.py
@@ -59,7 +59,8 @@ class RootDecomposition(Function):
             t_mat = t_mat.unsqueeze(0)
         n_probes = t_mat.size(0)
 
-        eigenvalues, eigenvectors = lanczos_tridiag_to_diag(t_mat + 1e-5 * torch.eye(t_mat.size(-1)).expand_as(t_mat))
+        jitter_mat = 1e-5 * torch.eye(t_mat.size(-1)).type_as(t_mat).expand_as(t_mat)
+        eigenvalues, eigenvectors = lanczos_tridiag_to_diag(t_mat + jitter_mat)
 
         # Get orthogonal matrix and eigenvalue roots
         q_mat = q_mat.matmul(eigenvectors)

--- a/gpytorch/functions/_root_decomposition.py
+++ b/gpytorch/functions/_root_decomposition.py
@@ -50,6 +50,7 @@ class RootDecomposition(Function):
             batch_shape=self.batch_shape,
             init_vecs=self.initial_vectors,
         )
+
         if self.batch_shape is None:
             q_mat = q_mat.unsqueeze(-3)
             t_mat = t_mat.unsqueeze(-3)
@@ -58,11 +59,12 @@ class RootDecomposition(Function):
             t_mat = t_mat.unsqueeze(0)
         n_probes = t_mat.size(0)
 
-        eigenvalues, eigenvectors = lanczos_tridiag_to_diag(t_mat)
+        eigenvalues, eigenvectors = lanczos_tridiag_to_diag(t_mat + 1e-5 * torch.eye(t_mat.size(-1)).expand_as(t_mat))
 
         # Get orthogonal matrix and eigenvalue roots
         q_mat = q_mat.matmul(eigenvectors)
         root_evals = eigenvalues.sqrt()
+
         # Store q_mat * t_mat_chol
         # Decide if we're computing the inverse, or the regular root
         root = torch.empty(0, dtype=q_mat.dtype, device=q_mat.device)

--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -2,6 +2,7 @@
 
 import itertools
 import torch
+from ..utils.memoize import cached
 
 from .lazy_tensor import LazyTensor
 from .root_lazy_tensor import RootLazyTensor
@@ -178,6 +179,7 @@ class BatchRepeatLazyTensor(LazyTensor):
     def root_decomposition(self):
         return RootLazyTensor(self.base_lazy_tensor.root_decomposition().root.repeat(*self.batch_repeat, 1, 1))
 
+    @cached
     def root_inv_decomposition(self, initial_vectors=None, test_vectors=None):
         return RootLazyTensor(
             self.base_lazy_tensor.root_inv_decomposition(

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -992,6 +992,7 @@ class LazyTensor(object):
         )(*self.representation())
         return RootLazyTensor(res)
 
+    @cached
     def root_inv_decomposition(self, initial_vectors=None, test_vectors=None):
         """
         Returns a (usually low-rank) root decomposotion lazy tensor of a PSD matrix.

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -960,6 +960,7 @@ class LazyTensor(object):
         self.requires_grad = val
         return self
 
+    @cached(name="root_decomposition")
     def root_decomposition(self):
         """
         Returns a (usually low-rank) root decomposotion lazy tensor of a PSD matrix.
@@ -1038,6 +1039,11 @@ class LazyTensor(object):
             inverse=True,
             initial_vectors=initial_vectors,
         )(*self.representation())
+
+        if initial_vectors is not None and initial_vectors.size(-1) > 1:
+            getattr(self, '__cache')["root_decomposition"] = RootLazyTensor(roots[0])
+        else:
+            getattr(self, '__cache')["root_decomposition"] = RootLazyTensor(roots)
 
         # Choose the best of the inv_roots, if there were more than one initial vectors
         if initial_vectors is not None and initial_vectors.size(-1) > 1:

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -94,11 +94,19 @@ class ExactGP(GP):
 
         full_output = super(ExactGP, self).__call__(*full_inputs, **kwargs)
 
+        # Copy model without copying training data or prediction strategy (since we'll overwrite those)
         from copy import deepcopy
         old_pred_strat = self.prediction_strategy
+        old_train_inputs = self.train_inputs
+        old_train_targets = self.train_targets
         self.prediction_strategy = None
+        self.train_inputs = None
+        self.train_targets = None
         new_model = deepcopy(self)
         self.prediction_strategy = old_pred_strat
+        self.train_inputs = old_train_inputs
+        self.train_targets = old_train_targets
+
         new_model.train_inputs = full_inputs
         new_model.train_targets = full_targets
         new_model.prediction_strategy = old_pred_strat.get_fantasy_strategy(

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -96,10 +96,13 @@ class ExactGP(GP):
         full_output = super(ExactGP, self).__call__(*full_inputs, **kwargs)
 
         from copy import deepcopy
+        old_pred_strat = self.prediction_strategy
+        self.prediction_strategy = None
         new_model = deepcopy(self)
+        self.prediction_strategy = old_pred_strat
         new_model.train_inputs = full_inputs
         new_model.train_targets = full_targets
-        new_model.prediction_strategy = self.prediction_strategy.get_fantasy_strategy(
+        new_model.prediction_strategy = old_pred_strat.get_fantasy_strategy(
             inputs,
             targets,
             full_inputs,

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -76,7 +76,6 @@ class ExactGP(GP):
         if not isinstance(inputs, list):
             inputs = [inputs]
 
-        # TODO: Move this code to a new method for re-use with __call__
         inputs = list(i.unsqueeze(-1) if i.ndimension() == 1 else i for i in inputs)
 
         # If input is n x d but targets is b x n x d, expand input to b x n x d

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -77,6 +77,23 @@ class DefaultPredictionStrategy(object):
         return test_train_covar.matmul(precomputed_cache)
 
     def get_fantasy_strategy(self, inputs, targets, full_inputs, full_targets, full_output):
+        """
+        Returns a new PredictionStrategy that incorporates the specified inputs and targets as new training data.
+
+        This method is primary responsible for updating the mean and covariance caches. To add fantasy data to a
+        GP model, use the :meth:`~gpytorch.models.ExactGP.get_fantasy_model` method.
+
+        Args:
+            - :attr:`inputs` (Tensor `m x d` or `b x m x d`): Locations of fantasy observations.
+            - :attr:`targets` (Tensor `m` or `b x m`): Labels of fantasy observations.
+            - :attr:`full_inputs` (Tensor `n+m x d` or `b x n+m x d`): Training data concatenated with fantasy inputs
+            - :attr:`full_targets` (Tensor `n+m` or `b x n+m`): Training labels concatenated with fantasy labels.
+            - :attr:`full_output` (:class:`gpytorch.distributions.MultivariateNormal`): Prior called on full_inputs
+        Returns:
+            - :class:`DefaultPredictionStrategy`
+                A `DefaultPredictionStrategy` model with `n + m` training examples, where the `m` fantasy examples have
+                been added and all test-time caches have been updated.
+        """
         full_mean, full_covar = full_output.mean, full_output.lazy_covariance_matrix
 
         batch_shape = full_inputs[0].shape[:-2]

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -182,6 +182,17 @@ class max_preconditioner_size(_value_context):
     _global_value = 5
 
 
+class tridiagonal_jitter(_value_context):
+    """
+    The (relative) amount of noise to add to the diagonal of tridiagonal matrices before
+    eigendecomposing. root_decomposition becomes slightly more stable with this, as we need
+    to take the square root of the eigenvalues. Any eigenvalues still negative after adding jitter
+    will be zeroed out.
+    """
+
+    _global_value = 1e-6
+
+
 class max_lanczos_quadrature_iterations(_value_context):
     """
     The maximum number of Lanczos iterations to perform when doing stochastic

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -9,12 +9,12 @@ def cached(method=None, name=None):
         return functools.partial(cached, name=name)
 
     @functools.wraps(method)
-    def g(self):
+    def g(self, *args, **kwargs):
         if not hasattr(self, "__cache"):
             self.__cache = dict()
         cache_name = name if name is not None else method
         if cache_name not in self.__cache:
-            self.__cache[cache_name] = method(self)
+            self.__cache[cache_name] = method(self, *args, **kwargs)
         return self.__cache[cache_name]
 
     return g

--- a/test/examples/test_simple_gp_regression.py
+++ b/test/examples/test_simple_gp_regression.py
@@ -159,6 +159,10 @@ class TestSimpleGPRegression(unittest.TestCase):
 
         self.assertLess(mean_abs_error.item(), 0.05)
 
+    def test_fantasy_updates_cuda(self):
+        if torch.cuda.is_available():
+            self.test_fantasy_updates(cuda=True)
+
     def test_fantasy_updates(self, cuda=False):
         train_x, test_x, train_y, test_y = self._get_data(cuda=cuda)
         # We're manually going to set the hyperparameters to something they shouldn't be
@@ -204,7 +208,7 @@ class TestSimpleGPRegression(unittest.TestCase):
         gp_model.set_train_data(train_x[:5], train_y[:5], strict=False)
         likelihood(gp_model(test_x))
 
-        fantasy_x = torch.nn.Parameter(train_x[5:])
+        fantasy_x = train_x[5:].clone().requires_grad_(True)
         fant_model = gp_model.get_fantasy_model(fantasy_x, train_y[5:])
         fant_function_predictions = likelihood(fant_model(test_x))
 


### PR DESCRIPTION
At long last!

Adds official support for updating an `ExactGP` with fantasy observations:
```python
# Get predictions with original model
test_x = torch.linspace(0, 1, 51)
observed_pred = likelihood(model(test_x))
...
# Get a new model with fantasy observations added to training set, make predictions
fant_model = model.get_fantasy_model(fantasy_x, fantasy_y)
observed_pred = likelihood(fant_model(test_x))
```
The `get_fantasy_model` method returns a copy of `model` with `train_targets`, `train_inputs`, and `prediction_strategy` updated to account for the fantasy data being added to the training set. At the moment, the mean cache is using an efficient bordered linear system solve, rather than computed from scratch. Covariance cache updates are coming soon

## To-do in this PR
- [x] Update covariance cache as well
- [x] Add unit test to test if fantasy model gives same prediction as updating the training data directly with `set_train_data`. (I have this in a notebook, and it passes).
- [x] Add a unit test to ensure we get derivatives w.r.t. fantasy inputs if required, even if `detach_test_caches` is `True`.

## To-do in a later PR
- Add support for adding fantasies to multi-task GPs (really easy, just want to keep the PR small).
- Add support for models that use `InterpolatedLazyTensors`