### PR TITLE
Convert scalar tensors to ints in __getitem__

### DIFF
--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1277,6 +1277,7 @@ class LazyTensor(object):
         # Process the index
         index = index if isinstance(index, tuple) else (index,)
         index = tuple(torch.tensor(idx) if isinstance(idx, list) else idx for idx in index)
+        index = tuple(idx.item() if torch.is_tensor(idx) and not len(idx.shape) else idx for idx in index)
 
         # Handle the ellipsis
         # Find the index of the ellipsis


### PR DESCRIPTION
Minor change, this just exploits the fact that indexing with torch scalars and ints have the same behavior (specifically, they both squeeze):
```python
foo = torch.randn(3, 3)
a = foo[torch.tensor(1), :]  # torch.Size([3])
b = foo[1, :]  # torch.Size([3])
c = foo[[1], :]  # torch.Size([1, 3])
```
Since they have the same behavior, I added a conversion from scalars to ints so we can process them the same way downstream. I don't think this is useful for any of the `_getitem` definitions we currently have, but it turns out to be very convenient for one we are working on.