### PR TITLE
Fix autograd bug with preconditioner, default _getitem

### DIFF
--- a/gpytorch/functions/_inv_matmul.py
+++ b/gpytorch/functions/_inv_matmul.py
@@ -6,9 +6,8 @@ from .. import settings
 
 
 class InvMatmul(Function):
-    def __init__(self, representation_tree, preconditioner=None, has_left=False):
+    def __init__(self, representation_tree, has_left=False):
         self.representation_tree = representation_tree
-        self.preconditioner = preconditioner
         self.has_left = has_left
 
     def forward(self, *args):
@@ -21,6 +20,9 @@ class InvMatmul(Function):
             right_tensor, *matrix_args = args
         orig_right_tensor = right_tensor
         lazy_tsr = self.representation_tree(*matrix_args)
+
+        with torch.no_grad():
+            self.preconditioner = lazy_tsr.detach()._inv_matmul_preconditioner()
 
         self.is_vector = False
         if right_tensor.ndimension() == 1:

--- a/gpytorch/functions/_inv_quad_log_det.py
+++ b/gpytorch/functions/_inv_quad_log_det.py
@@ -71,8 +71,8 @@ class InvQuadLogDet(Function):
 
         # Get closure for matmul
         lazy_tsr = self.representation_tree(*matrix_args)
-        preconditioner = lazy_tsr._preconditioner()[0]
-        logdet_correction = lazy_tsr._preconditioner()[1]
+        with torch.no_grad():
+            preconditioner, logdet_correction = lazy_tsr.detach()._preconditioner()
 
         # Collect terms for LinearCG
         # We use LinearCG for both matrix solves and for stochastically estimating the log det

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -681,7 +681,6 @@ class LazyTensor(object):
 
         func = InvMatmul(
             self.representation_tree(),
-            preconditioner=self._inv_matmul_preconditioner(),
             has_left=(left_tensor is not None),
         )
         if left_tensor is None:

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -758,8 +758,6 @@ class LazyTensor(object):
             device=self.device,
             inv_quad=(inv_quad_rhs is not None),
             logdet=logdet,
-            preconditioner=self._preconditioner()[0],
-            logdet_correction=self._preconditioner()[1],
             probe_vectors=probe_vectors,
             probe_vector_norms=probe_vector_norms,
         )(*args)

--- a/test/examples/test_grid_gp_regression.py
+++ b/test/examples/test_grid_gp_regression.py
@@ -12,14 +12,14 @@ from torch import optim
 
 def make_data(grid, cuda=False):
     train_x = gpytorch.utils.grid.create_data_from_grid(grid)
-    train_y = torch.sin((train_x[:, 0] + train_x[:, 1]) * (2 * math.pi)) + torch.randn_like(train_x[:, 0]).mul(0.01)
+    train_y = torch.sin((train_x.sum(-1)) * (2 * math.pi)) + torch.randn_like(train_x[:, 0]).mul(0.01)
     n = 20
     test_x = torch.zeros(int(pow(n, 2)), 2)
     for i in range(n):
         for j in range(n):
             test_x[i * n + j][0] = float(i) / (n - 1)
             test_x[i * n + j][1] = float(j) / (n - 1)
-    test_y = torch.sin(((test_x[:, 0] + test_x[:, 1]) * (2 * math.pi)))
+    test_y = torch.sin(((test_x.sum(-1)) * (2 * math.pi)))
     if cuda:
         train_x = train_x.cuda()
         train_y = train_y.cuda()
@@ -53,9 +53,9 @@ class TestGridGPRegression(unittest.TestCase):
         if hasattr(self, "rng_state"):
             torch.set_rng_state(self.rng_state)
 
-    def test_grid_gp_mean_abs_error(self, cuda=False):
+    def test_grid_gp_mean_abs_error(self, num_dim=1, cuda=False):
         device = torch.device("cuda") if cuda else torch.device("cpu")
-        grid_bounds = [(0, 1), (0, 2)]
+        grid_bounds = [(0, 1)] if num_dim == 1 else [(0, 1), (0, 2)]
         grid_size = 25
         grid = torch.zeros(grid_size, len(grid_bounds), device=device)
         for i in range(len(grid_bounds)):
@@ -107,6 +107,13 @@ class TestGridGPRegression(unittest.TestCase):
     def test_grid_gp_mean_abs_error_cuda(self):
         if torch.cuda.is_available():
             self.test_grid_gp_mean_abs_error(cuda=True)
+
+    def test_grid_gp_mean_abs_error_2d(self):
+        self.test_grid_gp_mean_abs_error(num_dim=2)
+
+    def test_grid_gp_mean_abs_error_2d_cuda(self):
+        if torch.cuda.is_available():
+            self.test_grid_gp_mean_abs_error(cuda=True, num_dim=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For some reason, using the preconditioner in conjunction with the default _getitem causes an autograd error. We definitely should not be computing the backward pass of the preconditioner anyways.

This ensures that the preconditioner is detached and that we are not computing its backwards pass.

Closes #501 