### PR TITLE
`inv_matmul` function takes optional argument for left multiply

### DIFF
--- a/gpytorch/functions/__init__.py
+++ b/gpytorch/functions/__init__.py
@@ -89,23 +89,42 @@ def matmul(mat, rhs):
     return mat.matmul(rhs)
 
 
-def inv_matmul(mat, rhs):
-    """
-    Computes a linear solve with several right hand sides.
+def inv_matmul(mat, right_tensor, left_tensor=None):
+    r"""
+    Computes a linear solve (w.r.t :attr:`mat` = :math:`A`) with several right hand sides :math:`R`.
+    I.e. computes
+
+    ... math::
+
+        \begin{equation}
+            A^{-1} R,
+        \end{equation}
+
+    where :math:`R` is :attr:`right_tensor` and :math:`A` is :attr:`mat`.
+
+    If :attr:`left_tensor` is supplied, computes
+
+    ... math::
+
+        \begin{equation}
+            L A^{-1} R,
+        \end{equation}
+
+    where :math:`L` is :attr:`left_tensor`. Supplying this can reduce the number of
+    CG calls required.
 
     Args:
-        - mat (matrix nxn) - Matrix to solve with
-        - rhs (matrix nxk) - rhs matrix or vector
+        - :obj:`torch.tensor` (n x k) - Matrix :math:`R` right hand sides
+        - :obj:`torch.tensor` (m x n) - Optional matrix :math:`L` to perform left multiplication with
 
     Returns:
-        - matrix nxk - (mat)^{-1} rhs
+        - :obj:`torch.tensor` - :math:`A^{-1}R` or :math:`LA^{-1}R`.
     """
     if hasattr(mat, "inv_matmul"):
-        return mat.inv_matmul(rhs)
+        return mat.inv_matmul(right_tensor, left_tensor)
     else:
         from ..lazy.non_lazy_tensor import NonLazyTensor
-
-        return NonLazyTensor(mat).inv_matmul(rhs)
+        return NonLazyTensor(mat).inv_matmul(right_tensor, left_tensor)
 
 
 def inv_quad(mat, tensor):

--- a/gpytorch/functions/_inv_matmul.py
+++ b/gpytorch/functions/_inv_matmul.py
@@ -7,29 +7,50 @@ from .. import settings
 
 
 class InvMatmul(Function):
-    def __init__(self, representation_tree, preconditioner=None):
+    def __init__(self, representation_tree, preconditioner=None, has_left=False):
         self.representation_tree = representation_tree
         self.preconditioner = preconditioner
+        self.has_left = has_left
 
-    def forward(self, rhs, *matrix_args):
+    def forward(self, *args):
+        left_tensor = None
+        right_tensor = None
+        matrix_args = None
+        if self.has_left:
+            left_tensor, right_tensor, *matrix_args = args
+        else:
+            right_tensor, *matrix_args = args
         lazy_tsr = self.representation_tree(*matrix_args)
         matmul_closure = lazy_tsr._matmul
 
         self.is_vector = False
-        if rhs.ndimension() == 1:
-            rhs.unsqueeze_(-1)
+        if right_tensor.ndimension() == 1:
+            right_tensor.unsqueeze_(-1)
             self.is_vector = True
 
         # Perform solves (for inv_quad) and tridiagonalization (for estimating log_det)
-        res = linear_cg(
-            matmul_closure, rhs, max_iter=settings.max_cg_iterations.value(), preconditioner=self.preconditioner
-        )
+        if self.has_left:
+            rhs = torch.cat([left_tensor.transpose(-1, -2), right_tensor], -1)
+            solves = linear_cg(
+                matmul_closure, rhs, max_iter=settings.max_cg_iterations.value(), preconditioner=self.preconditioner
+            )
+            res = solves[..., left_tensor.size(-2):]
+            res = left_tensor @ res
+        else:
+            solves = linear_cg(
+                matmul_closure, right_tensor, max_iter=settings.max_cg_iterations.value(),
+                preconditioner=self.preconditioner
+            )
+            res = solves
 
         if self.is_vector:
             res.squeeze_(-1)
-            rhs.squeeze_(-1)
+            right_tensor.squeeze_(-1)
 
-        args = [res, rhs] + list(matrix_args)
+        if self.has_left:
+            args = [solves, left_tensor, right_tensor] + list(matrix_args)
+        else:
+            args = [solves, right_tensor] + list(matrix_args)
         self.save_for_backward(*args)
         if not settings.memory_efficient.on():
             self._lazy_tsr = lazy_tsr
@@ -38,9 +59,12 @@ class InvMatmul(Function):
 
     def backward(self, grad_output):
         # Extract items that were saved
-        rhs_solves = self.saved_tensors[0]
-        rhs = self.saved_tensors[1]
-        matrix_args = self.saved_tensors[2:]
+        if self.has_left:
+            solves, left_tensor, right_tensor, *matrix_args = self.saved_tensors
+            left_solves = solves[..., :left_tensor.size(-2)]
+            right_solves = solves[..., left_tensor.size(-2):]
+        else:
+            right_solves, right_tensor, *matrix_args = self.saved_tensors
 
         # Get matrix functions
         if hasattr(self, "_lazy_tsr"):
@@ -51,33 +75,48 @@ class InvMatmul(Function):
 
         # Define gradient placeholders
         arg_grads = [None] * len(matrix_args)
-        rhs_grad = None
+        left_grad = None
+        right_grad = None
         if any(self.needs_input_grad):
             # De-vectorize objects
             if self.is_vector:
-                rhs = rhs.unsqueeze(-1)
-                rhs_solves = rhs_solves.unsqueeze(-1)
-                grad_output = grad_output.unsqueeze(-1)
+                right_tensor = right_tensor.unsqueeze(-1)
 
-            # Compute self^{-1} grad_output
-            grad_output_solves = linear_cg(
-                matmul_closure,
-                grad_output,
-                max_iter=settings.max_cg_iterations.value(),
-                preconditioner=self.preconditioner,
-            )
-
-            # input_1 gradient
-            if any(self.needs_input_grad[1:]):
-                if lazy_tsr is not None:
-                    arg_grads = lazy_tsr._quad_form_derivative(grad_output_solves, rhs_solves.mul(-1))
-                else:
-                    arg_grads = (torch.matmul(grad_output_solves, rhs_solves.mul(-1).transpose(-1, -2)),)
-
-            # input_2 gradient
-            if self.needs_input_grad[0]:
-                rhs_grad = grad_output_solves
+            if not self.has_left:
                 if self.is_vector:
-                    rhs_grad.squeeze_(-1)
+                    grad_output = grad_output.unsqueeze(-1)
+                    right_solves.unsqueeze_(-1)
 
-        return tuple([rhs_grad] + list(arg_grads))
+                # Compute self^{-1} grad_output
+                left_solves = linear_cg(
+                    matmul_closure,
+                    grad_output,
+                    max_iter=settings.max_cg_iterations.value(),
+                    preconditioner=self.preconditioner,
+                )
+
+                if any(self.needs_input_grad[1:]):
+                    arg_grads = lazy_tsr._quad_form_derivative(left_solves, right_solves.mul(-1))
+                if self.needs_input_grad[0]:
+                    right_grad = left_solves
+                    if self.is_vector:
+                        right_grad.squeeze_(-1)
+
+                return tuple([right_grad] + list(arg_grads))
+
+            else:
+                if self.is_vector:
+                    grad_output = grad_output.unsqueeze(-1)
+
+                left_solves = left_solves @ grad_output
+
+                if self.needs_input_grad[1]:
+                    left_grad = grad_output @ right_solves.transpose(-1, -2)
+                if any(self.needs_input_grad[2:]):
+                    arg_grads = lazy_tsr._quad_form_derivative(left_solves, right_solves.mul(-1))
+                if self.needs_input_grad[0]:
+                    right_grad = left_solves
+                    if self.is_vector:
+                        right_grad.squeeze_(-1)
+
+                return tuple([left_grad, right_grad] + list(arg_grads))

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -122,8 +122,11 @@ class DiagLazyTensor(LazyTensor):
     def inverse(self):
         return DiagLazyTensor(self._diag.reciprocal())
 
-    def inv_matmul(self, tensor):
-        return self.inverse()._matmul(tensor)
+    def inv_matmul(self, right_tensor, left_tensor=None):
+        res = self.inverse()._matmul(right_tensor)
+        if left_tensor is not None:
+            res = left_tensor @ res
+        return res
 
     def inv_quad_log_det(self, inv_quad_rhs=None, log_det=False, reduce_inv_quad=True):
 

--- a/gpytorch/lazy/zero_lazy_tensor.py
+++ b/gpytorch/lazy/zero_lazy_tensor.py
@@ -119,7 +119,7 @@ class ZeroLazyTensor(LazyTensor):
     def evaluate(self):
         return torch.zeros(*self.sizes)
 
-    def inv_matmul(self, tensor):
+    def inv_matmul(self, right_tensor, left_tensor=None):
         raise RuntimeError("ZeroLazyTensors are not invertible!")
 
     def inv_quad(self, tensor):


### PR DESCRIPTION
**TLDR** - this PR reduces the number of CG calls from 3 -> 2 for variational inference.

The function `inv_matmul` takes in an optional second argument (`left_tensor`). If it is supplied, the function compute:

`left_tensor` @ lazy_tensor^{-1} @ right_tensor`

If it is not supplied, `inv_matmul` simply computes `lazy_tensor^{-1} @ right_tensor`.

If `left_tensor` is supplied we can compute `lazy_tensor^{-1} @ [right_tensor; left_tensor]` in batch on the forward pass. This makes it possible to skip a call on CG in the backward pass.