### PR TITLE
Kernel checkpointing

### DIFF
--- a/gpytorch/beta_features.py
+++ b/gpytorch/beta_features.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import warnings
-from .settings import _feature_flag
+from .settings import _feature_flag, _value_context
 from .settings import fast_pred_var as _fast_pred_var
 from .settings import fast_pred_samples as _fast_pred_samples
 
@@ -24,6 +24,25 @@ class _moved_beta_feature(object):
 
 fast_pred_var = _moved_beta_feature(_fast_pred_var)
 fast_pred_samples = _moved_beta_feature(_fast_pred_samples)
+
+
+class checkpoint_kernel(_value_context):
+    """
+    Should the kernel be computed in chunks with checkpointing or not? (Default, no)
+
+    If `split_size = 0`:
+        The kernel is computed explicitly. During training, the kernel matrix is
+        kept in memory for the backward pass. This is the fastest option but the
+        most memory intensive.
+    If `split_size > 0`:
+        The kernel is never fully computed or stored. Instead, the kernel is only
+        accessed through matrix multiplication. The matrix multiplication is
+        computed in `segments` chunks. This is slower, but requires significantly less memory.
+
+    Default: 0
+    """
+
+    _global_value = 0
 
 
 class diagonal_correction(_feature_flag):

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -379,7 +379,7 @@ class Kernel(Module):
 
         else:
             if settings.lazily_evaluate_kernels.on():
-                res = LazyEvaluatedKernelTensor(self, x1_, x2_, batch_dims=batch_dims, **params)
+                res = LazyEvaluatedKernelTensor(x1_, x2_, kernel=self, batch_dims=batch_dims, **params)
             else:
                 res = super(Kernel, self).__call__(x1_, x2_, batch_dims=batch_dims, **params)
 

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -2,21 +2,23 @@
 
 import torch
 
-from .. import settings
+from .. import settings, beta_features
 from ..utils.memoize import cached
 from .lazy_tensor import LazyTensor
-from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
 from .non_lazy_tensor import lazify
 
 
-LAZY_KERNEL_TENSOR_WARNING = (
-    "A LazyEvaluatedKernelTensor is not intended to be used directly as a tensor! Call evaluate() first."
-)
-
-
 class LazyEvaluatedKernelTensor(LazyTensor):
-    def __init__(self, kernel, x1, x2, batch_dims=None, squeeze_row=False, squeeze_col=False, **params):
-        super(LazyEvaluatedKernelTensor, self).__init__(kernel, x1, x2, **params)
+    def _check_args(self, x1, x2, kernel, batch_dims=None, squeeze_row=False, squeeze_col=False, **params):
+        if not torch.is_tensor(x1):
+            return "x1 must be a tensor. Got {}".format(x1.__class__.__name__)
+        if not torch.is_tensor(x2):
+            return "x1 must be a tensor. Got {}".format(x1.__class__.__name__)
+
+    def __init__(self, x1, x2, kernel, batch_dims=None, squeeze_row=False, squeeze_col=False, **params):
+        super(LazyEvaluatedKernelTensor, self).__init__(
+            x1, x2, kernel=kernel, batch_dims=batch_dims, squeeze_row=squeeze_row, squeeze_col=squeeze_col, **params
+        )
         self.kernel = kernel
         self.x1 = x1
         self.x2 = x2
@@ -35,7 +37,7 @@ class LazyEvaluatedKernelTensor(LazyTensor):
         return self.x1.device
 
     def _get_indices(self, left_indices, right_indices, *batch_indices):
-        from ..kernels import Kernel
+        from ..kernels.kernel import Kernel
 
         x1 = self.x1[(*batch_indices, left_indices)].unsqueeze(0)
         x2 = self.x2[(*batch_indices, right_indices)].unsqueeze(0)
@@ -70,8 +72,8 @@ class LazyEvaluatedKernelTensor(LazyTensor):
                 x2 = x2.unsqueeze(1)
                 squeeze_col = True
 
-            return LazyEvaluatedKernelTensor(
-                self.kernel, x1, x2, squeeze_row=squeeze_row, squeeze_col=squeeze_col, **self.params
+            return self.__class__(
+                x1, x2, kernel=self.kernel, squeeze_row=squeeze_row, squeeze_col=squeeze_col, **self.params
             )
         else:
             left_index = indices[0]
@@ -88,15 +90,80 @@ class LazyEvaluatedKernelTensor(LazyTensor):
                 x2 = x2.unsqueeze(1)
                 squeeze_col = True
 
-            return LazyEvaluatedKernelTensor(
-                self.kernel, x1, x2, squeeze_row=squeeze_row, squeeze_col=squeeze_col, **self.params
+            return self.__class__(
+                x1, x2, kernel=self.kernel, squeeze_row=squeeze_row, squeeze_col=squeeze_col, **self.params
             )
 
     def _matmul(self, rhs):
-        raise RuntimeError(LAZY_KERNEL_TENSOR_WARNING)
+        # This _matmul is defined computes the kernel in chunks
+        # It is only used when we are using kernel checkpointing
+        # It won't be called if checkpointing is off
+        if not self.is_batch:
+            x1 = self.x1.unsqueeze(0)
+            x2 = self.x2.unsqueeze(0)
+            rhs = rhs.unsqueeze(0)
+        else:
+            x1 = self.x1
+            x2 = self.x2
+
+        split_size = beta_features.checkpoint_kernel.value()
+        if not split_size:
+            raise RuntimeError(
+                "Should not have ended up in LazyEvaluatedKernelTensor._matmul without kernel checkpointing. "
+                "This is probably a bug in GPyTorch."
+            )
+
+        with torch.no_grad(), settings.lazily_evaluate_kernels(False):
+            sub_x1s = torch.split(x1, split_size, dim=-2)
+            res = []
+            for sub_x1 in sub_x1s:
+                sub_kernel_matrix = lazify(
+                    self.kernel(sub_x1, x2, diag=False, batch_dims=self.batch_dims, **self.params)
+                )
+                res.append(sub_kernel_matrix._matmul(rhs))
+
+            res = torch.cat(res, dim=-2)
+            if not self.is_batch:
+                res = res.squeeze(0)
+            return res
 
     def _quad_form_derivative(self, left_vecs, right_vecs):
-        raise RuntimeError(LAZY_KERNEL_TENSOR_WARNING)
+        # This _quad_form_derivative computes the kernel in chunks
+        # It is only used when we are using kernel checkpointing
+        # It won't be called if checkpointing is off
+        split_size = beta_features.checkpoint_kernel.value()
+        if not split_size:
+            raise RuntimeError(
+                "Should not have ended up in LazyEvaluatedKernelTensor._quad_form_derivative without kernel "
+                "checkpointing. This is probably a bug in GPyTorch."
+            )
+
+        if not self.is_batch:
+            x1 = self.x1.unsqueeze(0)
+            x2 = self.x2.unsqueeze(0)
+            left_vecs = left_vecs.unsqueeze(0)
+            right_vecs = right_vecs.unsqueeze(0)
+        else:
+            x1 = self.x1
+            x2 = self.x2
+
+        x1 = x1.detach()
+        x2 = x2.detach()
+
+        # Break objects into chunks
+        sub_x1s = torch.split(x1, split_size, dim=-2)
+        sub_left_vecss = torch.split(left_vecs, split_size, dim=-2)
+        # Compute the gradient in chunks
+        for sub_x1, sub_left_vecs in zip(sub_x1s, sub_left_vecss):
+            with torch.enable_grad(), settings.lazily_evaluate_kernels(False):
+                sub_kernel_matrix = lazify(
+                    self.kernel(sub_x1, x2, diag=False, batch_dims=self.batch_dims, **self.params)
+                )
+            sub_grad_outputs = tuple(sub_kernel_matrix._quad_form_derivative(sub_left_vecs, right_vecs))
+            sub_kernel_outputs = tuple(sub_kernel_matrix.representation())
+            torch.autograd.backward(sub_kernel_outputs, sub_grad_outputs)
+
+        return x1.grad, x2.grad
 
     def _size(self):
         size = self.kernel.size(self.x1, self.x2)
@@ -108,11 +175,15 @@ class LazyEvaluatedKernelTensor(LazyTensor):
         return size
 
     def _transpose_nonbatch(self):
-        return self.__class__(self.kernel, self.x2, self.x1, **self.params)
+        return self.__class__(
+            self.x2, self.x1, kernel=self.kernel, batch_dims=self.batch_dims,
+            squeeze_row=self.squeeze_col, squeeze_col=self.squeeze_row, **self.params
+        )
 
-    def _t_matmul(self, rhs):
-        raise RuntimeError(LAZY_KERNEL_TENSOR_WARNING)
+    def add_jitter(self, jitter_val=1e-3):
+        return self.evaluate_kernel().add_jitter(jitter_val)
 
+    @cached(name="kernel_diag")
     def diag(self):
         """
         Getting the diagonal of a kernel can be handled more efficiently by
@@ -122,100 +193,96 @@ class LazyEvaluatedKernelTensor(LazyTensor):
         """
         from ..kernels import Kernel
 
-        if hasattr(self, "_cached_kernel_diag"):
-            return self._cached_kernel_diag
-        elif hasattr(self, "_cached_kernel_eval"):
-            return self._cached_kernel_eval.diag()
+        if not self.is_batch:
+            x1 = self.x1.unsqueeze(0)
+            x2 = self.x2.unsqueeze(0)
         else:
-            if not self.is_batch:
-                x1 = self.x1.unsqueeze(0)
-                x2 = self.x2.unsqueeze(0)
-            else:
-                x1 = self.x1
-                x2 = self.x2
+            x1 = self.x1
+            x2 = self.x2
 
-            # If x1 or x2 only has one data point, make sure to unsqueeze the data-size dimension
-            if x1.dim() == 2:  # We only have a single data point
-                x1 = x1.unsqueeze(1)
-            if x2.dim() == 2:  # We only have a single data point
-                x2 = x2.unsqueeze(1)
+        # If x1 or x2 only has one data point, make sure to unsqueeze the data-size dimension
+        if x1.dim() == 2:  # We only have a single data point
+            x1 = x1.unsqueeze(1)
+        if x2.dim() == 2:  # We only have a single data point
+            x2 = x2.unsqueeze(1)
 
-            res = super(Kernel, self.kernel).__call__(x1, x2, diag=True, batch_dims=self.batch_dims, **self.params)
+        res = super(Kernel, self.kernel).__call__(x1, x2, diag=True, batch_dims=self.batch_dims, **self.params)
 
-            # Did this Kernel eat the diag option?
-            # If it does not return a LazyEvaluatedKernelTensor, we can call diag on the output
-            if not isinstance(res, LazyEvaluatedKernelTensor):
-                if res.dim() == x1.dim() and res.shape[-2:] == torch.Size((x1.size(-2), x2.size(-2))):
-                    res = res.diag()
+        # Did this Kernel eat the diag option?
+        # If it does not return a LazyEvaluatedKernelTensor, we can call diag on the output
+        if not isinstance(res, LazyEvaluatedKernelTensor):
+            if res.dim() == x1.dim() and res.shape[-2:] == torch.Size((x1.size(-2), x2.size(-2))):
+                res = res.diag()
 
-            # Now we'll make sure that the shape we're getting from diag makes sense
-            if settings.debug.on():
-                # If we used batch_dims...
-                shape = self.kernel.size(x1, x2)
-                if self.batch_dims == (0, 2):
-                    if len(shape) == 2:
-                        expected_shape = torch.Size((x1.size(-1), shape[0]))
-                    else:
-                        expected_shape = torch.Size((shape[0] * x1.size(-1), shape[1]))
-                    if res.shape != expected_shape:
-                        raise RuntimeError(
-                            "The kernel {} is not equipped to handle batch_dims=(0, 2) "
-                            "and diag. Expected size {}. Got size {}.".format(
-                                self.__class__.__name__, expected_shape, res.shape
-                            )
-                        )
-
-                # If we didn't use batch_dims...
+        # Now we'll make sure that the shape we're getting from diag makes sense
+        if settings.debug.on():
+            # If we used batch_dims...
+            shape = self.kernel.size(x1, x2)
+            if self.batch_dims == (0, 2):
+                if len(shape) == 2:
+                    expected_shape = torch.Size((x1.size(-1), shape[0]))
                 else:
-                    expected_shape = shape[:-1]
-                    if res.shape != expected_shape:
-                        raise RuntimeError(
-                            "The kernel {} is not equipped to handle and diag. Expected size {}. "
-                            "Got size {}".format(self.__class__.__name__, expected_shape, res.shape)
+                    expected_shape = torch.Size((shape[0] * x1.size(-1), shape[1]))
+                if res.shape != expected_shape:
+                    raise RuntimeError(
+                        "The kernel {} is not equipped to handle batch_dims=(0, 2) "
+                        "and diag. Expected size {}. Got size {}.".format(
+                            self.__class__.__name__, expected_shape, res.shape
                         )
+                    )
 
-            if isinstance(res, LazyTensor):
-                res = res.evaluate()
-            self._cached_kernel_diag = res.view(self.shape[:-1]).contiguous()
-            return self._cached_kernel_diag
+            # If we didn't use batch_dims...
+            else:
+                expected_shape = shape[:-1]
+                if res.shape != expected_shape:
+                    raise RuntimeError(
+                        "The kernel {} is not equipped to handle and diag. Expected size {}. "
+                        "Got size {}".format(self.__class__.__name__, expected_shape, res.shape)
+                    )
 
+        if isinstance(res, LazyTensor):
+            res = res.evaluate()
+        return res.view(self.shape[:-1]).contiguous()
+
+    @cached(name="kernel_eval")
     def evaluate_kernel(self):
         """
         NB: This is a meta LazyTensor, in the sense that evaluate can return
         a LazyTensor if the kernel being evaluated does so.
         """
-        if hasattr(self, "_cached_kernel_eval"):
-            return self._cached_kernel_eval
+        if not self.is_batch:
+            x1 = self.x1.unsqueeze(0)
+            x2 = self.x2.unsqueeze(0)
         else:
-            if not self.is_batch:
-                x1 = self.x1.unsqueeze(0)
-                x2 = self.x2.unsqueeze(0)
-            else:
-                x1 = self.x1
-                x2 = self.x2
+            x1 = self.x1
+            x2 = self.x2
 
-            with settings.lazily_evaluate_kernels(False):
-                self._cached_kernel_eval = self.kernel(
-                    x1, x2, diag=False, batch_dims=self.batch_dims, **self.params
-                )
-            if self.squeeze_row:
-                self._cached_kernel_eval.squeeze_(-2)
-            if self.squeeze_col:
-                self._cached_kernel_eval.squeeze_(-1)
+        with settings.lazily_evaluate_kernels(False):
+            res = self.kernel(
+                x1, x2, diag=False, batch_dims=self.batch_dims, **self.params
+            )
+        if self.squeeze_row:
+            res.squeeze_(-2)
+        if self.squeeze_col:
+            res.squeeze_(-1)
 
-            if (
-                not self.is_batch
-                and self._cached_kernel_eval.ndimension() == 3
-                and self._cached_kernel_eval.size(0) == 1
-            ):
-                self._cached_kernel_eval = self._cached_kernel_eval[0]
+        if (
+            not self.is_batch
+            and res.ndimension() == 3
+            and res.size(0) == 1
+        ):
+            res = res[0]
 
-            self._cached_kernel_eval = lazify(self._cached_kernel_eval)
-            return self._cached_kernel_eval
+        return lazify(res)
 
     @cached
     def evaluate(self):
         return self.evaluate_kernel().evaluate()
+
+    def mul(self, other):
+        if isinstance(other, LazyEvaluatedKernelTensor):
+            other = other.evaluate_kernel()
+        return self.evaluate_kernel().mul(other)
 
     def repeat(self, *sizes):
         if self.squeeze_row or self.squeeze_col:
@@ -229,10 +296,22 @@ class LazyEvaluatedKernelTensor(LazyTensor):
         else:
             raise RuntimeError("Invalid number of sizes (expected 2 or 3)")
 
-        return LazyEvaluatedKernelTensor(self.kernel, x1, x2, **self.params)
+        return self.__class__(x1, x2, kernel=self.kernel, batch_dims=self.batch_dims, **self.params)
 
     def representation(self):
-        return self.evaluate_kernel().representation()
+        # If we're checkpointing the kernel, we'll use chunked _matmuls defined in LazyEvaluatedKernelTensor
+        if beta_features.checkpoint_kernel.value():
+            return super().representation()
+        # Otherwise, we'll evaluate the kernel (or at least its LazyTensor representation) and use its
+        # representation
+        else:
+            return self.evaluate_kernel().representation()
 
     def representation_tree(self):
-        return LazyTensorRepresentationTree(self.evaluate_kernel())
+        # If we're checkpointing the kernel, we'll use chunked _matmuls defined in LazyEvaluatedKernelTensor
+        if beta_features.checkpoint_kernel.value():
+            return super().representation_tree()
+        # Otherwise, we'll evaluate the kernel (or at least its LazyTensor representation) and use its
+        # representation
+        else:
+            return self.evaluate_kernel().representation_tree()

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -978,7 +978,7 @@ class LazyTensor(object):
         for arg in self._args:
             if torch.is_tensor(arg):
                 representation.append(arg)
-            elif isinstance(arg, LazyTensor):
+            elif hasattr(arg, "representation") and callable(arg.representation):  # Is it a LazyTensor?
                 representation += list(arg.representation())
             else:
                 raise RuntimeError("Representation of a LazyTensor should consist only of Tensors")

--- a/gpytorch/lazy/lazy_tensor_representation_tree.py
+++ b/gpytorch/lazy/lazy_tensor_representation_tree.py
@@ -9,7 +9,7 @@ class LazyTensorRepresentationTree(object):
         counter = 0
         self.children = []
         for arg in lazy_tsr._args:
-            if hasattr(arg, "representation"):  # Is it a lazy tensor?
+            if hasattr(arg, "representation") and callable(arg.representation):  # Is it a lazy tensor?
                 representation_size = len(arg.representation())
                 self.children.append((slice(counter, counter + representation_size, None), arg.representation_tree()))
                 counter += representation_size

--- a/gpytorch/lazy/mul_lazy_tensor.py
+++ b/gpytorch/lazy/mul_lazy_tensor.py
@@ -52,9 +52,7 @@ class MulLazyTensor(LazyTensor):
     @property
     def _args(self):
         if not hasattr(self, "_mul_args_memo") and not hasattr(self, "_non_lazy_self"):
-            lazy_tensors = sorted(
-                (lv.evaluate_kernel() for lv in self.lazy_tensors), key=lambda lv: lv.root_decomposition_size()
-            )
+            lazy_tensors = sorted(self.lazy_tensors, key=lambda lv: lv.root_decomposition_size())
 
             if any(isinstance(lv, NonLazyTensor) for lv in lazy_tensors):
                 self._non_lazy_self = [NonLazyTensor(prod([lv.evaluate() for lv in lazy_tensors]))]

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -235,7 +235,7 @@ class ExactGP(GP):
             train_mean = full_mean.narrow(-1, 0, train_targets.size(-1))
 
             if self.prediction_strategy is None:
-                train_train_covar = full_covar[..., :num_train, :num_train].evaluate_kernel()
+                train_train_covar = full_covar[..., :num_train, :num_train]
                 self.prediction_strategy = prediction_strategy(
                     num_train,
                     train_inputs,

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -447,8 +447,6 @@ class InterpolatedPredictionStrategy(DefaultPredictionStrategy):
     def exact_predictive_mean(self, test_mean, test_train_covar):
         precomputed_cache = self.mean_cache
 
-        test_train_covar = test_train_covar.evaluate_kernel()
-
         test_interp_indices = test_train_covar.left_interp_indices
         test_interp_values = test_train_covar.left_interp_values
         res = left_interp(test_interp_indices, test_interp_values, precomputed_cache).squeeze(-1) + test_mean
@@ -458,10 +456,7 @@ class InterpolatedPredictionStrategy(DefaultPredictionStrategy):
         if settings.fast_pred_var.off() and settings.fast_pred_samples.off():
             return super(InterpolatedPredictionStrategy, self).exact_predictive_covar(test_test_covar, test_train_covar)
 
-        test_train_covar = test_train_covar.evaluate_kernel()
         self._last_test_train_covar = test_train_covar
-        test_test_covar = test_test_covar.evaluate_kernel()
-
         test_interp_indices = test_train_covar.left_interp_indices
         test_interp_values = test_train_covar.left_interp_values
 
@@ -502,7 +497,6 @@ class SumPredictionStrategy(DefaultPredictionStrategy):
         return sub_strategies
 
     def _exact_predictive_covar_inv_quad_form_cache(self, train_train_covar_inv_root, test_train_covar):
-        test_train_covar = test_train_covar.evaluate_kernel()
         if not isinstance(test_train_covar, SumLazyTensor):
             return super(SumPredictionStrategy, self)._exact_predictive_covar_inv_quad_form_cache(
                 train_train_covar_inv_root, test_train_covar

--- a/gpytorch/utils/cholesky.py
+++ b/gpytorch/utils/cholesky.py
@@ -40,8 +40,7 @@ def psd_safe_cholesky(A, upper=False, out=None, jitter=None):
                 raise RuntimeError("Adding jitter of {} to the diagonal did not make A p.d.".format(jitter))
         warnings.warn("A not p.d., added jitter of {} to the diagonal".format(jitter), RuntimeWarning)
 
-    if out is None:
-        return L
+    return L
 
 
 def cholesky_solve(b, u, upper=False):

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -18,3 +18,10 @@ def cached(method=None, name=None):
         return self._memoize_cache[cache_name]
 
     return g
+
+
+def is_cached(self, name):
+    """
+    Determine if a cached item has been computed
+    """
+    return hasattr(self, "_memoize_cache") and name in self._memoize_cache.keys()

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -12,7 +12,6 @@ def pivoted_cholesky(matrix, max_iter, error_tol=1e-3):
     # Need to get diagonals. This is easy if it's a LazyTensor, since
     # LazyTensor.diag() operates in batch mode.
     matrix = lazify(matrix)
-    matrix = matrix.evaluate_kernel()
     matrix_diag = matrix._approx_diag()
 
     # Make sure max_iter isn't bigger than the matrix

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -63,7 +63,7 @@ class VariationalStrategy(Module):
         """
         out = self.model.forward(self.inducing_points)
         res = MultivariateNormal(
-            out.mean, out.lazy_covariance_matrix.evaluate_kernel().add_jitter()
+            out.mean, out.lazy_covariance_matrix.add_jitter()
         )
         return res
 
@@ -125,7 +125,7 @@ class VariationalStrategy(Module):
             mean_diff = (variational_dist.mean - induc_mean).unsqueeze(-1)
 
             # Covariance terms
-            induc_induc_covar = full_covar[..., :num_induc, :num_induc].evaluate_kernel().add_jitter()
+            induc_induc_covar = full_covar[..., :num_induc, :num_induc].add_jitter()
             induc_data_covar = full_covar[..., :num_induc, num_induc:].evaluate()
             data_data_covar = full_covar[..., num_induc:, num_induc:]
             root_variational_covar = variational_dist.lazy_covariance_matrix.root_decomposition().root.evaluate()

--- a/gpytorch/variational/whitened_variational_strategy.py
+++ b/gpytorch/variational/whitened_variational_strategy.py
@@ -113,7 +113,7 @@ class WhitenedVariationalStrategy(VariationalStrategy):
             mean_diff = (variational_dist.mean - induc_mean).unsqueeze(-1)
 
             # Covariance terms
-            induc_induc_covar = full_covar[..., :num_induc, :num_induc].evaluate_kernel().add_jitter()
+            induc_induc_covar = full_covar[..., :num_induc, :num_induc].add_jitter()
             induc_data_covar = full_covar[..., :num_induc, num_induc:].evaluate()
             data_data_covar = full_covar[..., num_induc:, num_induc:]
 


### PR DESCRIPTION
This PR enables implicitly computing kernel matrices through MVMs. It computes the kernel in batches, trading of time for memory.

This feature is activated by using `with gpytorch.beta_features.checkpoint_kernel(<value>)`