### PR TITLE
Make zero_mean_mvn samples work with arbirary sample_shapes (onto batch_lazy_tensor PR)

### DIFF
--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -131,12 +131,7 @@ class _MultivariateNormalBase(TMultivariateNormal, Distribution):
     def rsample(self, sample_shape=torch.Size(), base_samples=None):
         covar = self.lazy_covariance_matrix
         if base_samples is None:
-            # Create some samples
-            num_samples = sample_shape.numel() or 1
-
-            # Get samples
-            res = covar.zero_mean_mvn_samples(num_samples) + self.loc.unsqueeze(0)
-            res = res.view(*tuple(sample_shape), *tuple(self.loc.size()))
+            return self.loc + covar.zero_mean_mvn_samples(sample_shape)
 
         else:
             # Make sure that the base samples agree with the distribution
@@ -147,7 +142,7 @@ class _MultivariateNormalBase(TMultivariateNormal, Distribution):
                 )
 
             # Determine what the appropriate sample_shape parameter is
-            sample_shape = torch.Size(tuple(base_samples.size(i) for i in range(base_samples.dim() - self.loc.dim())))
+            sample_shape = base_samples.shape[:-self.loc.dim()]
 
             # Reshape samples to be batch_size x num_dim x num_samples
             # or num_bim x num_samples

--- a/gpytorch/lazy/block_diag_lazy_tensor.py
+++ b/gpytorch/lazy/block_diag_lazy_tensor.py
@@ -83,3 +83,11 @@ class BlockDiagLazyTensor(BlockLazyTensor):
             chol = torch.cholesky(self.base_lazy_tensor.evaluate())
             res = self.__class__(NonLazyTensor(chol), block_dim=self.block_dim)
         return RootLazyTensor(res)
+
+    def zero_mean_mvn_samples(self, sample_shape=torch.Size()):
+        res = self.base_lazy_tensor.zero_mean_mvn_samples(sample_shape=sample_shape)
+
+        # Move the block dimension to the appropriate place
+        res = res.unsqueeze(-2).transpose(-2, self.block_dim).squeeze(self.block_dim).contiguous()
+        res = res.view(*sample_shape, *self.batch_shape, self.size(-2))
+        return res

--- a/gpytorch/lazy/block_lazy_tensor.py
+++ b/gpytorch/lazy/block_lazy_tensor.py
@@ -100,8 +100,3 @@ class BlockLazyTensor(LazyTensor):
 
     def _transpose_nonbatch(self):
         return self.__class__(self.base_lazy_tensor._transpose_nonbatch(), block_dim=self.block_dim)
-
-    def zero_mean_mvn_samples(self, num_samples):
-        res = self.base_lazy_tensor.zero_mean_mvn_samples(num_samples)
-        res = self._remove_batch_dim(res.unsqueeze(-1)).squeeze(-1)
-        return res

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -136,6 +136,6 @@ class DiagLazyTensor(LazyTensor):
     def sqrt(self):
         return DiagLazyTensor(self._diag.sqrt())
 
-    def zero_mean_mvn_samples(self, num_samples):
-        base_samples = torch.randn(num_samples, *self._diag.shape, dtype=self.dtype, device=self.device)
+    def zero_mean_mvn_samples(self, sample_shape=torch.Size()):
+        base_samples = torch.randn(sample_shape + self._diag.shape, dtype=self.dtype, device=self.device)
         return base_samples * self._diag.sqrt()

--- a/gpytorch/lazy/interpolated_lazy_tensor.py
+++ b/gpytorch/lazy/interpolated_lazy_tensor.py
@@ -411,10 +411,7 @@ class InterpolatedLazyTensor(LazyTensor):
             res = res.squeeze(-1)
         return res
 
-    def zero_mean_mvn_samples(self, num_samples):
-        base_samples = self.base_lazy_tensor.zero_mean_mvn_samples(num_samples)
-        batch_iter = tuple(range(1, base_samples.dim()))
-        base_samples = base_samples.permute(*batch_iter, 0)
-        res = left_interp(self.left_interp_indices, self.left_interp_values, base_samples).contiguous()
-        batch_iter = tuple(range(res.dim() - 1))
-        return res.permute(-1, *batch_iter).contiguous()
+    def zero_mean_mvn_samples(self, sample_shape=torch.Size()):
+        base_samples = self.base_lazy_tensor.zero_mean_mvn_samples(sample_shape=sample_shape).unsqueeze(-1)
+        res = left_interp(self.left_interp_indices, self.left_interp_values, base_samples).squeeze(-1)
+        return res

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1304,7 +1304,9 @@ class LazyTensor(object):
         else:
             covar_root = self.root_decomposition().root
 
-        base_shape = sample_shape + self.shape[:-2] + self.shape[-1:]
+        # the last dimension here is covar_root.shape[-1] and not self.shape[-1], since the root may
+        # be a low-rank approximation
+        base_shape = sample_shape + self.shape[:-2] + covar_root.shape[-1:]
         base_samples = torch.randn(base_shape, device=self.device, dtype=self.dtype)
         samples = covar_root.matmul(base_samples.unsqueeze(-1)).squeeze(-1).contiguous()
         return samples

--- a/gpytorch/lazy/psd_sum_lazy_tensor.py
+++ b/gpytorch/lazy/psd_sum_lazy_tensor.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import torch
 from .sum_lazy_tensor import SumLazyTensor
 
 
@@ -8,5 +9,5 @@ class PsdSumLazyTensor(SumLazyTensor):
     A SumLazyTensor, but where every component of the sum is positive semi-definite
     """
 
-    def zero_mean_mvn_samples(self, num_samples):
-        return sum(lazy_tensor.zero_mean_mvn_samples(num_samples) for lazy_tensor in self.lazy_tensors)
+    def zero_mean_mvn_samples(self, sample_shape=torch.Size()):
+        return sum(lazy_tensor.zero_mean_mvn_samples(sample_shape=sample_shape) for lazy_tensor in self.lazy_tensors)

--- a/gpytorch/lazy/sum_batch_lazy_tensor.py
+++ b/gpytorch/lazy/sum_batch_lazy_tensor.py
@@ -86,3 +86,7 @@ class SumBatchLazyTensor(BlockLazyTensor):
     def diag(self):
         diag = self.base_lazy_tensor.diag().sum(self._positive_block_dim)
         return diag
+
+    def zero_mean_mvn_samples(self, sample_shape=torch.Size()):
+        res = self.base_lazy_tensor.zero_mean_mvn_samples(sample_shape=sample_shape)
+        return res.sum(self.block_dim + 1)  # self.block_dim is a negative index - and we lost one of those

--- a/test/lazy/_lazy_tensor_test_case.py
+++ b/test/lazy/_lazy_tensor_test_case.py
@@ -599,6 +599,6 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
             lazy_tensor = self.create_lazy_tensor()
             evaluated = self.evaluate_lazy_tensor(lazy_tensor)
 
-            samples = lazy_tensor.zero_mean_mvn_samples(50000)
+            samples = lazy_tensor.zero_mean_mvn_samples(torch.Size([50000]))
             sample_covar = samples.unsqueeze(-1).matmul(samples.unsqueeze(-2)).mean(0)
             self.assertLess(((sample_covar - evaluated).abs() / evaluated.abs().clamp(1, math.inf)).max().item(), 3e-1)


### PR DESCRIPTION
(Same thing as #480, but onto the batch lazy tensor PR WIP)

Makes this consistent with the torch interface, declutters some of the special casing by using shape arithmetic. This will be useful whenutilizing QMC base samples, in which case we can't just reshape
everyting into a big tensor but have to comply with batch / sample shape (because samples are not iid anymore).

It also enables sampling from multi-dimensional batch shapes in LazyTensors (once those are fully supported)