### PR TITLE
Revert "Fix kernel memory usage"

### DIFF
--- a/gpytorch/kernels/cosine_kernel.py
+++ b/gpytorch/kernels/cosine_kernel.py
@@ -98,6 +98,8 @@ class CosineKernel(Kernel):
     def forward(self, x1, x2, **params):
         x1_ = x1.div(self.period_length)
         x2_ = x2.div(self.period_length)
-        diff = self._covar_sq_dist(x1_, x2_, **params).sqrt_()
+        x1_, x2_ = self._create_input_grid(x1_, x2_, **params)
+
+        diff = torch.norm((x1_ - x2_).abs(), 2, -1)
         res = torch.cos(diff.mul(math.pi))
         return res

--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -112,7 +112,9 @@ class MaternKernel(Kernel):
 
         x1_ = (x1 - mean).div(self.lengthscale)
         x2_ = (x2 - mean).div(self.lengthscale)
-        distance = self._covar_sq_dist(x1_, x2_, **params).sqrt_()
+        x1_, x2_ = self._create_input_grid(x1_, x2_, **params)
+
+        distance = (x1_ - x2_).norm(2, dim=-1)
         exp_component = torch.exp(-math.sqrt(self.nu * 2) * distance)
 
         if self.nu == 0.5:

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -121,7 +121,9 @@ class PeriodicKernel(Kernel):
     def forward(self, x1, x2, **params):
         x1_ = x1.div(self.period_length)
         x2_ = x2.div(self.period_length)
-        diff = self._covar_sq_dist(x1_, x2_, **params).sqrt_()
+        x1_, x2_ = self._create_input_grid(x1_, x2_, **params)
+
+        diff = torch.sum((x1_ - x2_).abs(), -1)
         res = torch.sin(diff.mul(math.pi)).pow(2).mul(-2 / self.lengthscale).exp_()
         if diff.ndimension() == 2:
             res = res.squeeze(0)

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -92,5 +92,7 @@ class RBFKernel(Kernel):
     def forward(self, x1, x2, **params):
         x1_ = x1.div(self.lengthscale)
         x2_ = x2.div(self.lengthscale)
-        diff = self._covar_sq_dist(x1_, x2_, **params)
-        return diff.div_(-2).exp_()
+        x1_, x2_ = self._create_input_grid(x1_, x2_, **params)
+
+        diff = (x1_ - x2_).norm(2, dim=-1)
+        return diff.pow(2).div_(-2).exp_()

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -178,43 +178,6 @@ class SpectralMixtureKernel(Kernel):
         self.raw_mixture_weights.data.fill_(train_y.std() / self.num_mixtures)
         self.raw_mixture_weights.data = self._inv_param_transform(self.raw_mixture_weights.data)
 
-    def _create_input_grid(self, x1, x2, diag=False, batch_dims=None, **params):
-        """
-        This is a helper method for creating a grid of the kernel's inputs.
-        Use this helper rather than maually creating a meshgrid.
-
-        The grid dimensions depend on the kernel's evaluation mode.
-
-        Args:
-            :attr:`x1` (Tensor `n x d` or `b x n x d`)
-            :attr:`x2` (Tensor `m x d` or `b x m x d`) - for diag mode, these must be the same inputs
-
-        Returns:
-            (:class:`Tensor`, :class:`Tensor) corresponding to the gridded `x1` and `x2`.
-            The shape depends on the kernel's mode
-
-            * `full_covar`: (`b x n x 1 x d` and `b x 1 x m x d`)
-            * `full_covar` with `batch_dims=(0, 2)`: (`b x k x n x 1 x 1` and `b x k x 1 x m x 1`)
-            * `diag`: (`b x n x d` and `b x n x d`)
-            * `diag` with `batch_dims=(0, 2)`: (`b x k x n x 1` and `b x k x n x 1`)
-        """
-        x1_, x2_ = x1, x2
-        if batch_dims == (0, 2):
-            x1_ = x1_.view(*x1.size()[:-1], -1, 1)
-            x1_ = x1_.permute(0, -2, *list(range(1, x1_.dim() - 2)), -1).contiguous()
-            x1_ = x1_.view(-1, *x1_.size()[2:])
-            if torch.equal(x1, x2):
-                x2_ = x1_
-            else:
-                x2_ = x2_.view(*x2.size()[:-1], -1, 1)
-                x2_ = x2_.permute(0, -2, *list(range(1, x2_.dim() - 2)), -1).contiguous()
-                x2_ = x2_.view(-1, *x2_.size()[2:])
-
-        if diag:
-            return x1_, x2_
-        else:
-            return x1_.unsqueeze(-2), x2_.unsqueeze(-3)
-
     def forward(self, x1, x2, **params):
         batch_size, n, num_dims = x1.size()
         _, m, _ = x2.size()


### PR DESCRIPTION
Reverts cornellius-gp/gpytorch#434

Obviously correctness is more important than memory usage, so let's just revert the PR and re-open it until we're satisfied that it is numerically stable as well as memory efficient (#438).