### PR TITLE
Inducing point locations can be non-batch for batch variational GPs

### DIFF
--- a/gpytorch/mlls/variational_elbo.py
+++ b/gpytorch/mlls/variational_elbo.py
@@ -25,6 +25,9 @@ class VariationalELBO(MarginalLogLikelihood):
         variational_dist_u = self.model.variational_strategy.variational_distribution.variational_distribution
         prior_dist = self.model.variational_strategy.prior_distribution
 
+        if len(variational_dist_u.batch_shape) < len(prior_dist.batch_shape):
+            variational_dist_u = variational_dist_u.expand(prior_dist.batch_shape)
+
         log_likelihood = self.likelihood.variational_log_probability(variational_dist_f, target, **kwargs).div(
             num_batch
         )

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -79,11 +79,16 @@ class VariationalStrategy(Module):
             :obj:`gpytorch.distributions.MultivariateNormal`: The distribution q(f|x)
         """
         variational_dist = self.variational_distribution.variational_distribution
-        if torch.equal(x, self.inducing_points):
+        inducing_points = self.inducing_points
+
+        if inducing_points.dim() < x.dim():
+            inducing_points = inducing_points.expand(*x.shape[:-2], *inducing_points.shape[-2:])
+            variational_dist = variational_dist.expand(x.shape[:-2])
+        if torch.equal(x, inducing_points):
             return variational_dist
         else:
-            n_induc = self.inducing_points.size(-2)
-            full_inputs = torch.cat([self.inducing_points, x], dim=-2)
+            n_induc = inducing_points.size(-2)
+            full_inputs = torch.cat([inducing_points, x], dim=-2)
             full_output = self.model.forward(full_inputs)
             full_mean, full_covar = full_output.mean, full_output.lazy_covariance_matrix
 

--- a/test/examples/test_batch_svgp_gp_regression.py
+++ b/test/examples/test_batch_svgp_gp_regression.py
@@ -95,6 +95,41 @@ class TestSVGPRegression(unittest.TestCase):
         self.assertLess(mean_abs_error.item(), 1e-1)
         self.assertLess(mean_abs_error2.item(), 1e-1)
 
+    def test_regression_error_shared_inducing_locations(self):
+        train_x, train_y = train_data()
+        likelihood = GaussianLikelihood()
+        inducing_points = torch.linspace(0, 1, 25).unsqueeze(-1)
+        model = SVGPRegressionModel(inducing_points)
+        mll = gpytorch.mlls.VariationalELBO(likelihood, model, num_data=train_y.size(-1))
+
+        # Find optimal model hyperparameters
+        model.train()
+        likelihood.train()
+        optimizer = optim.Adam([{"params": model.parameters()}, {"params": likelihood.parameters()}], lr=0.01)
+        for _ in range(150):
+            optimizer.zero_grad()
+            output = model(train_x)
+            loss = -mll(output, train_y)
+            loss = loss.sum()
+            loss.backward()
+            optimizer.step()
+
+        for param in model.parameters():
+            self.assertTrue(param.grad is not None)
+            self.assertGreater(param.grad.norm().item(), 0)
+        for param in likelihood.parameters():
+            self.assertTrue(param.grad is not None)
+            self.assertGreater(param.grad.norm().item(), 0)
+
+        # Set back to eval mode
+        model.eval()
+        likelihood.eval()
+        test_preds = likelihood(model(train_x)).mean.squeeze()
+        mean_abs_error = torch.mean(torch.abs(train_y[0, :] - test_preds[0, :]) / 2)
+        mean_abs_error2 = torch.mean(torch.abs(train_y[1, :] - test_preds[1, :]) / 2)
+        self.assertLess(mean_abs_error.item(), 1e-1)
+        self.assertLess(mean_abs_error2.item(), 1e-1)
+
     def test_regression_error_cuda(self):
         if torch.cuda.is_available():
             train_x, train_y = train_data(cuda=True)


### PR DESCRIPTION
Right now when using variational GPs with non-gridded inducing points in batch mode, we implicitly require that all GPs have independent inducing point locations by requiring the inducing points to be batch (`b x n x d`) when supplied to the model.

This PR allows the batch GPs to share inducing point locations by passing in a non-batched set of inducing points (see the unit test for an example). Note that the `VariationalDistribution` should still be made with `batch_size=b`, because unless the `b` functions are all identical the variational parameters `q(f)` should not be shared.

cc/ @martinjankowiak 