### PR TITLE
Make "lazify/delazify" helpers, better lazy kernel evaluation

### DIFF
--- a/gpytorch/__init__.py
+++ b/gpytorch/__init__.py
@@ -41,7 +41,6 @@ __all__ = [
     # Submodules
     "distributions",
     "kernels",
-    "lazify",
     "lazy",
     "likelihoods",
     "means",
@@ -57,10 +56,12 @@ __all__ = [
     # Functions
     "add_diag",
     "add_jitter",
+    "delazify",
     "dsmm",
     "inv_matmul",
     "inv_quad",
     "inv_quad_log_det",
+    "lazify",
     "log_det",
     "log_normal_cdf",
     "matmul",

--- a/gpytorch/__init__.py
+++ b/gpytorch/__init__.py
@@ -30,6 +30,7 @@ from .functions import (
     root_inv_decomposition,
 )
 from .mlls import ExactMarginalLogLikelihood, VariationalMarginalLogLikelihood
+from .lazy import lazify
 
 
 # Old deprecated stuff
@@ -40,6 +41,7 @@ __all__ = [
     # Submodules
     "distributions",
     "kernels",
+    "lazify",
     "lazy",
     "likelihoods",
     "means",

--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -8,7 +8,7 @@ from torch.distributions.kl import register_kl
 from torch.distributions.utils import _standard_normal, lazy_property
 
 from .. import settings
-from ..lazy import LazyTensor, NonLazyTensor
+from ..lazy import LazyTensor, lazify
 from .distribution import Distribution
 
 
@@ -103,7 +103,7 @@ class _MultivariateNormalBase(TMultivariateNormal, Distribution):
         if self.islazy:
             return self._covar
         else:
-            return NonLazyTensor(super(_MultivariateNormalBase, self).covariance_matrix)
+            return lazify(super(_MultivariateNormalBase, self).covariance_matrix)
 
     def log_prob(self, value):
         if self._validate_args:

--- a/gpytorch/functions/__init__.py
+++ b/gpytorch/functions/__init__.py
@@ -20,12 +20,8 @@ def add_diag(input, diag):
     Returns:
         :obj:`Tensor` (bxnxn or nxn)
     """
-    if torch.is_tensor(input):
-        from ..lazy import NonLazyTensor
-
-        return NonLazyTensor(input).add_diag(diag)
-    else:
-        return input.add_diag(diag)
+    from ..lazy import lazify
+    return lazify(input).add_diag(diag)
 
 
 def add_jitter(mat, jitter_val=1e-3):
@@ -100,12 +96,8 @@ def inv_matmul(mat, rhs):
     Returns:
         - matrix nxk - (mat)^{-1} rhs
     """
-    if hasattr(mat, "inv_matmul"):
-        return mat.inv_matmul(rhs)
-    else:
-        from ..lazy.non_lazy_tensor import NonLazyTensor
-
-        return NonLazyTensor(mat).inv_matmul(rhs)
+    from ..lazy import lazify
+    return lazify(mat).inv_matmul(rhs)
 
 
 def inv_quad(mat, tensor):
@@ -136,12 +128,8 @@ def inv_quad_log_det(mat, inv_quad_rhs=None, log_det=False, reduce_inv_quad=True
         - scalar - tr( tensor^T (mat)^{-1} tensor )
         - scalar - log determinant
     """
-    if hasattr(mat, "inv_quad_log_det"):
-        return mat.inv_quad_log_det(inv_quad_rhs, log_det, reduce_inv_quad=reduce_inv_quad)
-    else:
-        from ..lazy.non_lazy_tensor import NonLazyTensor
-
-        return NonLazyTensor(mat).inv_quad_log_det(inv_quad_rhs, log_det, reduce_inv_quad=reduce_inv_quad)
+    from ..lazy import lazify
+    return lazify(mat).inv_quad_log_det(inv_quad_rhs, log_det, reduce_inv_quad=reduce_inv_quad)
 
 
 def log_det(mat):
@@ -168,12 +156,8 @@ def root_decomposition(mat):
     This can be used for sampling from a Gaussian distribution, or for obtaining a
     low-rank version of a matrix
     """
-    if hasattr(mat, "root_decomposition"):
-        return mat.root_decomposition()
-    else:
-        from ..lazy.non_lazy_tensor import NonLazyTensor
-
-        return NonLazyTensor(mat).root_decomposition()
+    from ..lazy import lazify
+    return lazify(mat).root_decomposition()
 
 
 def root_inv_decomposition(mat, initial_vectors=None, test_vectors=None):
@@ -182,12 +166,8 @@ def root_inv_decomposition(mat, initial_vectors=None, test_vectors=None):
     This can be used for sampling from a Gaussian distribution, or for obtaining a
     low-rank version of a matrix
     """
-    if hasattr(mat, "root_inv_decomposition"):
-        return mat.root_inv_decomposition(initial_vectors, test_vectors)
-    else:
-        from ..lazy.non_lazy_tensor import NonLazyTensor
-
-        return NonLazyTensor(mat).root_inv_decomposition(initial_vectors, test_vectors)
+    from ..lazy import lazify
+    return lazify(mat).root_inv_decomposition(initial_vectors, test_vectors)
 
 
 __all__ = [

--- a/gpytorch/functions/_root_decomposition.py
+++ b/gpytorch/functions/_root_decomposition.py
@@ -37,7 +37,7 @@ class RootDecomposition(Function):
         - (Tensor) R, such that R R^T \approx A
         - (Tensor) R_inv, such that R_inv R_inv^T \approx A^{-1} (will only be populated if self.inverse = True)
         """
-        from ..lazy import NonLazyTensor
+        from ..lazy import lazify
 
         # Get closure for matmul
         lazy_tsr = self.representation_tree(*matrix_args)
@@ -61,7 +61,7 @@ class RootDecomposition(Function):
             t_mat = t_mat.unsqueeze(0)
         n_probes = t_mat.size(0)
 
-        mins = NonLazyTensor(t_mat).diag().min(dim=-1, keepdim=True)[0].unsqueeze(-1)
+        mins = lazify(t_mat).diag().min(dim=-1, keepdim=True)[0].unsqueeze(-1)
         jitter_mat = (settings.tridiagonal_jitter.value() * mins) * torch.eye(t_mat.size(-1)).type_as(t_mat).expand_as(
             t_mat
         )

--- a/gpytorch/kernels/additive_structure_kernel.py
+++ b/gpytorch/kernels/additive_structure_kernel.py
@@ -42,7 +42,7 @@ class AdditiveStructureKernel(Kernel):
         if batch_dims == (0, 2):
             raise RuntimeError("AdditiveStructureKernel does not accept the batch_dims argument.")
 
-        res = self.base_kernel(x1, x2, batch_dims=(0, 2), **params).evaluate_kernel()
+        res = self.base_kernel(x1, x2, batch_dims=(0, 2), **params)
 
         evaluate = False
         if not isinstance(res, LazyTensor):

--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -2,7 +2,7 @@
 
 import torch
 from .kernel import Kernel
-from ..lazy import ToeplitzLazyTensor, KroneckerProductLazyTensor
+from ..lazy import delazify, ToeplitzLazyTensor, KroneckerProductLazyTensor
 from .. import settings
 from gpytorch.utils.grid import create_data_from_grid
 
@@ -75,13 +75,13 @@ class GridKernel(Kernel):
             if settings.use_toeplitz.on():
                 first_item = grid[:, 0:1]
                 covar_columns = self.base_kernel(first_item, grid, diag=False, batch_dims=(0, 2), **params)
-                covar_columns = covar_columns.evaluate().squeeze(-2)
+                covar_columns = delazify(covar_columns).squeeze(-2)
                 if batch_dims == (0, 2):
                     covars = [ToeplitzLazyTensor(covar_columns)]
                 else:
                     covars = [ToeplitzLazyTensor(covar_columns[i : i + 1]) for i in range(n_dim)]
             else:
-                full_covar = self.base_kernel(grid, grid, batch_dims=(0, 2), **params).evaluate_kernel()
+                full_covar = self.base_kernel(grid, grid, batch_dims=(0, 2), **params)
                 if batch_dims == (0, 2):
                     covars = [full_covar]
                 else:

--- a/gpytorch/kernels/multitask_kernel.py
+++ b/gpytorch/kernels/multitask_kernel.py
@@ -3,7 +3,7 @@
 import torch
 from .kernel import Kernel
 from .index_kernel import IndexKernel
-from ..lazy import LazyTensor, NonLazyTensor, KroneckerProductLazyTensor
+from ..lazy import lazify, KroneckerProductLazyTensor
 
 
 class MultitaskKernel(Kernel):
@@ -45,9 +45,7 @@ class MultitaskKernel(Kernel):
             raise RuntimeError("AdditiveGridInterpolationKernel does not accept the batch_dims argument.")
         covar_i = self.task_covar_module.covar_matrix
         covar_i = covar_i.repeat(x1.size(0), 1, 1)
-        covar_x = self.data_covar_module.forward(x1, x2, **params)
-        if not isinstance(covar_x, LazyTensor):
-            covar_x = NonLazyTensor(covar_x)
+        covar_x = lazify(self.data_covar_module.forward(x1, x2, **params))
         res = KroneckerProductLazyTensor(covar_x, covar_i)
         return res.diag() if diag else res
 

--- a/gpytorch/kernels/product_structure_kernel.py
+++ b/gpytorch/kernels/product_structure_kernel.py
@@ -47,7 +47,7 @@ class ProductStructureKernel(Kernel):
         if batch_dims == (0, 2):
             raise RuntimeError("ProductStructureKernel does not accept the batch_dims argument.")
 
-        res = self.base_kernel(x1, x2, batch_dims=(0, 2), **params).evaluate_kernel()
+        res = self.base_kernel(x1, x2, batch_dims=(0, 2), **params)
 
         evaluate = False
         if not isinstance(res, LazyTensor):

--- a/gpytorch/kernels/scale_kernel.py
+++ b/gpytorch/kernels/scale_kernel.py
@@ -87,7 +87,7 @@ class ScaleKernel(Kernel):
             value = torch.tensor(value)
         self.initialize(raw_outputscale=self._inv_param_transform(value))
 
-    def forward(self, x1, x2, batch_dims=None, **params):
+    def forward(self, x1, x2, batch_dims=None, diag=False, **params):
         outputscales = self.outputscale
         if batch_dims == (0, 2) and outputscales.numel() > 1:
             outputscales = outputscales.unsqueeze(1).repeat(1, x1.size(-1)).view(-1)

--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from .lazy_tensor import LazyTensor
+from .lazy_tensor import delazify, LazyTensor
 from .added_diag_lazy_tensor import AddedDiagLazyTensor
 from .batch_repeat_lazy_tensor import BatchRepeatLazyTensor
 from .block_lazy_tensor import BlockLazyTensor
@@ -23,6 +23,7 @@ from .zero_lazy_tensor import ZeroLazyTensor
 
 
 __all__ = [
+    "delazify",
     "lazify",
     "LazyTensor",
     "LazyEvaluatedKernelTensor",

--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -13,7 +13,7 @@ from .kronecker_product_lazy_tensor import KroneckerProductLazyTensor
 from .lazy_evaluated_kernel_tensor import LazyEvaluatedKernelTensor
 from .matmul_lazy_tensor import MatmulLazyTensor
 from .mul_lazy_tensor import MulLazyTensor
-from .non_lazy_tensor import NonLazyTensor
+from .non_lazy_tensor import lazify, NonLazyTensor
 from .psd_sum_lazy_tensor import PsdSumLazyTensor
 from .root_lazy_tensor import RootLazyTensor
 from .sum_lazy_tensor import SumLazyTensor
@@ -23,6 +23,7 @@ from .zero_lazy_tensor import ZeroLazyTensor
 
 
 __all__ = [
+    "lazify",
     "LazyTensor",
     "LazyEvaluatedKernelTensor",
     "AddedDiagLazyTensor",

--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -2,7 +2,7 @@
 
 import torch
 import warnings
-from .non_lazy_tensor import NonLazyTensor
+from .non_lazy_tensor import lazify
 from .sum_lazy_tensor import SumLazyTensor
 from .diag_lazy_tensor import DiagLazyTensor
 from ..utils import pivoted_cholesky
@@ -73,7 +73,7 @@ class AddedDiagLazyTensor(SumLazyTensor):
             )
             lr_flipped = lr_flipped + torch.eye(n=lr_flipped.size(-2), dtype=lr_flipped.dtype, device=lr_flipped.device)
             if lr_flipped.ndimension() == 3:
-                ld_one = (NonLazyTensor(torch.cholesky(lr_flipped, upper=True)).diag().log().sum(-1)) * 2
+                ld_one = (lazify(torch.cholesky(lr_flipped, upper=True)).diag().log().sum(-1)) * 2
                 ld_two = self._diag_tensor.diag().log().sum(-1)
             else:
                 ld_one = lr_flipped.cholesky(upper=True).diag().log().sum() * 2

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -6,7 +6,7 @@ import torch
 
 from ..utils.memoize import cached
 from .lazy_tensor import LazyTensor
-from .non_lazy_tensor import NonLazyTensor
+from .non_lazy_tensor import lazify
 from .root_lazy_tensor import RootLazyTensor
 
 
@@ -97,9 +97,7 @@ class DiagLazyTensor(LazyTensor):
         return DiagLazyTensor(self._diag + added_diag.expand_as(self._diag))
 
     def __mul__(self, other):
-        if torch.is_tensor(other):
-            other = NonLazyTensor(other)
-
+        other = lazify(other)
         if isinstance(other, DiagLazyTensor):
             return DiagLazyTensor(self._diag * other._diag)
         else:

--- a/gpytorch/lazy/interpolated_lazy_tensor.py
+++ b/gpytorch/lazy/interpolated_lazy_tensor.py
@@ -3,7 +3,7 @@
 import torch
 from .block_diag_lazy_tensor import BlockDiagLazyTensor
 from .lazy_tensor import LazyTensor
-from .non_lazy_tensor import NonLazyTensor
+from .non_lazy_tensor import lazify
 from .root_lazy_tensor import RootLazyTensor
 from ..utils import sparse
 from ..utils.interpolation import left_interp, left_t_interp
@@ -19,8 +19,7 @@ class InterpolatedLazyTensor(LazyTensor):
         right_interp_indices=None,
         right_interp_values=None,
     ):
-        if torch.is_tensor(base_lazy_tensor):
-            base_lazy_tensor = NonLazyTensor(base_lazy_tensor)
+        base_lazy_tensor = lazify(base_lazy_tensor)
 
         if left_interp_indices is None:
             num_rows = base_lazy_tensor.size()[-2]

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -3,6 +3,7 @@
 import torch
 import operator
 from .lazy_tensor import LazyTensor
+from .non_lazy_tensor import lazify
 from functools import reduce
 
 
@@ -34,7 +35,9 @@ def _t_matmul(lazy_tensors, rhs):
 
 class KroneckerProductLazyTensor(LazyTensor):
     def __init__(self, *lazy_tensors):
-        if not all(isinstance(lazy_tensor, LazyTensor) for lazy_tensor in lazy_tensors):
+        try:
+            lazy_tensors = tuple(lazify(lazy_tensor) for lazy_tensor in lazy_tensors)
+        except TypeError:
             raise RuntimeError("KroneckerProductLazyTensor is intended to wrap lazy tensors.")
         for prev_lazy_tensor, curr_lazy_tensor in zip(lazy_tensors[:-1], lazy_tensors[1:]):
             if prev_lazy_tensor.ndimension() != curr_lazy_tensor.ndimension():

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -6,7 +6,7 @@ from .. import settings
 from ..utils.memoize import cached
 from .lazy_tensor import LazyTensor
 from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
-from .non_lazy_tensor import NonLazyTensor
+from .non_lazy_tensor import lazify
 
 
 LAZY_KERNEL_TENSOR_WARNING = (
@@ -210,9 +210,8 @@ class LazyEvaluatedKernelTensor(LazyTensor):
                 and self._cached_kernel_eval.size(0) == 1
             ):
                 self._cached_kernel_eval = self._cached_kernel_eval[0]
-            if not isinstance(self._cached_kernel_eval, LazyTensor):
-                self._cached_kernel_eval = NonLazyTensor(self._cached_kernel_eval)
 
+            self._cached_kernel_eval = lazify(self._cached_kernel_eval)
             return self._cached_kernel_eval
 
     @cached

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -184,8 +184,6 @@ class LazyEvaluatedKernelTensor(LazyTensor):
         NB: This is a meta LazyTensor, in the sense that evaluate can return
         a LazyTensor if the kernel being evaluated does so.
         """
-        from ..kernels import Kernel
-
         if hasattr(self, "_cached_kernel_eval"):
             return self._cached_kernel_eval
         else:
@@ -196,9 +194,10 @@ class LazyEvaluatedKernelTensor(LazyTensor):
                 x1 = self.x1
                 x2 = self.x2
 
-            self._cached_kernel_eval = super(Kernel, self.kernel).__call__(
-                x1, x2, diag=False, batch_dims=self.batch_dims, **self.params
-            )
+            with settings.lazily_evaluate_kernels(False):
+                self._cached_kernel_eval = self.kernel(
+                    x1, x2, diag=False, batch_dims=self.batch_dims, **self.params
+                )
             if self.squeeze_row:
                 self._cached_kernel_eval.squeeze_(-2)
             if self.squeeze_col:

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1338,3 +1338,25 @@ def _import_dotted_name(name):
     for component in components[1:]:
         obj = getattr(obj, component)
     return obj
+
+
+def delazify(obj):
+    """
+    A function which ensures that `obj` is a (normal) Tensor.
+
+    If `obj` is a Tensor, this function does nothing.
+    If `obj` is a LazyTensor, this function evaluates it.
+    """
+
+    if torch.is_tensor(obj):
+        return obj
+    elif isinstance(obj, LazyTensor):
+        return obj.evaluate()
+    else:
+        raise TypeError("object of class {} cannot be made into a Tensor".format(obj.__class__.__name__))
+
+
+__all__ = [
+    "LazyTensor",
+    "delazify",
+]

--- a/gpytorch/lazy/matmul_lazy_tensor.py
+++ b/gpytorch/lazy/matmul_lazy_tensor.py
@@ -4,7 +4,7 @@ import torch
 
 from ..utils.memoize import cached
 from .lazy_tensor import LazyTensor
-from .non_lazy_tensor import NonLazyTensor
+from .non_lazy_tensor import lazify, NonLazyTensor
 
 
 def _inner_repeat(tensor, amt):
@@ -17,10 +17,8 @@ def _outer_repeat(tensor, amt):
 
 class MatmulLazyTensor(LazyTensor):
     def __init__(self, left_lazy_tensor, right_lazy_tensor):
-        if not isinstance(left_lazy_tensor, LazyTensor):
-            left_lazy_tensor = NonLazyTensor(left_lazy_tensor)
-        if not isinstance(right_lazy_tensor, LazyTensor):
-            right_lazy_tensor = NonLazyTensor(right_lazy_tensor)
+        left_lazy_tensor = lazify(left_lazy_tensor)
+        right_lazy_tensor = lazify(right_lazy_tensor)
 
         super(MatmulLazyTensor, self).__init__(left_lazy_tensor, right_lazy_tensor)
         self.left_lazy_tensor = left_lazy_tensor

--- a/gpytorch/lazy/non_lazy_tensor.py
+++ b/gpytorch/lazy/non_lazy_tensor.py
@@ -61,3 +61,25 @@ class NonLazyTensor(LazyTensor):
 
     def evaluate(self):
         return self.tensor
+
+
+def lazify(obj):
+    """
+    A function which ensures that `obj` is a LazyTensor.
+
+    If `obj` is a LazyTensor, this function does nothing.
+    If `obj` is a (normal) Tensor, this function wraps it with a `NonLazyTensor`.
+    """
+
+    if torch.is_tensor(obj):
+        return NonLazyTensor(obj)
+    elif isinstance(obj, LazyTensor):
+        return obj
+    else:
+        raise TypeError("object of class {} cannot be made into a LazyTensor".format(obj.__class__.__name__))
+
+
+__all__ = [
+    "NonLazyTensor",
+    "lazify",
+]

--- a/gpytorch/lazy/root_lazy_tensor.py
+++ b/gpytorch/lazy/root_lazy_tensor.py
@@ -4,7 +4,7 @@ import torch
 
 from ..utils.memoize import cached
 from .lazy_tensor import LazyTensor
-from .non_lazy_tensor import NonLazyTensor
+from .non_lazy_tensor import lazify, NonLazyTensor
 
 
 def _inner_repeat(tensor, amt):
@@ -17,8 +17,7 @@ def _outer_repeat(tensor, amt):
 
 class RootLazyTensor(LazyTensor):
     def __init__(self, root):
-        if not isinstance(root, LazyTensor):
-            root = NonLazyTensor(root)
+        root = lazify(root)
         super(RootLazyTensor, self).__init__(root)
         self.root = root
 

--- a/gpytorch/lazy/sum_lazy_tensor.py
+++ b/gpytorch/lazy/sum_lazy_tensor.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-import torch
-
 from ..utils.memoize import cached
+from .non_lazy_tensor import lazify
 from .lazy_tensor import LazyTensor
-from .non_lazy_tensor import NonLazyTensor
 from .zero_lazy_tensor import ZeroLazyTensor
 
 
@@ -12,11 +10,10 @@ class SumLazyTensor(LazyTensor):
     def __init__(self, *lazy_tensors):
         lazy_tensors = list(lazy_tensors)
         for i, lazy_tensor in enumerate(lazy_tensors):
-            if not isinstance(lazy_tensor, LazyTensor):
-                if torch.is_tensor(lazy_tensor):
-                    lazy_tensors[i] = NonLazyTensor(lazy_tensor)
-                else:
-                    raise RuntimeError("All arguments of a SumLazyTensor should be LazyTensors or Tensors")
+            try:
+                lazy_tensors[i] = lazify(lazy_tensor)
+            except TypeError:
+                raise TypeError("All arguments of a SumLazyTensor should be LazyTensors or Tensors")
         super(SumLazyTensor, self).__init__(*lazy_tensors)
 
         self.lazy_tensors = lazy_tensors

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -206,6 +206,19 @@ class fast_computations(object):
         return False
 
 
+class lazily_evaluate_kernels(_feature_flag):
+    """
+    Lazily compute the entries of covariance matrices (set to True by default).
+    This can result in memory and speed savings - if say cross covariance terms are not needed
+    or if you only need to compute variances (not covariances).
+
+    If set to False, gpytorch will always compute the entire covariance matrix between
+    training and test data.
+    """
+
+    _state = True
+
+
 class max_cg_iterations(_value_context):
     """
     The maximum number of conjugate gradient iterations to perform (when computing

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -4,18 +4,16 @@ import torch
 
 
 def pivoted_cholesky(matrix, max_iter, error_tol=1e-3):
-    from ..lazy import LazyTensor, NonLazyTensor
+    from ..lazy import lazify, LazyTensor
 
     batch_shape = matrix.shape[:-2]
     matrix_shape = matrix.shape[-2:]
 
     # Need to get diagonals. This is easy if it's a LazyTensor, since
     # LazyTensor.diag() operates in batch mode.
-    if isinstance(matrix, LazyTensor):
-        matrix = matrix.evaluate_kernel()
-        matrix_diag = matrix._approx_diag()
-    elif torch.is_tensor(matrix):
-        matrix_diag = NonLazyTensor(matrix).diag()
+    matrix = lazify(matrix)
+    matrix = matrix.evaluate_kernel()
+    matrix_diag = matrix._approx_diag()
 
     # Make sure max_iter isn't bigger than the matrix
     max_iter = min(max_iter, matrix_shape[-1])

--- a/gpytorch/variational/cholesky_variational_distribution.py
+++ b/gpytorch/variational/cholesky_variational_distribution.py
@@ -2,7 +2,7 @@
 
 import torch
 from ..functions import add_diag
-from ..lazy import CholLazyTensor, NonLazyTensor
+from ..lazy import lazify, CholLazyTensor
 from ..distributions import MultivariateNormal
 from .variational_distribution import VariationalDistribution
 
@@ -48,7 +48,7 @@ class CholeskyVariationalDistribution(VariationalDistribution):
         that the diagonal remains positive.
         """
         chol_variational_covar = self.chol_variational_covar
-        diagonal = NonLazyTensor(chol_variational_covar).diag()
+        diagonal = lazify(chol_variational_covar).diag()
         dtype = chol_variational_covar.dtype
         device = chol_variational_covar.device
 


### PR DESCRIPTION
This PR does two things:
- Prevents nested kernels from creating nestings of `LazyEvaluatedKernelTensors`. Now only the outermost kernel wraps the output in one of these.
- Introduces `lazify` and `delazify` helper method. They do what they sound like they do, and can operate on regular Tensors and LazyTensors.

This doesn't change any behavior (kernels are lazily evaluated still). However, it prevents lots of bugs associated with nested kernels. In addition, it is now possible to turn off lazy kernel evaluation (for debugging) using the context manager `gpytorch.settings.lazily_evaluate_kernels(False)`.