### PR TITLE
Faster multidevicekernel

### DIFF
--- a/gpytorch/kernels/multi_device_kernel.py
+++ b/gpytorch/kernels/multi_device_kernel.py
@@ -17,7 +17,14 @@ class MultiDeviceKernel(DataParallel, Kernel):
         - :attr:`output_device`: Device where outputs will be placed
     """
 
-    def __init__(self, base_kernel, device_ids, output_device=None, **kwargs):
+    def __init__(self, base_kernel, device_ids, output_device=None,
+                 create_cuda_context=True, **kwargs):
+        # Need to warm up each GPU otherwise scattering in forward will be
+        # EXTREMELY slow. This memory will be available as soon as we leave __init__
+        if create_cuda_context:
+            for d in device_ids:
+                _ = torch.tensor([], device=d)
+
         DataParallel.__init__(self,
                               module=base_kernel,
                               device_ids=device_ids,

--- a/gpytorch/lazy/cat_lazy_tensor.py
+++ b/gpytorch/lazy/cat_lazy_tensor.py
@@ -347,7 +347,9 @@ class CatLazyTensor(LazyTensor):
 
     def to(self, device_id):
         """
-        Change the output_device of CatLazyTensor.
+        returns a new CatLazyTensor with device_id as the output_device
+        Warning: this does not move the LazyTensors in this CatLazyTensor to
+        device_id
         """
         new_kwargs = dict(self._kwargs)
         new_kwargs['output_device'] = device_id
@@ -355,8 +357,9 @@ class CatLazyTensor(LazyTensor):
 
     def all_to(self, device_id):
         """
-        Move all LazyTensors in CatLazyTensor to one device even if they are on
-        the different devices. Also change the output_device to device_id
+        Create a new CatLazyTensor with all LazyTensors in CatLazyTensor moved
+        to one device device. The new CatLazyTensor also has device_id as the
+        output_device.
         """
         new_args = []
         new_kwargs = {}

--- a/gpytorch/lazy/cat_lazy_tensor.py
+++ b/gpytorch/lazy/cat_lazy_tensor.py
@@ -344,3 +344,31 @@ class CatLazyTensor(LazyTensor):
     @property
     def device_count(self):
         return len(set(self.devices))
+
+    def to(self, device_id):
+        """
+        Change the output_device of CatLazyTensor.
+        """
+        new_kwargs = dict(self._kwargs)
+        new_kwargs['output_device'] = device_id
+        return self.__class__(*self._args, **new_kwargs)
+
+    def all_to(self, device_id):
+        """
+        Move all LazyTensors in CatLazyTensor to one device even if they are on
+        the different devices. Also change the output_device to device_id
+        """
+        new_args = []
+        new_kwargs = {}
+        for arg in self._args:
+            if hasattr(arg, "to"):
+                new_args.append(arg.to(device_id))
+            else:
+                new_args.append(arg)
+        for name, val in self._kwargs.items():
+            if hasattr(val, "to"):
+                new_kwargs[name] = val.to(device_id)
+            else:
+                new_kwargs[name] = val
+        new_kwargs['output_device'] = device_id
+        return self.__class__(*new_args, **new_kwargs)


### PR DESCRIPTION
Warm up MultiDeviceKernel to reduce first scatter time by 1000x.
 
Before we were taking 22 seconds to scatter a tensor of size `[1, 4882, 20]` in the first forward method. This offloads that 22 seconds to the initialization of MultiDeviceKernel by creating the CUDA context during initialization (can be turned off with a kwarg). 

With this change, the first time we call scatter in a forward pass takes only 0.02 seconds. This makes
GP training on 8 GPUs only twice as slow as GP training on 1 GPU if we don't measure the initialization time of MultiDeviceKernel