### PR TITLE
Add meta.yaml for conda build

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,42 @@
+{% set data = load_setup_py_data(setup_file="setup.py", from_recipe_dir=True) %}
+
+package:
+  name: {{ data.get("name")|lower }}
+  version: {{ data.get("version") }}
+
+source:
+  path: ./
+
+build:
+  noarch: python
+  script: "$PYTHON setup.py install --single-version-externally-managed --record=record.txt"
+
+requirements:
+  host:
+    - python>=3.6
+
+  run:
+    - pytorch>=1.0
+
+test:
+  imports:
+    - gpytorch
+    - gpytorch.distributions
+    - gpytorch.functions
+    - gpytorch.kernels
+    - gpytorch.lazy
+    - gpytorch.likelihoods
+    - gpytorch.means
+    - gpytorch.mlls
+    - gpytorch.models
+    - gpytorch.priors
+    - gpytorch.utils
+    - gpytorch.variational
+
+about:
+  home: https://gpytorch.ai
+  license: MIT
+  license_file: LICENSE
+  summary: An implementation of Gaussian Processes in Pytorch
+  doc_url: https://gpytorch.readthedocs.io/en/latest/
+  dev_url: https://github.com/cornellius-gp/gpytorch


### PR DESCRIPTION
Addresses #460.

A couple notes on the conda build file:

- It gets package version info from `setup.py`, so most routine releases shouldn't require `meta.yaml` to be modified.
- It does not get dependencies from `setup.py`, so adding dependencies *will* require `meta.yaml` to be modified. This should happen only rarely.
- The testing is minimal; it only makes sure the package imports correctly. This speeds up the build and avoids duplicating the unit tests run on Travis. 
- The build only supports *NIX (to avoid `setup.bat` clutter) but the package is type "noarch" so it will work on all platforms. 

I didn't see any code to automatically deploy to PyPI, so I didn't add anything to automatically deploy to Anaconda Cloud. In any case the manual deployment process is easy--`conda-build` prints instructions on build success.

Once it's deployed to Anaconda Cloud, users can install with the following commands:

```
$ conda config --append channels pytorch
$ conda install -c CHANNEL_NAME pgplvm
```

where `CHANNEL_NAME` is the name of the channel on which gpytorch is hosted.