### PR TITLE
Fix kernel memory usage

### DIFF
--- a/gpytorch/kernels/cosine_kernel.py
+++ b/gpytorch/kernels/cosine_kernel.py
@@ -98,8 +98,6 @@ class CosineKernel(Kernel):
     def forward(self, x1, x2, **params):
         x1_ = x1.div(self.period_length)
         x2_ = x2.div(self.period_length)
-        x1_, x2_ = self._create_input_grid(x1_, x2_, **params)
-
-        diff = torch.norm((x1_ - x2_).abs(), 2, -1)
+        diff = self._covar_sq_dist(x1_, x2_, **params).sqrt_()
         res = torch.cos(diff.mul(math.pi))
         return res

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -156,20 +156,11 @@ class Kernel(Module):
         Computes the covariance between x1 and x2.
         This method should be imlemented by all Kernel subclasses.
 
-        .. note::
-
-            All non-compositional kernels should use the :meth:`gpytorch.kernels.Kernel._create_input_grid`
-            method to create a meshgrid between x1 and x2 (if necessary).
-
-            Do not manually create the grid - this is inefficient and will cause erroneous behavior in certain
-            evaluation modes.
-
         Args:
             - :attr:`x1` (Tensor `n x d` or `b x n x d`)
             - :attr:`x2` (Tensor `m x d` or `b x m x d`)
             - :attr:`diag` (bool):
                 Should the Kernel compute the whole kernel, or just the diag?
-                For most Kernels, this option will be passed into `create_input_grid`
             - :attr:`batch_dims` (tuple, optional):
                 If this option is passed in, it will tell the tensor which of the
                 three dimensions are batch dimensions.
@@ -187,42 +178,58 @@ class Kernel(Module):
         """
         raise NotImplementedError()
 
-    def _create_input_grid(self, x1, x2, diag=False, batch_dims=None, **params):
+    def _covar_sq_dist(self, x1, x2, diag=False, batch_dims=None, **params):
         """
-        This is a helper method for creating a grid of the kernel's inputs.
-        Use this helper rather than maually creating a meshgrid.
+        This is a helper method for computing the squared Euclidean distance between
+        all pairs of points in x1 and x2.
 
-        The grid dimensions depend on the kernel's evaluation mode.
+        The dimensionality of the output depends on the
 
         Args:
-            :attr:`x1` (Tensor `n x d` or `b x n x d`)
-            :attr:`x2` (Tensor `m x d` or `b x m x d`) - for diag mode, these must be the same inputs
+            - :attr:`x1` (Tensor `n x d` or `b x n x d`)
+            - :attr:`x2` (Tensor `m x d` or `b x m x d`) - for diag mode, these must be the same inputs
+            - :attr:`diag` (bool):
+                Should we return the whole distance matrix, or just the diagonal?
+            - :attr:`batch_dims` (tuple, optional):
+                If this option is passed in, it will tell the tensor which of the
+                three dimensions are batch dimensions.
+                Currently accepts: standard mode (either None or (0,))
+                or (0, 2) for use with Additive/Multiplicative kernels
 
         Returns:
-            (:class:`Tensor`, :class:`Tensor) corresponding to the gridded `x1` and `x2`.
+            (:class:`Tensor`, :class:`Tensor) corresponding to the distance matrix between `x1` and `x2`.
             The shape depends on the kernel's mode
 
-            * `full_covar`: (`b x n x 1 x d` and `b x 1 x m x d`)
-            * `full_covar` with `batch_dims=(0, 2)`: (`b x k x n x 1 x 1` and `b x k x 1 x m x 1`)
-            * `diag`: (`b x n x d` and `b x n x d`)
-            * `diag` with `batch_dims=(0, 2)`: (`b x k x n x 1` and `b x k x n x 1`)
+            * `diag=False` and `batch_dims=None`: (`b x n x n`)
+            * `diag=False` and `batch_dims=(0, 2)`: (`bd x n x n`)
+            * `diag=True` and `batch_dims=None`: (`b x n`)
+            * `diag=True` and `batch_dims=(0, 2)`: (`bd x n`)
         """
-        x1_, x2_ = x1, x2
+
+        center = x1.mean(dim=-2, keepdim=True)
+        x1 = x1 - center
+        x2 = x2 - center
         if batch_dims == (0, 2):
-            x1_ = x1_.view(*x1.size()[:-1], -1, 1)
-            x1_ = x1_.permute(0, -2, *list(range(1, x1_.dim() - 2)), -1).contiguous()
-            x1_ = x1_.view(-1, *x1_.size()[2:])
-            if torch.equal(x1, x2):
-                x2_ = x1_
-            else:
-                x2_ = x2_.view(*x2.size()[:-1], -1, 1)
-                x2_ = x2_.permute(0, -2, *list(range(1, x2_.dim() - 2)), -1).contiguous()
-                x2_ = x2_.view(-1, *x2_.size()[2:])
+            x1 = x1.unsqueeze(0).transpose(0, -1)
+            x2 = x2.unsqueeze(0).transpose(0, -1)
+
+        x1_norm = x1.pow(2).sum(dim=-1, keepdim=True)
+        x2_norm = x2.pow(2).sum(dim=-1, keepdim=True)
 
         if diag:
-            return x1_, x2_
+            mid = (x1 * x2).sum(dim=-1, keepdim=True)
+            res = (x1_norm - 2 * mid + x2_norm).squeeze(-1)
         else:
-            return x1_.unsqueeze(-2), x2_.unsqueeze(-3)
+            mid = x1.matmul(x2.transpose(-2, -1))
+            res = x1_norm - 2 * mid + x2_norm.transpose(-2, -1)
+
+        if batch_dims == (0, 2):
+            if diag:
+                res = res.transpose(0, 1).contiguous().view(-1, res.shape[-1])
+            else:
+                res = res.transpose(0, 1).contiguous().view(-1, *res.shape[-2:])
+
+        return res
 
     def __call__(self, x1, x2=None, diag=False, batch_dims=None, **params):
         x1_, x2_ = x1, x2

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -207,10 +207,11 @@ class Kernel(Module):
 
         if x1_eq_x2:
             # Ensure zero diagonal
-            res[..., torch.arange(x1.shape[-2]), torch.arange(x1.shape[-2])] = 0
+            diag_inds = torch.arange(x1.shape[-2])
+            res[..., diag_inds, diag_inds] = 0
 
         # Zero out negative values
-        res[res < 0] = 0
+        res.clamp_min_(0)
 
         return res
 
@@ -263,7 +264,7 @@ class Kernel(Module):
                 res = self.__slow_sq_dist(x1, x2, diag, x1_eq_x2)
         elif x1_eq_x2:
             # Full distance matrix in the square symmetric case
-            if x1.shape[0] == 1:
+            if x1.dim() == 3 and x1.shape[0] == 1:
                 # If we aren't in batch mode, we can always use torch.pdist
                 res = self.__pdist_sq_dist(x1.squeeze(0)).unsqueeze(0)
             elif self.__pdist_supports_batch:
@@ -271,12 +272,15 @@ class Kernel(Module):
                 # TODO: This else branch is not needed on the next PyTorch release (> 1.0.0).
                 try:
                     res = self.__pdist_sq_dist(x1)
-                except RuntimeError:
-                    warnings.warn('You are using a version of PyTorch where torch.pdist does not support batch '
-                                  'matrices. Falling back on manual distance computation. Updating PyTorch to the '
-                                  'latest pytorch-nightly build will offer significant memory savings during kernel '
-                                  'computation.')
-                    self.__pdist_supports_batch = False
+                except RuntimeError as e:
+                    if 'pdist only supports 2D tensors, got:' in str(e):
+                        warnings.warn('You are using a version of PyTorch where torch.pdist does not support batch '
+                                      'matrices. Falling back on manual distance computation. Updating PyTorch to the '
+                                      'latest pytorch-nightly build will offer significant memory savings during kernel'
+                                      ' computation.')
+                        self.__pdist_supports_batch = False
+                    else:
+                        raise e
 
         if res is None:
             """

--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -112,9 +112,7 @@ class MaternKernel(Kernel):
 
         x1_ = (x1 - mean).div(self.lengthscale)
         x2_ = (x2 - mean).div(self.lengthscale)
-        x1_, x2_ = self._create_input_grid(x1_, x2_, **params)
-
-        distance = (x1_ - x2_).norm(2, dim=-1)
+        distance = self._covar_sq_dist(x1_, x2_, **params).sqrt_()
         exp_component = torch.exp(-math.sqrt(self.nu * 2) * distance)
 
         if self.nu == 0.5:

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -121,9 +121,7 @@ class PeriodicKernel(Kernel):
     def forward(self, x1, x2, **params):
         x1_ = x1.div(self.period_length)
         x2_ = x2.div(self.period_length)
-        x1_, x2_ = self._create_input_grid(x1_, x2_, **params)
-
-        diff = torch.sum((x1_ - x2_).abs(), -1)
+        diff = self._covar_sq_dist(x1_, x2_, **params).sqrt_()
         res = torch.sin(diff.mul(math.pi)).pow(2).mul(-2 / self.lengthscale).exp_()
         if diff.ndimension() == 2:
             res = res.squeeze(0)

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -92,7 +92,5 @@ class RBFKernel(Kernel):
     def forward(self, x1, x2, **params):
         x1_ = x1.div(self.lengthscale)
         x2_ = x2.div(self.lengthscale)
-        x1_, x2_ = self._create_input_grid(x1_, x2_, **params)
-
-        diff = (x1_ - x2_).norm(2, dim=-1)
-        return diff.pow(2).div_(-2).exp_()
+        diff = self._covar_sq_dist(x1_, x2_, **params)
+        return diff.div_(-2).exp_()

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -178,6 +178,43 @@ class SpectralMixtureKernel(Kernel):
         self.raw_mixture_weights.data.fill_(train_y.std() / self.num_mixtures)
         self.raw_mixture_weights.data = self._inv_param_transform(self.raw_mixture_weights.data)
 
+    def _create_input_grid(self, x1, x2, diag=False, batch_dims=None, **params):
+        """
+        This is a helper method for creating a grid of the kernel's inputs.
+        Use this helper rather than maually creating a meshgrid.
+
+        The grid dimensions depend on the kernel's evaluation mode.
+
+        Args:
+            :attr:`x1` (Tensor `n x d` or `b x n x d`)
+            :attr:`x2` (Tensor `m x d` or `b x m x d`) - for diag mode, these must be the same inputs
+
+        Returns:
+            (:class:`Tensor`, :class:`Tensor) corresponding to the gridded `x1` and `x2`.
+            The shape depends on the kernel's mode
+
+            * `full_covar`: (`b x n x 1 x d` and `b x 1 x m x d`)
+            * `full_covar` with `batch_dims=(0, 2)`: (`b x k x n x 1 x 1` and `b x k x 1 x m x 1`)
+            * `diag`: (`b x n x d` and `b x n x d`)
+            * `diag` with `batch_dims=(0, 2)`: (`b x k x n x 1` and `b x k x n x 1`)
+        """
+        x1_, x2_ = x1, x2
+        if batch_dims == (0, 2):
+            x1_ = x1_.view(*x1.size()[:-1], -1, 1)
+            x1_ = x1_.permute(0, -2, *list(range(1, x1_.dim() - 2)), -1).contiguous()
+            x1_ = x1_.view(-1, *x1_.size()[2:])
+            if torch.equal(x1, x2):
+                x2_ = x1_
+            else:
+                x2_ = x2_.view(*x2.size()[:-1], -1, 1)
+                x2_ = x2_.permute(0, -2, *list(range(1, x2_.dim() - 2)), -1).contiguous()
+                x2_ = x2_.view(-1, *x2_.size()[2:])
+
+        if diag:
+            return x1_, x2_
+        else:
+            return x1_.unsqueeze(-2), x2_.unsqueeze(-3)
+
     def forward(self, x1, x2, **params):
         batch_size, n, num_dims = x1.size()
         _, m, _ = x2.size()


### PR DESCRIPTION
See #434, #438, #439. The current kernels are significantly more numerically stable, but use too much memory. We need to achieve the best of both worlds here, as the memory problems prevent exact GPs from running on as large of datasets as they otherwise could, and the round-off problems in the memory efficient version of the kernel cause other problems.