### PR TITLE
Rename potrs with cholesky_solve

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -135,7 +135,7 @@ class DefaultPredictionStrategy(object):
             # TODO: Delete this part of the if statement when PyTorch implements potrs derivative.
             fant_cache_lower = torch.gesv(small_system_rhs.unsqueeze(-1), schur_complement)[0]
         else:
-            fant_cache_lower = torch.potrs(small_system_rhs, torch.cholesky(schur_complement, upper=True))
+            fant_cache_lower = torch.cholesky_solve(small_system_rhs, torch.cholesky(schur_complement))
 
         # Get "a", the new upper portion of the cache corresponding to the old training points.
         fant_cache_upper = self.mean_cache.unsqueeze(-1) - fant_solve.matmul(fant_cache_lower)
@@ -185,7 +185,7 @@ class DefaultPredictionStrategy(object):
             # TODO: Delete this part of the if statement when PyTorch implements potrs derivative.
             new_covar_cache = torch.gesv(new_root.transpose(-2, -1), cap_mat)[0].transpose(-2, -1)
         else:
-            new_covar_cache = torch.potrs(new_root.transpose(-2, -1), torch.cholesky(cap_mat, upper=True))
+            new_covar_cache = torch.cholesky_solve(new_root.transpose(-2, -1), torch.cholesky(cap_mat))
             new_covar_cache = new_covar_cache.transpose(-2, -1)
 
         # Create new DefaultPredictionStrategy object

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -100,7 +100,7 @@ def woodbury_factor(low_rank_mat, shift):
 
     shifted_mat = shifted_mat + torch.eye(k, dtype=shifted_mat.dtype, device=shifted_mat.device)
 
-    R = torch.potrs(low_rank_mat, torch.cholesky(shifted_mat, upper=True))
+    R = torch.cholesky_solve(low_rank_mat, torch.cholesky(shifted_mat))
     return R
 
 

--- a/test/utils/test_cholesky.py
+++ b/test/utils/test_cholesky.py
@@ -18,7 +18,7 @@ class TestTriDiag(unittest.TestCase):
 
         mat = torch.randn(1, 4, 3)
         self.assertTrue(
-            approx_equal(torch.potrs(mat[0], chol[0], upper=False), tridiag_batch_potrs(mat, chol, upper=False)[0])
+            approx_equal(torch.cholesky_solve(mat[0], chol[0]), tridiag_batch_potrs(mat, chol, upper=False)[0])
         )
 
 

--- a/test/utils/test_linear_cg.py
+++ b/test/utils/test_linear_cg.py
@@ -32,8 +32,8 @@ class TestLinearCG(unittest.TestCase):
         solves = linear_cg(matrix.matmul, rhs=rhs, max_iter=size)
 
         # Check cg
-        matrix_chol = matrix.cholesky(upper=True)
-        actual = torch.potrs(rhs, matrix_chol)
+        matrix_chol = matrix.cholesky()
+        actual = torch.cholesky_solve(rhs, matrix_chol)
         self.assertTrue(approx_equal(solves, actual))
 
     def test_cg_with_tridiag(self):
@@ -49,8 +49,8 @@ class TestLinearCG(unittest.TestCase):
         )
 
         # Check cg
-        matrix_chol = matrix.cholesky(upper=True)
-        actual = torch.potrs(rhs, matrix_chol)
+        matrix_chol = matrix.cholesky()
+        actual = torch.cholesky_solve(rhs, matrix_chol)
         self.assertTrue(approx_equal(solves, actual))
 
         # Check tridiag
@@ -71,8 +71,8 @@ class TestLinearCG(unittest.TestCase):
         solves = linear_cg(matrix.matmul, rhs=rhs, max_iter=size)
 
         # Check cg
-        matrix_chol = torch.cholesky(matrix, upper=True)
-        actual = torch.potrs(rhs, matrix_chol)
+        matrix_chol = torch.cholesky(matrix)
+        actual = torch.cholesky_solve(rhs, matrix_chol)
         self.assertTrue(approx_equal(solves, actual))
 
     def test_batch_cg_with_tridiag(self):
@@ -89,8 +89,8 @@ class TestLinearCG(unittest.TestCase):
         )
 
         # Check cg
-        matrix_chol = torch.cholesky(matrix, upper=True)
-        actual = torch.potrs(rhs, matrix_chol)
+        matrix_chol = torch.cholesky(matrix)
+        actual = torch.cholesky_solve(rhs, matrix_chol)
         self.assertTrue(approx_equal(solves, actual))
 
         # Check tridiag


### PR DESCRIPTION
As stated in the title.

This change was introduced in https://github.com/pytorch/pytorch/pull/15334 .

Now the upper arguments in both cholesky_solve and cholesky are the same, so you don't have to explicitly specify upper every time unless necessary.