### PR TITLE
JIT for distance computation, more efficient Matern kernel, JIT scripted linear CG

### DIFF
--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -263,8 +263,10 @@ class Kernel(Module):
         elif jit_func is not None:
             res = jit_func(x1, x2, torch.tensor(diag), torch.tensor(x1_eq_x2))
         elif not square_dist:
-            # TODO: Use torch.pdist here when it isn't buggy.
-            res = torch.norm(x1.unsqueeze(-2) - x2.unsqueeze(-3), p=2, dim=-1)
+            if x1_eq_x2:
+                res = self.__jit_sq_dist(x1, x2, torch.tensor(diag), torch.tensor(x1_eq_x2)).clamp_min_(1e-30).sqrt_()
+            else:
+                res = torch.norm(x1.unsqueeze(-2) - x2.unsqueeze(-3), p=2, dim=-1)
         else:
             res = self.__jit_sq_dist(x1, x2, torch.tensor(diag), torch.tensor(x1_eq_x2))
 

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -99,6 +99,4 @@ class RBFKernel(Kernel):
         x1_ = x1.div(self.lengthscale)
         x2_ = x2.div(self.lengthscale)
         diff = self._covar_dist(x1_, x2_, square_dist=True, diag=diag, postprocess_func=postprocess_rbf, **params)
-        if diag:
-            diff.div_(-2).exp_()
         return diff

--- a/gpytorch/utils/linear_cg.py
+++ b/gpytorch/utils/linear_cg.py
@@ -97,9 +97,9 @@ def linear_cg(
         initial_guess = torch.zeros_like(rhs)
     if preconditioner is None:
         preconditioner = _default_preconditioner
-        no_precond = True
+        precond = False
     else:
-        no_precond = False
+        precond = True
 
     # If we are running m CG iterations, we obviously can't get more than m Lanczos coefficients
     if max_tridiag_iter > max_iter:
@@ -160,7 +160,7 @@ def linear_cg(
         # Get next alpha
         # alpha_{k} = (residual_{k-1}^T precon_residual{k-1}) / (p_vec_{k-1}^T mat p_vec_{k-1})
         mvms = matmul_closure(curr_conjugate_vec)
-        if not no_precond:
+        if precond:
             torch.mul(curr_conjugate_vec, mvms, out=mul_storage)
             torch.sum(mul_storage, -2, keepdim=True, out=alpha)
             alpha.add_(eps)

--- a/gpytorch/utils/linear_cg.py
+++ b/gpytorch/utils/linear_cg.py
@@ -7,6 +7,7 @@ from .. import settings
 def _default_preconditioner(x):
     return x.clone()
 
+
 @torch.jit.script
 def _jit_linear_cg_updates_no_precond(
     mvms, result, alpha, residual_inner_prod, eps, beta, residual, precond_residual, mul_storage, curr_conjugate_vec
@@ -22,7 +23,7 @@ def _jit_linear_cg_updates_no_precond(
 
     # Update precond_residual
     # precon_residual{k} = M^-1 residual_{k}
-    precond_residual = residual.clone() # preconditioner(residual)
+    precond_residual = residual.clone()
 
     # # Update result
     # # result_{k} = result_{k-1} + alpha_{k} p_vec_{k-1}
@@ -208,8 +209,6 @@ def linear_cg(
                 mul_storage,
                 curr_conjugate_vec,
             )
-        # # if (residual_norm < tolerance).all() and not (n_tridiag and k < n_tridiag_iter):
-        # #     break
 
         # Update tridiagonal matrices, if applicable
         if n_tridiag and k < n_tridiag_iter and update_tridiag:

--- a/test/kernels/test_grid_kernel.py
+++ b/test/kernels/test_grid_kernel.py
@@ -28,7 +28,7 @@ class TestGridKernel(unittest.TestCase):
         self.assertIsInstance(grid_covar, KroneckerProductLazyTensor)
         grid_eval = kernel(grid_data, grid_data).evaluate()
         actual_eval = base_kernel(grid_data, grid_data).evaluate()
-        self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
+        self.assertLess(torch.norm(grid_eval - actual_eval), 1.2e-5)
 
     def test_nongrid_grid(self):
         base_kernel = RBFKernel()


### PR DESCRIPTION
TL;DR: Reduces the memory overhead of kernels (and therefore exact GPs) by ~3x when using squared distances, reduces the memory usage of RBFKernel specifically by ~4x.

- `__slow_sq_dist` is now `__jit_sq_dist` and uses the torch JIT script functionality. This is around as fast as `torch.pdist(...).pow_(2)`, but (a) uses much less memory than `torch.pdist` surprisingly, and (b) uses around 3x less memory than `__slow_sq_dist`.

- Kernels can now pass a `jit_func` to `covar_dist`. If they do, this JIT function is called in non-diag mode instead of doing the distance computation at all. This is useful if the Kernel is just the distance plus a few steps, because the few extra steps can just be thrown in the JIT function which saves memory.

## To do
- Use torch.pdist in the `elif not square_dist` branch once `torch.pdist` is less buggy / bad.
- Figure out how to do a numerically stable `__jit_dist` for non squared distances.
- Write custom JIT functions for other kernels (right now implemented for RBF only).

cc/ @KeAWang @gpleiss 