### PR TITLE
Add event_shape property to MTMVN

### DIFF
--- a/gpytorch/distributions/multitask_multivariate_normal.py
+++ b/gpytorch/distributions/multitask_multivariate_normal.py
@@ -36,6 +36,10 @@ class MultitaskMultivariateNormal(MultivariateNormal):
             validate_args=validate_args,
         )
 
+    @property
+    def event_shape(self):
+        return self._output_shape
+
     def get_base_samples(self, sample_shape=torch.Size()):
         """Get i.i.d. standard Normal samples (to be used with rsample(base_samples=base_samples))"""
         res = super(MultitaskMultivariateNormal, self).get_base_samples(sample_shape)

--- a/test/distributions/test_multitask_multivariate_normal.py
+++ b/test/distributions/test_multitask_multivariate_normal.py
@@ -44,6 +44,7 @@ class TestMultiTaskMultivariateNormal(unittest.TestCase):
         self.assertTrue(torch.equal(mtmvn.mean, mean))
         self.assertTrue(approx_equal(mtmvn.variance, variance.view(2, 2)))
         self.assertTrue(torch.equal(mtmvn.scale_tril, covmat.sqrt()))
+        self.assertTrue(mtmvn.event_shape == torch.Size([2, 2]))
         mvn_plus1 = mtmvn + 1
         self.assertTrue(torch.equal(mvn_plus1.mean, mtmvn.mean + 1))
         self.assertTrue(torch.equal(mvn_plus1.covariance_matrix, mtmvn.covariance_matrix))


### PR DESCRIPTION
Prior to this, MTMVNs would return the event shape of the underlying MVN representation, which is not the shape that (r)sample would return.