### PR TITLE
Fix slowdown of covar_dist

### DIFF
--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -96,5 +96,5 @@ class RBFKernel(Kernel):
     def forward(self, x1, x2, diag=False, **params):
         x1_ = x1.div(self.lengthscale)
         x2_ = x2.div(self.lengthscale)
-        diff = self._covar_dist(x1_, x2_, square_dist=True, diag=diag, postprocess_func=postprocess_rbf, **params)
+        diff = self._covar_dist(x1_, x2_, square_dist=True, diag=diag, dist_postprocess_func=postprocess_rbf, **params)
         return diff


### PR DESCRIPTION
This commit (mostly) fixes issue #503. Now we cache the distance_module
the first time covar_dist is called. This way the JIT no longer
recompiles the module every time.

Unfortunately, it is still about 100us slower than what it was before
the breaking commit 0ff6416, with 0.0013s per forward pass instead of
0.0012s (about 8% slower).