### PR TITLE
Fix InducingPointKernel memory usage and speed

### DIFF
--- a/gpytorch/kernels/inducing_point_kernel.py
+++ b/gpytorch/kernels/inducing_point_kernel.py
@@ -4,7 +4,7 @@ import math
 import torch
 from .kernel import Kernel
 from ..functions import add_jitter
-from ..lazy import delazify, DiagLazyTensor, MatmulLazyTensor, RootLazyTensor
+from ..lazy import delazify, DiagLazyTensor, MatmulLazyTensor, RootLazyTensor, PsdSumLazyTensor
 from ..distributions import MultivariateNormal
 from ..mlls import InducingPointKernelAddedLossTerm
 
@@ -42,14 +42,11 @@ class InducingPointKernel(Kernel):
         if not self.training and hasattr(self, "_cached_kernel_inv_root"):
             return self._cached_kernel_inv_root
         else:
-            inv_roots_list = []
             chols = torch.cholesky(add_jitter(self._inducing_mat), upper=True)
-            for i in range(self._inducing_mat.size(0)):
-                chol = chols[i]
-                eye = torch.eye(chol.size(-1), device=chol.device)
-                inv_roots_list.append(torch.trtrs(eye, chol)[0])
+            eye = torch.eye(chols[0].size(-1), device=chols[0].device)
+            inv_root_list = [torch.trtrs(eye, chol)[0].unsqueeze(0) for chol in chols]
 
-            res = torch.cat(inv_roots_list, 0)
+            res = torch.cat(inv_root_list, 0)
             if not self.training:
                 self._cached_kernel_inv_root = res
             return res
@@ -61,7 +58,7 @@ class InducingPointKernel(Kernel):
 
             # Diagonal correction for predictive posterior
             correction = (self.base_kernel(x1, x2, diag=True) - covar.diag()).clamp(0, math.inf)
-            covar = covar + DiagLazyTensor(correction)
+            covar = PsdSumLazyTensor(covar, DiagLazyTensor(correction))
         else:
             k_ux2 = delazify(self.base_kernel(x2, self.inducing_points))
             covar = MatmulLazyTensor(

--- a/test/examples/test_sgpr_regression.py
+++ b/test/examples/test_sgpr_regression.py
@@ -21,7 +21,7 @@ from gpytorch.distributions import MultivariateNormal
 def make_data(cuda=False):
     train_x = torch.linspace(0, 1, 100)
     train_y = torch.sin(train_x * (2 * pi))
-    test_x = torch.linspace(0, 1, 51)
+    test_x = torch.rand(51)
     test_y = torch.sin(test_x * (2 * pi))
     if cuda:
         train_x = train_x.cuda()
@@ -70,7 +70,7 @@ class TestSGPRRegression(unittest.TestCase):
         likelihood.train()
 
         optimizer = optim.Adam(gp_model.parameters(), lr=0.1)
-        for _ in range(50):
+        for _ in range(30):
             optimizer.zero_grad()
             output = gp_model(train_x)
             loss = -mll(output, train_y)


### PR DESCRIPTION
Right now, InducingPointKernel unintentionally gets the diagonal correction by calling the kernel on the full data and then calling `diag` rather than calling the kernel with `diag=True`:
https://github.com/cornellius-gp/gpytorch/blob/4e30c948055e20c35b11e7435e8eba673a7f3401/gpytorch/kernels/inducing_point_kernel.py#L63
 This has clearly unintended ramifications for memory usage and speed. While I was at it, I also changed `_inducing_inv_root` to take advantage of the fact that `torch.cholesky` now operates in batch mode.