### PR TITLE
Custom RBF and Matern Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ GPyTorch is primarily maintained by:
 
 <img width="300" src=https://brand.cornell.edu/assets/images/downloads/logos/cornell_logo_simple/cornell_logo_simple.svg alt="Cornell Logo" />
 
-We would like to thank our other contributors including (but not limited to) Eytan Bakshy, David Arbour, Ruihan Wu, Bram Wallace, Sam Stanton, and Jared Frank.
+We would like to thank our other contributors including (but not limited to)  David Arbour, Eytan Bakshy, Jared Frank, Sam Stanton, Bram Wallace, Ke Alexander Wang, Ruihan Wu.
 
 ## Acknowledgements
 Development of GPyTorch is supported by funding from [Facebook](https://research.fb.com/), the [Bill and Melinda Gates Foundation](https://www.gatesfoundation.org/), the [National Science Foundation](https://www.nsf.gov/), and [SAP](https://www.sap.com/index.html).

--- a/gpytorch/functions/__init__.py
+++ b/gpytorch/functions/__init__.py
@@ -6,6 +6,8 @@ from ._dsmm import DSMM
 from ._normal_cdf import NormalCDF
 from ._log_normal_cdf import LogNormalCDF
 from ..utils.deprecation import _deprecated_function_for
+from .rbf_covariance import RBFCovariance
+from .matern_covariance import MaternCovariance
 
 
 def add_diag(input, diag):
@@ -196,6 +198,8 @@ inv_quad_log_det = _deprecated_function_for("inv_quad_log_det", inv_quad_logdet)
 
 
 __all__ = [
+    "MaternCovariance",
+    "RBFCovariance",
     "add_diag",
     "dsmm",
     "inv_matmul",

--- a/gpytorch/functions/matern_covariance.py
+++ b/gpytorch/functions/matern_covariance.py
@@ -1,0 +1,54 @@
+import torch
+import math
+
+
+class MaternCovariance(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x1, x2, lengthscale, nu, dist_func):
+        if any(ctx.needs_input_grad[:2]):
+            raise RuntimeError("MaternCovariance cannot compute gradients with "
+                               "respect to x1 and x2")
+        if lengthscale.size(-1) > 1:
+            raise ValueError("MaternCovariance cannot handle multiple lengthscales")
+        # Subtract mean for numerical stability. Won't affect computations
+        # because covariance matrix is stationary.
+        needs_grad = any(ctx.needs_input_grad)
+        mean = x1.contiguous().view(-1, x1.size(-1)).mean(0)[(None,) * (x1.dim() - 1)]
+        x1_ = (x1 - mean).div(lengthscale)
+        x2_ = (x2 - mean).div(lengthscale)
+        scaled_unitless_dist = dist_func(x1_, x2_).mul_(math.sqrt(2 * nu))
+        if nu == 0.5:
+            # 1 kernel sized Tensor if no grad else 2
+            scaled_unitless_dist_ = scaled_unitless_dist.clone() if needs_grad else scaled_unitless_dist
+            exp_component = scaled_unitless_dist_.neg_().exp_()
+            covar_mat = exp_component
+            if needs_grad:
+                d_output_d_input = scaled_unitless_dist.div_(lengthscale).mul_(exp_component)
+        elif nu == 1.5:
+            # 2 kernel sized Tensors if no grad else 3
+            if needs_grad:
+                scaled_unitless_dist_ = scaled_unitless_dist.clone()
+            linear_term = scaled_unitless_dist.clone().add_(1)
+            exp_component = scaled_unitless_dist.neg_().exp_()
+            covar_mat = linear_term.mul_(exp_component)
+            if needs_grad:
+                d_output_d_input = scaled_unitless_dist_.pow_(2).div_(lengthscale).mul_(exp_component)
+        elif nu == 2.5:
+            # 3 kernel sized Tensors if no grad else 4
+            linear_term = scaled_unitless_dist.clone().add_(1)
+            quadratic_term = scaled_unitless_dist.clone().pow_(2).div_(3)
+            exp_component = scaled_unitless_dist.neg_().exp_()
+            if needs_grad:
+                covar_mat = (linear_term + quadratic_term).mul_(exp_component)
+                d_output_d_input = linear_term.mul_(quadratic_term).mul_(exp_component).div_(lengthscale)
+            else:
+                covar_mat = exp_component.mul_(linear_term.add_(quadratic_term))
+        if needs_grad:
+            ctx.save_for_backward(d_output_d_input)
+        return covar_mat
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        d_output_d_input = ctx.saved_tensors[0]
+        lengthscale_grad = grad_output * d_output_d_input
+        return None, None, lengthscale_grad, None, None

--- a/gpytorch/functions/rbf_covariance.py
+++ b/gpytorch/functions/rbf_covariance.py
@@ -1,0 +1,28 @@
+import torch
+
+
+class RBFCovariance(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x1, x2, lengthscale, sq_dist_func):
+        if any(ctx.needs_input_grad[:2]):
+            raise RuntimeError("RBFCovariance cannot compute gradients with "
+                               "respect to x1 and x2")
+        if lengthscale.size(-1) > 1:
+            raise ValueError("RBFCovariance cannot handle multiple lengthscales")
+        needs_grad = any(ctx.needs_input_grad)
+        x1_ = x1.div(lengthscale)
+        x2_ = x2.div(lengthscale)
+        unitless_sq_dist = sq_dist_func(x1_, x2_)
+        # clone because inplace operations will mess with what's saved for backward
+        unitless_sq_dist_ = unitless_sq_dist.clone() if needs_grad else unitless_sq_dist
+        covar_mat = unitless_sq_dist_.div_(-2.).exp_()
+        if needs_grad:
+            d_output_d_input = unitless_sq_dist.mul_(covar_mat).div_(lengthscale)
+            ctx.save_for_backward(d_output_d_input)
+        return covar_mat
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        d_output_d_input = ctx.saved_tensors[0]
+        lengthscale_grad = grad_output * d_output_d_input
+        return None, None, lengthscale_grad, None

--- a/test/functions/test_matern_covariance.py
+++ b/test/functions/test_matern_covariance.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import math
+import unittest
+import torch
+import gpytorch
+
+
+def dist_func(x1, x2):
+    dist_module = gpytorch.kernels.kernel.Distance()
+    return dist_module._jit_dist(x1, x2, torch.tensor(torch.equal(x1, x2)),
+                                 postprocess=torch.tensor(False),
+                                 false_tensor=torch.tensor(False))
+
+
+class TestMaternCovariance(unittest.TestCase):
+    def test_1_2_forward(self):
+        nu = 1 / 2
+        batch_size = (3, 2, 4)
+        x1 = torch.randn(*batch_size, 7, 9)
+        x2 = torch.randn(*batch_size, 6, 9)
+        # Doesn't support ARD
+        lengthscale = torch.randn(*batch_size).view(*batch_size, 1, 1) ** 2
+
+        res = gpytorch.functions.MaternCovariance().apply(x1, x2, lengthscale, nu, dist_func)
+        scaled_unitless_dist = math.sqrt(nu * 2) * dist_func(x1, x2).div(lengthscale)
+        exp_component = torch.exp(-scaled_unitless_dist)
+        actual = exp_component
+        self.assertTrue(torch.allclose(res, actual))
+
+    def test_1_2_backward(self):
+        nu = 1 / 2
+        batch_size = (3, 2, 4)
+        x1 = torch.randn(*batch_size, 7, 9, dtype=torch.float64)
+        x2 = torch.randn(*batch_size, 6, 9, dtype=torch.float64)
+        lengthscale = torch.randn(
+            *batch_size, dtype=torch.float64, requires_grad=True).view(*batch_size, 1, 1) ** 2
+        f = lambda x1, x2, l: gpytorch.functions.MaternCovariance().apply(x1, x2, l, nu, dist_func)
+        try:
+            torch.autograd.gradcheck(f, (x1, x2, lengthscale))
+        except RuntimeError:
+            self.fail(f"Gradcheck failed")
+
+    def test_3_2_forward(self):
+        nu = 3 / 2
+        batch_size = (3, 2, 4)
+        x1 = torch.randn(*batch_size, 7, 9)
+        x2 = torch.randn(*batch_size, 6, 9)
+        # Doesn't support ARD
+        lengthscale = torch.randn(*batch_size).view(*batch_size, 1, 1) ** 2
+
+        res = gpytorch.functions.MaternCovariance().apply(x1, x2, lengthscale, nu, dist_func)
+        scaled_unitless_dist = math.sqrt(nu * 2) * dist_func(x1, x2).div(lengthscale)
+        exp_component = torch.exp(-scaled_unitless_dist)
+        actual = exp_component * (1 + scaled_unitless_dist)
+        self.assertTrue(torch.allclose(res, actual))
+
+    def test_3_2_backward(self):
+        nu = 3 / 2
+        batch_size = (3, 2, 4)
+        x1 = torch.randn(*batch_size, 7, 9, dtype=torch.float64)
+        x2 = torch.randn(*batch_size, 6, 9, dtype=torch.float64)
+        lengthscale = torch.randn(
+            *batch_size, dtype=torch.float64, requires_grad=True).view(*batch_size, 1, 1) ** 2
+        f = lambda x1, x2, l: gpytorch.functions.MaternCovariance().apply(x1, x2, l, nu, dist_func)
+        try:
+            torch.autograd.gradcheck(f, (x1, x2, lengthscale))
+        except RuntimeError:
+            self.fail(f"Gradcheck failed")
+
+    def test_5_2_forward(self):
+        nu = 5 / 2
+        batch_size = (3, 2, 4)
+        x1 = torch.randn(*batch_size, 7, 9)
+        x2 = torch.randn(*batch_size, 6, 9)
+        # Doesn't support ARD
+        lengthscale = torch.randn(*batch_size).view(*batch_size, 1, 1) ** 2
+
+        res = gpytorch.functions.MaternCovariance().apply(x1, x2, lengthscale, nu, dist_func)
+        scaled_unitless_dist = math.sqrt(nu * 2) * dist_func(x1, x2).div(lengthscale)
+        exp_component = torch.exp(-scaled_unitless_dist)
+        actual = exp_component * (1 + scaled_unitless_dist + scaled_unitless_dist ** 2 / 3)
+        self.assertTrue(torch.allclose(res, actual))
+
+    def test_5_2_backward(self):
+        nu = 5 / 2
+        batch_size = (3, 2, 4)
+        x1 = torch.randn(*batch_size, 7, 9, dtype=torch.float64)
+        x2 = torch.randn(*batch_size, 6, 9, dtype=torch.float64)
+        lengthscale = torch.randn(
+            *batch_size, dtype=torch.float64, requires_grad=True).view(*batch_size, 1, 1) ** 2
+        f = lambda x1, x2, l: gpytorch.functions.MaternCovariance().apply(x1, x2, l, nu, dist_func)
+        try:
+            torch.autograd.gradcheck(f, (x1, x2, lengthscale))
+        except RuntimeError:
+            self.fail(f"Gradcheck failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/functions/test_rbf_covariance.py
+++ b/test/functions/test_rbf_covariance.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import torch
+import unittest
+import gpytorch
+
+
+def sq_dist_func(x1, x2):
+    dist_module = gpytorch.kernels.kernel.Distance()
+    return dist_module._jit_sq_dist(x1, x2, torch.tensor(torch.equal(x1, x2)),
+                                    postprocess=torch.tensor(False))
+
+
+class TestRBFCovariance(unittest.TestCase):
+    def test_forward(self):
+        batch_size = (3, 2, 4)
+        x1 = torch.randn(*batch_size, 7, 9)
+        x2 = torch.randn(*batch_size, 6, 9)
+        # Doesn't support ARD
+        lengthscale = torch.randn(*batch_size).view(*batch_size, 1, 1) ** 2
+        res = gpytorch.functions.RBFCovariance().apply(x1, x2, lengthscale, sq_dist_func)
+        actual = sq_dist_func(x1, x2).div(-2 * lengthscale**2).exp()
+        self.assertTrue(torch.allclose(res, actual))
+
+    def test_backward(self):
+        batch_size = (3, 2, 4)
+        x1 = torch.randn(*batch_size, 7, 9, dtype=torch.float64)
+        x2 = torch.randn(*batch_size, 6, 9, dtype=torch.float64)
+        lengthscale = torch.randn(*batch_size, dtype=torch.float64, requires_grad=True).view(*batch_size, 1, 1) ** 2
+        f = lambda x1, x2, l: gpytorch.functions.RBFCovariance().apply(x1, x2, l, sq_dist_func)
+        try:
+            torch.autograd.gradcheck(f, (x1, x2, lengthscale))
+        except RuntimeError:
+            self.fail("Gradcheck failed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request tries to reduce the memory requirements of a RBFKernel and a MaternKernel by introducing a custom backward function when the lengthscales require grad.
- [x] Implement RBFCovariance Function. Fallback to RBFKernel when using ARD or when x1, x2 require grad
- [x] Implement MaternCovariance Function. Fallback to MaternKernel when using ARD or when x1, x2 require grad
- [x] Add unittests for forward and backward

ARD is not yet implemented because I'm not sure if there's a better way to do it than to create a distance matrix for each dimension (resulting in a 3D Tensor) since we need gradients of a 2D Tensor with respect to each of the lengthscales.