### PR TITLE
Setting for exact logprob computations

### DIFF
--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -106,6 +106,9 @@ class _MultivariateNormalBase(TMultivariateNormal, Distribution):
             return lazify(super(_MultivariateNormalBase, self).covariance_matrix)
 
     def log_prob(self, value):
+        if settings.fast_computations.log_prob.off():
+            return super().log_prob(value)
+
         if self._validate_args:
             self._validate_sample(value)
 

--- a/test/examples/test_simple_gp_regression.py
+++ b/test/examples/test_simple_gp_regression.py
@@ -299,8 +299,8 @@ class TestSimpleGPRegression(unittest.TestCase):
             self.test_posterior_latent_gp_and_likelihood_with_optimization(cuda=False)
 
     def test_posterior_with_exact_computations_cuda(self):
-        with gpytorch.settings.fast_computations(covar_root_decomposition=False, log_prob=False):
-            if torch.cuda.is_available():
+        if torch.cuda.is_available():
+            with gpytorch.settings.fast_computations(covar_root_decomposition=False, log_prob=False):
                 self.test_posterior_latent_gp_and_likelihood_with_optimization(cuda=True)
 
     def test_posterior_latent_gp_and_likelihood_fast_pred_var(self, cuda=False):

--- a/test/examples/test_simple_gp_regression.py
+++ b/test/examples/test_simple_gp_regression.py
@@ -294,6 +294,15 @@ class TestSimpleGPRegression(unittest.TestCase):
         if torch.cuda.is_available():
             self.test_posterior_latent_gp_and_likelihood_with_optimization(cuda=True)
 
+    def test_posterior_with_exact_computations(self):
+        with gpytorch.settings.fast_computations(covar_root_decomposition=False, log_prob=False):
+            self.test_posterior_latent_gp_and_likelihood_with_optimization(cuda=False)
+
+    def test_posterior_with_exact_computations_cuda(self):
+        with gpytorch.settings.fast_computations(covar_root_decomposition=False, log_prob=False):
+            if torch.cuda.is_available():
+                self.test_posterior_latent_gp_and_likelihood_with_optimization(cuda=True)
+
     def test_posterior_latent_gp_and_likelihood_fast_pred_var(self, cuda=False):
         train_x, test_x, train_y, test_y = self._get_data(cuda=cuda)
         with gpytorch.settings.fast_pred_var(), gpytorch.settings.debug(False):


### PR DESCRIPTION
Extension of #441 

Setting `gpytorch.settings.fast_computations(log_prob=False)` will use the Cholesky decomposition for computing the exact marginal log likelihood of GPs.

(Not recommended for performance, but useful for debugging).