### PR TITLE
Cache solves for fast variational

### DIFF
--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -225,7 +225,7 @@ except ImportError:
 @register_kl(MultivariateNormal, MultivariateNormal)
 def kl_mvn_mvn(p_dist, q_dist):
     q_mean = q_dist.loc
-    q_covar = q_dist.lazy_covariance_matrix.add_jitter()
+    q_covar = q_dist.lazy_covariance_matrix
 
     p_mean = p_dist.loc
     p_covar = p_dist.lazy_covariance_matrix
@@ -236,7 +236,7 @@ def kl_mvn_mvn(p_dist, q_dist):
         # right now this just catches if root_p_covar is a DiagLazyTensor,
         # but we may want to be smarter about this in the future
         root_p_covar = root_p_covar.evaluate()
-    inv_quad_rhs = torch.cat([root_p_covar, mean_diffs.unsqueeze(-1)], -1)
+    inv_quad_rhs = torch.cat([mean_diffs.unsqueeze(-1), root_p_covar], -1)
     log_det_p_covar = p_covar.log_det()
     trace_plus_inv_quad_form, log_det_q_covar = q_covar.inv_quad_log_det(inv_quad_rhs=inv_quad_rhs, log_det=True)
 

--- a/gpytorch/functions/__init__.py
+++ b/gpytorch/functions/__init__.py
@@ -117,7 +117,7 @@ def inv_matmul(mat, right_tensor, left_tensor=None):
         - :obj:`torch.tensor` - :math:`A^{-1}R` or :math:`LA^{-1}R`.
     """
     from ..lazy import lazify
-    return lazify(mat).inv_matmul(rhs, left_tensor)
+    return lazify(mat).inv_matmul(right_tensor, left_tensor)
 
 
 def inv_quad(mat, tensor):

--- a/gpytorch/functions/__init__.py
+++ b/gpytorch/functions/__init__.py
@@ -85,19 +85,39 @@ def matmul(mat, rhs):
     return mat.matmul(rhs)
 
 
-def inv_matmul(mat, rhs):
-    """
-    Computes a linear solve with several right hand sides.
+def inv_matmul(mat, right_tensor, left_tensor=None):
+    r"""
+    Computes a linear solve (w.r.t :attr:`mat` = :math:`A`) with several right hand sides :math:`R`.
+    I.e. computes
+
+    ... math::
+
+        \begin{equation}
+            A^{-1} R,
+        \end{equation}
+
+    where :math:`R` is :attr:`right_tensor` and :math:`A` is :attr:`mat`.
+
+    If :attr:`left_tensor` is supplied, computes
+
+    ... math::
+
+        \begin{equation}
+            L A^{-1} R,
+        \end{equation}
+
+    where :math:`L` is :attr:`left_tensor`. Supplying this can reduce the number of
+    CG calls required.
 
     Args:
-        - mat (matrix nxn) - Matrix to solve with
-        - rhs (matrix nxk) - rhs matrix or vector
+        - :obj:`torch.tensor` (n x k) - Matrix :math:`R` right hand sides
+        - :obj:`torch.tensor` (m x n) - Optional matrix :math:`L` to perform left multiplication with
 
     Returns:
-        - matrix nxk - (mat)^{-1} rhs
+        - :obj:`torch.tensor` - :math:`A^{-1}R` or :math:`LA^{-1}R`.
     """
     from ..lazy import lazify
-    return lazify(mat).inv_matmul(rhs)
+    return lazify(mat).inv_matmul(rhs, left_tensor)
 
 
 def inv_quad(mat, tensor):

--- a/gpytorch/functions/_inv_matmul.py
+++ b/gpytorch/functions/_inv_matmul.py
@@ -7,29 +7,50 @@ from .. import settings
 
 
 class InvMatmul(Function):
-    def __init__(self, representation_tree, preconditioner=None):
+    def __init__(self, representation_tree, preconditioner=None, has_left=False):
         self.representation_tree = representation_tree
         self.preconditioner = preconditioner
+        self.has_left = has_left
 
-    def forward(self, rhs, *matrix_args):
+    def forward(self, *args):
+        left_tensor = None
+        right_tensor = None
+        matrix_args = None
+        if self.has_left:
+            left_tensor, right_tensor, *matrix_args = args
+        else:
+            right_tensor, *matrix_args = args
         lazy_tsr = self.representation_tree(*matrix_args)
         matmul_closure = lazy_tsr._matmul
 
         self.is_vector = False
-        if rhs.ndimension() == 1:
-            rhs.unsqueeze_(-1)
+        if right_tensor.ndimension() == 1:
+            right_tensor.unsqueeze_(-1)
             self.is_vector = True
 
         # Perform solves (for inv_quad) and tridiagonalization (for estimating log_det)
-        res = linear_cg(
-            matmul_closure, rhs, max_iter=settings.max_cg_iterations.value(), preconditioner=self.preconditioner
-        )
+        if self.has_left:
+            rhs = torch.cat([left_tensor.transpose(-1, -2), right_tensor], -1)
+            solves = linear_cg(
+                matmul_closure, rhs, max_iter=settings.max_cg_iterations.value(), preconditioner=self.preconditioner
+            )
+            res = solves[..., left_tensor.size(-2):]
+            res = left_tensor @ res
+        else:
+            solves = linear_cg(
+                matmul_closure, right_tensor, max_iter=settings.max_cg_iterations.value(),
+                preconditioner=self.preconditioner
+            )
+            res = solves
 
         if self.is_vector:
             res.squeeze_(-1)
-            rhs.squeeze_(-1)
+            right_tensor.squeeze_(-1)
 
-        args = [res, rhs] + list(matrix_args)
+        if self.has_left:
+            args = [solves, left_tensor, right_tensor] + list(matrix_args)
+        else:
+            args = [solves, right_tensor] + list(matrix_args)
         self.save_for_backward(*args)
         if settings.memory_efficient.off():
             self._lazy_tsr = lazy_tsr
@@ -38,9 +59,12 @@ class InvMatmul(Function):
 
     def backward(self, grad_output):
         # Extract items that were saved
-        rhs_solves = self.saved_tensors[0]
-        rhs = self.saved_tensors[1]
-        matrix_args = self.saved_tensors[2:]
+        if self.has_left:
+            solves, left_tensor, right_tensor, *matrix_args = self.saved_tensors
+            left_solves = solves[..., :left_tensor.size(-2)]
+            right_solves = solves[..., left_tensor.size(-2):]
+        else:
+            right_solves, right_tensor, *matrix_args = self.saved_tensors
 
         # Get matrix functions
         if hasattr(self, "_lazy_tsr"):
@@ -51,33 +75,48 @@ class InvMatmul(Function):
 
         # Define gradient placeholders
         arg_grads = [None] * len(matrix_args)
-        rhs_grad = None
+        left_grad = None
+        right_grad = None
         if any(self.needs_input_grad):
             # De-vectorize objects
             if self.is_vector:
-                rhs = rhs.unsqueeze(-1)
-                rhs_solves = rhs_solves.unsqueeze(-1)
-                grad_output = grad_output.unsqueeze(-1)
+                right_tensor = right_tensor.unsqueeze(-1)
 
-            # Compute self^{-1} grad_output
-            grad_output_solves = linear_cg(
-                matmul_closure,
-                grad_output,
-                max_iter=settings.max_cg_iterations.value(),
-                preconditioner=self.preconditioner,
-            )
-
-            # input_1 gradient
-            if any(self.needs_input_grad[1:]):
-                if lazy_tsr is not None:
-                    arg_grads = lazy_tsr._quad_form_derivative(grad_output_solves, rhs_solves.mul(-1))
-                else:
-                    arg_grads = (torch.matmul(grad_output_solves, rhs_solves.mul(-1).transpose(-1, -2)),)
-
-            # input_2 gradient
-            if self.needs_input_grad[0]:
-                rhs_grad = grad_output_solves
+            if not self.has_left:
                 if self.is_vector:
-                    rhs_grad.squeeze_(-1)
+                    grad_output = grad_output.unsqueeze(-1)
+                    right_solves.unsqueeze_(-1)
 
-        return tuple([rhs_grad] + list(arg_grads))
+                # Compute self^{-1} grad_output
+                left_solves = linear_cg(
+                    matmul_closure,
+                    grad_output,
+                    max_iter=settings.max_cg_iterations.value(),
+                    preconditioner=self.preconditioner,
+                )
+
+                if any(self.needs_input_grad[1:]):
+                    arg_grads = lazy_tsr._quad_form_derivative(left_solves, right_solves.mul(-1))
+                if self.needs_input_grad[0]:
+                    right_grad = left_solves
+                    if self.is_vector:
+                        right_grad.squeeze_(-1)
+
+                return tuple([right_grad] + list(arg_grads))
+
+            else:
+                if self.is_vector:
+                    grad_output = grad_output.unsqueeze(-1)
+
+                left_solves = left_solves @ grad_output
+
+                if self.needs_input_grad[1]:
+                    left_grad = grad_output @ right_solves.transpose(-1, -2)
+                if any(self.needs_input_grad[2:]):
+                    arg_grads = lazy_tsr._quad_form_derivative(left_solves, right_solves.mul(-1))
+                if self.needs_input_grad[0]:
+                    right_grad = left_solves
+                    if self.is_vector:
+                        right_grad.squeeze_(-1)
+
+                return tuple([left_grad, right_grad] + list(arg_grads))

--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -5,6 +5,7 @@ from .added_diag_lazy_tensor import AddedDiagLazyTensor
 from .batch_repeat_lazy_tensor import BatchRepeatLazyTensor
 from .block_lazy_tensor import BlockLazyTensor
 from .block_diag_lazy_tensor import BlockDiagLazyTensor
+from .cached_cg_lazy_tensor import CachedCGLazyTensor
 from .chol_lazy_tensor import CholLazyTensor
 from .constant_mul_lazy_tensor import ConstantMulLazyTensor
 from .diag_lazy_tensor import DiagLazyTensor
@@ -31,6 +32,7 @@ __all__ = [
     "BatchRepeatLazyTensor",
     "BlockLazyTensor",
     "BlockDiagLazyTensor",
+    "CachedCGLazyTensor",
     "CholLazyTensor",
     "ConstantMulLazyTensor",
     "DiagLazyTensor",

--- a/gpytorch/lazy/cached_cg_lazy_tensor.py
+++ b/gpytorch/lazy/cached_cg_lazy_tensor.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import torch
+import warnings
+from .lazy_tensor import LazyTensor
+from .. import settings
+
+
+class CachedCGLazyTensor(LazyTensor):
+    """
+    A LazyTensor wrapper that eagerly computes many CG calls in batch.
+    This maximizes CG parallelism for fast inference.
+    Used primarily for variational inference with GPs.
+
+    Args:
+        :attr:`base_lazy_tensor` (:class:`gpytorch.lazy.LazyTensor`): the LazyTensor to wrap
+    """
+
+    def __init__(self, base_lazy_tensor, eager_rhss=[], solves=None):
+        # We're precomputing the solves and the normed version of the eager_rhss
+        # This will make it faster when we reconstruct the LazyTensor inside functions
+        with torch.no_grad():
+            if solves is None:
+                solves = [
+                    base_lazy_tensor._solve(eager_rhs, base_lazy_tensor._preconditioner()[0])
+                    for eager_rhs in eager_rhss
+                ]
+
+        super(CachedCGLazyTensor, self).__init__(
+            base_lazy_tensor, eager_rhss=eager_rhss, solves=solves,
+        )
+        self.base_lazy_tensor = base_lazy_tensor
+        self.eager_rhss = [eager_rhs.requires_grad_(False) for eager_rhs in eager_rhss]
+        self.solves = [solve.requires_grad_(False) for solve in solves]
+
+    @property
+    def requires_grad(self):
+        return self.base_lazy_tensor.requires_grad
+
+    @requires_grad.setter
+    def requires_grad(self, val):
+        self.base_lazy_tensor.requires_grad = val
+
+    def _get_indices(self, left_indices, right_indices, *batch_indices):
+        return self.base_lazy_tensor._get_indices(left_indices, right_indices, *batch_indices)
+
+    def _getitem(self, *indices):
+        return self.base_lazy_tensor._getitem(*indices)
+
+    def _matmul(self, tensor):
+        return self.base_lazy_tensor._matmul(tensor)
+
+    def _quad_form_derivative(self, left_vecs, right_vecs):
+        return self.base_lazy_tensor._quad_form_derivative(left_vecs, right_vecs)
+
+    def _solve(self, rhs, preconditioner):
+        # Here we check to see what solves we've already performed
+        for eager_rhs, solve in zip(self.eager_rhss, self.solves):
+            if torch.equal(rhs, eager_rhs):
+                return solve
+
+        if settings.debug.on():
+            warnings.warn(
+                "CachedCGLazyTensor had to run CG on a tensor of size {}. For best performance, this "
+                "LazyTensor should pre-register all vectors to run CG against.".format(rhs.shape)
+            )
+        return super(CachedCGLazyTensor, self)._solve(rhs, preconditioner)
+
+    def _size(self):
+        return self.base_lazy_tensor._size()
+
+    def _t_matmul(self, tensor):
+        return self.base_lazy_tensor._t_matmul(tensor)
+
+    def _transpose_nonbatch(self):
+        return self.base_lazy_tensor._transpose_nonbatch()
+
+    def detach_(self):
+        self.base_lazy_tensor.detach_()
+        return self

--- a/gpytorch/lazy/cached_cg_lazy_tensor.py
+++ b/gpytorch/lazy/cached_cg_lazy_tensor.py
@@ -13,7 +13,22 @@ class CachedCGLazyTensor(LazyTensor):
     Used primarily for variational inference with GPs.
 
     Args:
-        :attr:`base_lazy_tensor` (:class:`gpytorch.lazy.LazyTensor`): the LazyTensor to wrap
+        :attr:`base_lazy_tensor` (:class:`gpytorch.lazy.LazyTensor`):
+            the LazyTensor to wrap
+        :attr:`eager_rhss` (list of :class:`gpytorch.lazy.LazyTensor`):
+            list of right-hand sides with eagerly-computed solves
+        :attr:`solves` (list of :class:`gpytorch.lazy.LazyTensor`):
+            list of solves associated with :attr:`eager_rhss`
+        :attr:`probe_vectors` (:class:`gpytorch.lazy.LazyTensor`, optional):
+            normalized probe vectors (for computing logdet with SLQ)
+        :attr:`probe_vector_norms` (:class:`gpytorch.lazy.LazyTensor`, optional):
+            norms associated with :attr:`probe_vectors` that will return :attr:`probe_vectors`
+            to having identity covariance (for computing logdet with SLQ)
+        :attr:`probe_vector_solves` (:class:`gpytorch.lazy.LazyTensor`, optional):
+            solves associated with :attr:`probe_vectors` (for computing logdet with SLQ)
+        :attr:`probe_vector_tmats` (:class:`gpytorch.lazy.LazyTensor`, optional):
+            Lanczos tridiagonal matrices associated with :attr:`probe_vectors`
+            (for computing logdet with SLQ)
     """
 
     @classmethod

--- a/gpytorch/lazy/cached_cg_lazy_tensor.py
+++ b/gpytorch/lazy/cached_cg_lazy_tensor.py
@@ -16,24 +16,54 @@ class CachedCGLazyTensor(LazyTensor):
         :attr:`base_lazy_tensor` (:class:`gpytorch.lazy.LazyTensor`): the LazyTensor to wrap
     """
 
-    def __init__(self, base_lazy_tensor, eager_rhss=[], solves=None):
-        # We're precomputing the solves and the normed version of the eager_rhss
-        # This will make it faster when we reconstruct the LazyTensor inside functions
+    @classmethod
+    def precompute_terms(cls, base_lazy_tensor, eager_rhs):
+        """
+        Computes the solves, probe vectors, probe_vector norms, probe vector solves, and probe vector
+        tridiagonal matrices to construct a CachedCGLazyTensor
+        """
         with torch.no_grad():
-            if solves is None:
-                all_solves = base_lazy_tensor._solve(torch.cat(eager_rhss, -1), base_lazy_tensor._preconditioner()[0])
-                solves = []
-                for eager_rhs in eager_rhss:
-                    solve = all_solves[..., :eager_rhs.size(-1)]
-                    all_solves = all_solves[..., eager_rhs.size(-1):]
-                    solves.append(solve.detach())  # The detach is necessary here for some reason?
+            # Generate probe vectors
+            num_random_probes = settings.num_trace_samples.value()
+            probe_vectors = torch.empty(
+                base_lazy_tensor.matrix_shape[-1], num_random_probes, dtype=base_lazy_tensor.dtype,
+                device=base_lazy_tensor.device
+            )
+            probe_vectors.bernoulli_().mul_(2).add_(-1)
+            probe_vectors = probe_vectors.expand(
+                *base_lazy_tensor.batch_shape, base_lazy_tensor.matrix_shape[-1], num_random_probes
+            )
+            probe_vector_norms = torch.norm(probe_vectors, 2, dim=-2, keepdim=True)
+            probe_vectors = probe_vectors.div(probe_vector_norms)
 
+            # Compute solves
+            all_solves, probe_vector_tmats, = base_lazy_tensor._solve(
+                torch.cat([probe_vectors, eager_rhs], -1),
+                preconditioner=base_lazy_tensor._preconditioner()[0],
+                num_tridiag=probe_vectors.size(-1)
+            )
+            probe_vector_solves = all_solves[..., :probe_vectors.size(-1)].detach()
+            solves = all_solves[..., probe_vectors.size(-1):]
+
+            return solves.detach(), probe_vectors.detach(), probe_vector_norms.detach(), \
+                probe_vector_solves.detach(), probe_vector_tmats.detach()
+
+    def __init__(
+        self, base_lazy_tensor, eager_rhss=[], solves=[], probe_vectors=torch.tensor([]),
+        probe_vector_norms=torch.tensor([]), probe_vector_solves=torch.tensor([]), probe_vector_tmats=torch.tensor([])
+    ):
         super(CachedCGLazyTensor, self).__init__(
-            base_lazy_tensor, eager_rhss=eager_rhss, solves=solves,
+            base_lazy_tensor, eager_rhss=eager_rhss, solves=solves, probe_vectors=probe_vectors,
+            probe_vector_norms=probe_vector_norms, probe_vector_solves=probe_vector_solves,
+            probe_vector_tmats=probe_vector_tmats,
         )
         self.base_lazy_tensor = base_lazy_tensor
         self.eager_rhss = [eager_rhs.requires_grad_(False) for eager_rhs in eager_rhss]
         self.solves = [solve.requires_grad_(False) for solve in solves]
+        self.probe_vectors = probe_vectors.requires_grad_(False)
+        self.probe_vector_norms = probe_vector_norms.requires_grad_(False)
+        self.probe_vector_solves = probe_vector_solves.requires_grad_(False)
+        self.probe_vector_tmats = probe_vector_tmats.requires_grad_(False)
 
     @property
     def requires_grad(self):
@@ -52,25 +82,40 @@ class CachedCGLazyTensor(LazyTensor):
     def _matmul(self, tensor):
         return self.base_lazy_tensor._matmul(tensor)
 
+    def _probe_vectors_and_norms(self):
+        return self.probe_vectors, self.probe_vector_norms
+
     def _quad_form_derivative(self, left_vecs, right_vecs):
         return self.base_lazy_tensor._quad_form_derivative(left_vecs, right_vecs)
 
     def _solve(self, rhs, preconditioner, num_tridiag=None):
-        # Temporary
-        if num_tridiag is not None:
-            return super(CachedCGLazyTensor, self)._solve(rhs, preconditioner, num_tridiag=num_tridiag)
+        if num_tridiag:
+            probe_vectors = rhs[..., :num_tridiag].detach()
+            if torch.equal(probe_vectors, self.probe_vectors):
+                probe_vector_solves = self.probe_vector_solves
+                tmats = self.probe_vector_tmats
+            else:
+                if settings.debug.on():
+                    warnings.warn(
+                        "CachedCGLazyTensor did not recognize the supplied probe vectors for tridiagonalization."
+                    )
+                return super(CachedCGLazyTensor, self)._solve(rhs, preconditioner, num_tridiag=num_tridiag)
 
         # Here we check to see what solves we've already performed
+        truncated_rhs = rhs[..., (num_tridiag or 0):]
         for eager_rhs, solve in zip(self.eager_rhss, self.solves):
-            if torch.equal(rhs, eager_rhs):
-                return solve
+            if torch.equal(truncated_rhs, eager_rhs):
+                if num_tridiag:
+                    return torch.cat([probe_vector_solves, solve], -1), tmats
+                else:
+                    return solve
 
         if settings.debug.on():
             warnings.warn(
                 "CachedCGLazyTensor had to run CG on a tensor of size {}. For best performance, this "
                 "LazyTensor should pre-register all vectors to run CG against.".format(rhs.shape)
             )
-        return super(CachedCGLazyTensor, self)._solve(rhs, preconditioner)
+        return super(CachedCGLazyTensor, self)._solve(rhs, preconditioner, num_tridiag=num_tridiag)
 
     def _size(self):
         return self.base_lazy_tensor._size()

--- a/gpytorch/lazy/chol_lazy_tensor.py
+++ b/gpytorch/lazy/chol_lazy_tensor.py
@@ -12,10 +12,7 @@ class CholLazyTensor(RootLazyTensor):
             chol = chol.evaluate()
 
         # Check that we have a lower triangular matrix
-        mask = torch.full((chol.size(-2), chol.size(-2)), fill_value=-1, dtype=chol.dtype, device=chol.device)
-        mask.tril_().add_(1)
-        if chol.ndimension() == 3:
-            mask.unsqueeze_(0)
+        mask = torch.ones(chol.shape[-2:], dtype=chol.dtype, device=chol.device).triu_(1)
         if torch.max(chol.mul(mask)).item() > 1e-3 and torch.equal(chol, chol):
             raise RuntimeError("CholLazyVaraiable should take a lower-triangular " "matrix in the constructor.")
 

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -120,8 +120,11 @@ class DiagLazyTensor(LazyTensor):
     def inverse(self):
         return DiagLazyTensor(self._diag.reciprocal())
 
-    def inv_matmul(self, tensor):
-        return self.inverse()._matmul(tensor)
+    def inv_matmul(self, right_tensor, left_tensor=None):
+        res = self.inverse()._matmul(right_tensor)
+        if left_tensor is not None:
+            res = left_tensor @ res
+        return res
 
     def inv_quad_log_det(self, inv_quad_rhs=None, log_det=False, reduce_inv_quad=True):
 

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -685,7 +685,7 @@ class LazyTensor(object):
         else:
             return func(left_tensor, right_tensor, *self.representation())
 
-    def inv_quad(self, tensor):
+    def inv_quad(self, tensor, reduce_inv_quad=True):
         """
         Computes an inverse quadratic form (w.r.t self) with several right hand sides.
         I.e. computes tr( tensor^T self^{-1} tensor )
@@ -699,7 +699,7 @@ class LazyTensor(object):
         Returns:
             - tensor - tr( tensor^T (self)^{-1} tensor )
         """
-        res, _ = self.inv_quad_log_det(inv_quad_rhs=tensor, log_det=False)
+        res, _ = self.inv_quad_log_det(inv_quad_rhs=tensor, log_det=False, reduce_inv_quad=reduce_inv_quad)
         return res
 
     def inv_quad_log_det(self, inv_quad_rhs=None, log_det=False, reduce_inv_quad=True):

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -10,6 +10,7 @@ from ..functions._inv_matmul import InvMatmul
 from ..functions._inv_quad_log_det import InvQuadLogDet
 from ..functions._matmul import Matmul
 from ..functions._root_decomposition import RootDecomposition
+from ..utils import linear_cg
 from ..utils.broadcasting import _matmul_broadcast_shape
 from ..utils.memoize import cached
 from ..utils.qr import batch_qr
@@ -90,6 +91,9 @@ class LazyTensor(object):
             :obj:`torch.tensor`: matrix * rhs
         """
         raise NotImplementedError("The class {} requires a _matmul function!".format(self.__class__.__name__))
+
+    def _solve(self, rhs, preconditioner):
+        return linear_cg(self._matmul, rhs, max_iter=settings.max_cg_iterations.value(), preconditioner=preconditioner)
 
     def _size(self):
         """

--- a/gpytorch/lazy/zero_lazy_tensor.py
+++ b/gpytorch/lazy/zero_lazy_tensor.py
@@ -119,7 +119,7 @@ class ZeroLazyTensor(LazyTensor):
     def evaluate(self):
         return torch.zeros(*self.sizes)
 
-    def inv_matmul(self, tensor):
+    def inv_matmul(self, right_tensor, left_tensor=None):
         raise RuntimeError("ZeroLazyTensors are not invertible!")
 
     def inv_quad(self, tensor):

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -3,7 +3,7 @@
 import math
 import torch
 from .. import beta_features
-from ..lazy import RootLazyTensor, PsdSumLazyTensor, DiagLazyTensor
+from ..lazy import DiagLazyTensor, NonLazyTensor, PsdSumLazyTensor, RootLazyTensor
 from ..module import Module
 from ..distributions import MultivariateNormal
 
@@ -87,17 +87,29 @@ class VariationalStrategy(Module):
         if torch.equal(x, inducing_points):
             return variational_dist
         else:
-            n_induc = inducing_points.size(-2)
+            num_induc = inducing_points.size(-2)
             full_inputs = torch.cat([inducing_points, x], dim=-2)
             full_output = self.model.forward(full_inputs)
             full_mean, full_covar = full_output.mean, full_output.lazy_covariance_matrix
 
-            test_mean = full_mean[..., n_induc:]
-            induc_mean = full_mean[..., :n_induc]
-            induc_induc_covar = full_covar[..., :n_induc, :n_induc].add_jitter()
-            induc_data_covar = full_covar[..., :n_induc, n_induc:]
-            data_data_covar = full_covar[..., n_induc:, n_induc:]
+            # Mean terms
+            test_mean = full_mean[..., num_induc:]
+            induc_mean = full_mean[..., :num_induc]
             var_dist_mean = variational_dist.mean
+            mean_diff = (var_dist_mean - induc_mean).unsqueeze(-1)
+
+            # Covariance terms
+            induc_induc_covar = NonLazyTensor(full_covar[..., :num_induc, :num_induc].evaluate()).add_jitter()
+            # TODO: FIX
+            induc_data_covar = full_covar[..., :num_induc, num_induc:].evaluate()
+            data_data_covar = full_covar[..., num_induc:, num_induc:]
+            root_variational_covar = variational_dist.lazy_covariance_matrix.root_decomposition().root.evaluate()
+
+            # Compute all products with `induc_induc_covar^{-1}` simultaneously
+            eye = torch.eye(root_variational_covar.size(-1), dtype=mean_diff.dtype, device=mean_diff.device)
+            eye = eye.expand_as(root_variational_covar)
+            left_tensors = torch.cat([mean_diff, root_variational_covar.transpose(-1, -2), eye], -1)
+            inv_products = induc_induc_covar.inv_matmul(induc_data_covar, left_tensors.transpose(-1, -2))
 
             # Cache the prior distribution, for faster training
             if self.training:
@@ -105,18 +117,15 @@ class VariationalStrategy(Module):
                 self._prior_distribution_memo = prior_dist
 
             # Compute predictive mean/covariance
-            induc_data_covar = induc_data_covar.evaluate()
-            inv_product = induc_induc_covar.inv_matmul(induc_data_covar)
-            factor = variational_dist.lazy_covariance_matrix.root_decomposition().root.matmul(inv_product)
-            predictive_mean = torch.add(
-                test_mean, inv_product.transpose(-1, -2).matmul((var_dist_mean - induc_mean).unsqueeze(-1)).squeeze(-1)
-            )
-            predictive_covar = RootLazyTensor(factor.transpose(-2, -1))
+            predictive_mean = torch.add(test_mean, inv_products[..., 0, :])
+            predictive_covar = RootLazyTensor(inv_products[..., 1:-num_induc, :].transpose(-1, -2))
 
+            # Compute a diagonal correction for the covariance. It is the diagonal of the Schur complement
+            # K_{data,data} - K_{data,induc} K_{induc,induc}^{-1} K_{induc,data}
             if beta_features.diagonal_correction.on():
-                fake_diagonal = (inv_product * induc_data_covar).sum(-2)
-                real_diagonal = data_data_covar.diag()
-                diag_correction = DiagLazyTensor((real_diagonal - fake_diagonal).clamp(0, math.inf))
+                # interp_data_data_var = diag(K_{data,induc} K_{induc,induc}^{-1} K_{induc,data})
+                interp_data_data_var = (inv_products[..., -num_induc:, :] * induc_data_covar).sum(-2)
+                diag_correction = DiagLazyTensor((data_data_covar.diag() - interp_data_data_var).clamp(0, math.inf))
                 predictive_covar = PsdSumLazyTensor(predictive_covar, diag_correction)
 
             return MultivariateNormal(predictive_mean, predictive_covar)

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -122,7 +122,7 @@ class VariationalStrategy(Module):
                 ]
                 if settings.skip_logdet_forward.on():
                     eager_rhss.append(torch.cat([probe_vecs, left_tensors], -1))
-                    solves.append(torch.cat([probe_vec_solves, solve[..., left_tensors.size(-1):]], -1))
+                    solves.append(torch.cat([probe_vec_solves, solve[..., :left_tensors.size(-1)]], -1))
             induc_induc_covar = CachedCGLazyTensor(
                 induc_induc_covar, eager_rhss=eager_rhss, solves=solves, probe_vectors=probe_vecs,
                 probe_vector_norms=probe_vec_norms, probe_vector_solves=probe_vec_solves,

--- a/test/examples/test_batch_svgp_gp_regression.py
+++ b/test/examples/test_batch_svgp_gp_regression.py
@@ -71,7 +71,7 @@ class TestSVGPRegression(unittest.TestCase):
         model.train()
         likelihood.train()
         optimizer = optim.Adam([{"params": model.parameters()}, {"params": likelihood.parameters()}], lr=0.01)
-        for _ in range(150):
+        for _ in range(180):
             optimizer.zero_grad()
             output = model(train_x)
             loss = -mll(output, train_y)

--- a/test/examples/test_batch_svgp_gp_regression.py
+++ b/test/examples/test_batch_svgp_gp_regression.py
@@ -106,7 +106,7 @@ class TestSVGPRegression(unittest.TestCase):
         model.train()
         likelihood.train()
         optimizer = optim.Adam([{"params": model.parameters()}, {"params": likelihood.parameters()}], lr=0.01)
-        for _ in range(150):
+        for _ in range(200):
             optimizer.zero_grad()
             output = model(train_x)
             loss = -mll(output, train_y)

--- a/test/examples/test_svgp_gp_regression.py
+++ b/test/examples/test_svgp_gp_regression.py
@@ -65,8 +65,7 @@ class TestSVGPRegression(unittest.TestCase):
         model.train()
         likelihood.train()
         optimizer = optim.Adam([{"params": model.parameters()}, {"params": likelihood.parameters()}], lr=0.01)
-        optimizer.n_iter = 0
-        for _ in range(150):
+        for _ in range(170):
             optimizer.zero_grad()
             output = model(train_x)
             loss = -mll(output, train_y)

--- a/test/examples/test_svgp_gp_regression.py
+++ b/test/examples/test_svgp_gp_regression.py
@@ -55,7 +55,7 @@ class TestSVGPRegression(unittest.TestCase):
         if hasattr(self, "rng_state"):
             torch.set_rng_state(self.rng_state)
 
-    def test_regression_error(self):
+    def test_regression_error(self, skip_logdet_forward=False):
         train_x, train_y = train_data()
         likelihood = GaussianLikelihood()
         model = SVGPRegressionModel(torch.linspace(0, 1, 25))
@@ -65,12 +65,13 @@ class TestSVGPRegression(unittest.TestCase):
         model.train()
         likelihood.train()
         optimizer = optim.Adam([{"params": model.parameters()}, {"params": likelihood.parameters()}], lr=0.01)
-        for _ in range(170):
-            optimizer.zero_grad()
-            output = model(train_x)
-            loss = -mll(output, train_y)
-            loss.backward()
-            optimizer.step()
+        with gpytorch.settings.skip_logdet_forward(skip_logdet_forward):
+            for _ in range(170):
+                optimizer.zero_grad()
+                output = model(train_x)
+                loss = -mll(output, train_y)
+                loss.backward()
+                optimizer.step()
 
         for param in model.parameters():
             self.assertTrue(param.grad is not None)
@@ -85,6 +86,9 @@ class TestSVGPRegression(unittest.TestCase):
         test_preds = likelihood(model(train_x)).mean.squeeze()
         mean_abs_error = torch.mean(torch.abs(train_y - test_preds) / 2)
         self.assertLess(mean_abs_error.item(), 1e-1)
+
+    def test_regression_error_skip_logdet_forward(self):
+        return self.test_regression_error(skip_logdet_forward=True)
 
     def test_regression_error_cuda(self):
         if torch.cuda.is_available():

--- a/test/lazy/test_cached_cg_lazy_tensor.py
+++ b/test/lazy/test_cached_cg_lazy_tensor.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+import torch
+import gpytorch
+import unittest
+import warnings
+from gpytorch.lazy import CachedCGLazyTensor, NonLazyTensor
+from test.lazy._lazy_tensor_test_case import LazyTensorTestCase
+
+
+class TestCachedCGLazyTensor(LazyTensorTestCase, unittest.TestCase):
+    seed = 0
+
+    def create_lazy_tensor(self):
+        mat = torch.randn(5, 6)
+        mat = mat.matmul(mat.transpose(-1, -2))
+        mat.requires_grad_(True)
+
+        eager_rhss = [torch.randn(5, 10), torch.randn(5, 1)]
+        return CachedCGLazyTensor(NonLazyTensor(mat), eager_rhss)
+
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        return lazy_tensor.base_lazy_tensor.tensor
+
+    def test_inv_matmul_vec(self):
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+
+        test_vector = lazy_tensor.eager_rhss[1].squeeze(-1).clone().detach().requires_grad_(True)
+        test_vector_copy = lazy_tensor_copy.eager_rhss[1].squeeze(-1).clone().detach().requires_grad_(True)
+        # Make sure that we get no warning about CG
+        with gpytorch.settings.max_cg_iterations(200), warnings.catch_warnings(record=True) as w:
+            res = lazy_tensor.inv_matmul(test_vector)
+            actual = evaluated.inverse().matmul(test_vector_copy)
+            self.assertEqual(len(w), 0)
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 3e-1)
+
+        grad = torch.randn_like(res)
+        # Make sure that we get a warning that CG was run
+        with warnings.catch_warnings(record=True) as w:
+            res.backward(gradient=grad)
+            actual.backward(gradient=grad)
+            self.assertEqual(len(w), 1)
+        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+            if arg_copy.grad is not None:
+                self.assertLess(
+                    ((arg.grad - arg_copy.grad).abs() / arg_copy.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
+                )
+        self.assertLess(
+            ((test_vector.grad - test_vector_copy.grad).abs() / test_vector.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
+        )
+
+    def test_inv_matmul_vector_with_left(self):
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+
+        test_vector = lazy_tensor.eager_rhss[0][..., -1].squeeze(-1).clone().detach().requires_grad_(True)
+        test_vector_copy = lazy_tensor_copy.eager_rhss[0][..., -1].squeeze(-1).clone().detach().requires_grad_(True)
+        test_left = lazy_tensor.eager_rhss[0][..., :-1].t().clone().detach().requires_grad_(True)
+        test_left_copy = lazy_tensor_copy.eager_rhss[0][..., :-1].t().clone().detach().requires_grad_(True)
+        # Make sure that we get no warning about CG
+        with gpytorch.settings.max_cg_iterations(200), warnings.catch_warnings(record=True) as w:
+            res = lazy_tensor.inv_matmul(test_vector, test_left)
+            actual = test_left_copy @ evaluated.inverse() @ test_vector_copy
+            self.assertEqual(len(w), 0)
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 3e-1)
+
+        grad = torch.randn_like(res)
+        # Make sure that we get no warning about CG
+        with warnings.catch_warnings(record=True) as w:
+            res.backward(gradient=grad)
+            actual.backward(gradient=grad)
+            self.assertEqual(len(w), 0)
+        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+            if arg_copy.grad is not None:
+                self.assertLess(
+                    ((arg.grad - arg_copy.grad).abs() / arg_copy.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
+                )
+        self.assertLess(
+            ((test_left.grad - test_left_copy.grad).abs() / test_left.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
+        )
+        self.assertLess(
+            ((test_vector.grad - test_vector_copy.grad).abs() / test_vector.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
+        )
+
+    def test_inv_matmul_matrix(self):
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+
+        test_vector = lazy_tensor.eager_rhss[0].clone().detach().requires_grad_(True)
+        test_vector_copy = lazy_tensor_copy.eager_rhss[0].clone().detach().requires_grad_(True)
+        # Make sure that we get no warning about CG
+        with gpytorch.settings.max_cg_iterations(100), warnings.catch_warnings(record=True) as w:
+            res = lazy_tensor.inv_matmul(test_vector)
+            actual = evaluated.inverse().matmul(test_vector_copy)
+            self.assertEqual(len(w), 0)
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 3e-1)
+
+        grad = torch.randn_like(res)
+        # Make sure that we get a warning that CG was run
+        with warnings.catch_warnings(record=True) as w:
+            res.backward(gradient=grad)
+            actual.backward(gradient=grad)
+            self.assertEqual(len(w), 1)
+        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+            if arg_copy.grad is not None:
+                self.assertLess(
+                    ((arg.grad - arg_copy.grad).abs() / arg_copy.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
+                )
+        self.assertLess(
+            ((test_vector.grad - test_vector_copy.grad).abs() / test_vector.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
+        )
+
+    def test_inv_matmul_matrix_with_left(self):
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+
+        test_vector = lazy_tensor.eager_rhss[0][..., 2:].clone().detach().requires_grad_(True)
+        test_vector_copy = lazy_tensor_copy.eager_rhss[0][..., 2:].clone().detach().requires_grad_(True)
+        test_left = lazy_tensor.eager_rhss[0][..., :2].transpose(-1, -2).clone().detach().requires_grad_(True)
+        test_left_copy = lazy_tensor_copy.eager_rhss[0][..., :2].transpose(-1, -2).clone().detach().requires_grad_(True)
+        # Make sure that we get no warning about CG
+        with gpytorch.settings.max_cg_iterations(100), warnings.catch_warnings(record=True) as w:
+            res = lazy_tensor.inv_matmul(test_vector, test_left)
+            actual = test_left_copy @ evaluated.inverse() @ test_vector_copy
+            self.assertEqual(len(w), 0)
+        self.assertLess(((res - actual).abs() / actual.abs().clamp(1, 1e5)).max().item(), 3e-1)
+
+        grad = torch.randn_like(res)
+        # Make sure that we get no warning about CG
+        with warnings.catch_warnings(record=True) as w:
+            res.backward(gradient=grad)
+            actual.backward(gradient=grad)
+            self.assertEqual(len(w), 0)
+        for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+            if arg_copy.grad is not None:
+                self.assertLess(
+                    ((arg.grad - arg_copy.grad).abs() / arg_copy.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
+                )
+        self.assertLess(
+            ((test_left.grad - test_left_copy.grad).abs() / test_left.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
+        )
+        self.assertLess(
+            ((test_vector.grad - test_vector_copy.grad).abs() / test_vector.grad.abs().clamp(1, 1e5)).max().item(), 3e-1
+        )
+
+    def test_root_inv_decomposition(self):
+        lazy_tensor = self.create_lazy_tensor()
+        root_approx = lazy_tensor.root_inv_decomposition()
+
+        test_mat = lazy_tensor.eager_rhss[0].clone().detach()
+
+        res = root_approx.matmul(test_mat)
+        actual = lazy_tensor.inv_matmul(test_mat)
+        self.assertLess(torch.norm(res - actual) / actual.norm(), 0.1)
+
+
+class TestCachedCGLazyTensorBatch(TestCachedCGLazyTensor):
+    seed = 0
+
+    def create_lazy_tensor(self):
+        mat = torch.randn(3, 5, 6)
+        mat = mat.matmul(mat.transpose(-1, -2))
+        mat.requires_grad_(True)
+
+        eager_rhss = [torch.randn(3, 5, 10)]
+        return CachedCGLazyTensor(NonLazyTensor(mat), eager_rhss)
+
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        return lazy_tensor.base_lazy_tensor.tensor
+
+    def test_inv_matmul_vec(self):
+        pass
+
+    def test_inv_matmul_vector_with_left(self):
+        pass


### PR DESCRIPTION
This PR introduces `CachedCGLazyTensor`, which caches the solves that are performed by CG. This improves the speed of variational models. Variational models now call CG 1 time per ELBO computation rather than 3 times.