### PR TITLE
Improve speed, stability of woodbury for preconditioner

### DIFF
--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -34,6 +34,13 @@ class AddedDiagLazyTensor(SumLazyTensor):
         else:
             raise RuntimeError("One of the LazyTensors input to AddedDiagLazyTensor must be a DiagLazyTensor!")
 
+    def _matmul(self, rhs):
+        return torch.addcmul(
+            self._lazy_tensor._matmul(rhs),
+            self._diag_tensor._diag.unsqueeze(-1),
+            rhs
+        )
+
     def add_diag(self, added_diag):
         return AddedDiagLazyTensor(self._lazy_tensor, self._diag_tensor.add_diag(added_diag))
 

--- a/gpytorch/utils/woodbury.py
+++ b/gpytorch/utils/woodbury.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import torch
+from .cholesky import cholesky_solve
+from .. import settings
+
+
+def woodbury_factor(umat, vmat, diag):
+    r"""
+    Given a matrix factorized as (D + U V^T), where
+    U, V are (n x k) and D is a (n x n) diagonal matrix,
+    returns the matrix R so that
+
+    .. math::
+
+        \begin{equation*}
+            R = (I_k + V^T D^-1 U)^{-1} V^T
+        \end{equation*}
+
+    to be used in solves with (D + U V^T) via the Woodbury formula.
+    Can also be used in batch mode, where U, V, and D are batches of matrices
+
+    Args:
+        :attr:`umat` (Tensor n x k):
+            The left matrix factor
+        :attr:`vmat` (Tensor n x k):
+            The right matrix factor
+        :attr:`diag` (Tensor n):
+            The diagonal of D
+
+    """
+    if settings.debug.on():
+        if umat.shape != vmat.shape:
+            raise ValueError("umat ({}) and vmat ({}) must have the same shape.".format(umat.shape, vmat.shape))
+        if umat.shape[:-1] != diag.shape:
+            raise ValueError("Incompatible shape for diag ({}) given umat shape ({}).".format(diag.shape, umat.shape))
+
+    # Sizes
+    *batch_shape, n, k = umat.shape
+
+    # These reshapes make it easier to use faster blas calls
+    umat = umat.view(-1, n, k)
+    vmat = vmat.view(-1, n, k)
+    diag = diag.view(-1, n, 1)
+
+    # Scale the diagonal
+    # s = scale = max |1 / diag|
+    inv_scale = diag.abs().min()
+    scaled_inv_diag = inv_scale / diag
+
+    # Compute (1/s (I_k + V^T D^-1 U)), where s is a scale factor
+    inner_mat = torch.baddbmm(
+        inv_scale,
+        torch.eye(k, dtype=scaled_inv_diag.dtype, device=scaled_inv_diag.device),
+        1,
+        vmat.transpose(-1, -2),
+        umat * scaled_inv_diag
+    )
+
+    # Compute s (I_k + V^T D^-1 U))^-1 V^T
+    R = cholesky_solve(vmat.transpose(-1, -2), torch.cholesky(inner_mat))
+    return R.view(*batch_shape, k, n)
+
+
+def woodbury_solve(rhs, umat, woodbury_factor, diag):
+    """
+    Solves the system of equations: :math:`(D + U V^T)x = b` using the Woodbury formula,
+    where x is the right-hand-side (size n), U, V are (n x k), and D is a (n x n) diagonal matrix.
+    Can also be used in batch mode, where U, V, and D are batches of matrices and rhs is a batch of right-hand-side.
+
+    This should be used after calling woodbury_factor.
+
+    Args:
+        :attr:`rhs` (size n x t)
+            Right hand side vector b to solve with.
+        :attr:`umat` (n x k)
+            The U matrix
+        :attr:`woodbury_factor` (n x k)
+            The result of calling woodbury_factor on U, V, and D.
+        :attr:`diag` (vector)
+            The diagonal of D
+    """
+    # These reshapes make it easier to use faster blas calls
+    # Scale the diagonal (using the same scale from woodbury factor)
+    # s = scale = max |1 / diag|
+    # E^-1 = 1/s D^-1
+    inv_scale = diag.abs().min()
+    scaled_inv_diag = inv_scale / diag.unsqueeze(-1)
+
+    # (D + UV^T)x = D^-1 x - D^-1 U ((I + V^T D^-1 U)^-1 V^T) D^-1 x
+    #             = D^-1 x - D^-1 U (1/s (woodbury_factor)) D^-1 x
+    #             = s( E^-1 x - E^-1 U (woodbury_factor) E^-1 x )
+    scaled_inv_diag_rhs = rhs * scaled_inv_diag
+    res = torch.addcmul(scaled_inv_diag_rhs, -1, scaled_inv_diag, umat @ woodbury_factor @ scaled_inv_diag_rhs)
+    res = res.div_(inv_scale)
+
+    # Reshape the result to be the correct shape
+    return res

--- a/test/utils/test_pivoted_cholesky.py
+++ b/test/utils/test_pivoted_cholesky.py
@@ -3,11 +3,11 @@
 import os
 import random
 import unittest
+from gpytorch.utils import pivoted_cholesky, woodbury
 from test._utils import approx_equal
 
 import torch
 from gpytorch.kernels import RBFKernel
-from gpytorch.utils import pivoted_cholesky
 
 
 class TestPivotedCholesky(unittest.TestCase):
@@ -28,34 +28,20 @@ class TestPivotedCholesky(unittest.TestCase):
         train_x = torch.linspace(0, 1, size)
         covar_matrix = RBFKernel()(train_x, train_x).evaluate()
         piv_chol = pivoted_cholesky.pivoted_cholesky(covar_matrix, 10)
-        covar_approx = piv_chol.t().matmul(piv_chol)
+        covar_approx = piv_chol @ piv_chol.transpose(-1, -2)
         self.assertTrue(approx_equal(covar_approx, covar_matrix, 2e-4))
-
-    def test_solve_vector(self):
-        size = 100
-        train_x = torch.linspace(0, 1, size)
-        covar_matrix = RBFKernel()(train_x, train_x).evaluate()
-        piv_chol = pivoted_cholesky.pivoted_cholesky(covar_matrix, 10)
-        woodbury_factor = pivoted_cholesky.woodbury_factor(piv_chol, torch.ones(100))
-
-        rhs_vector = torch.randn(100)
-        shifted_covar_matrix = covar_matrix + torch.eye(size)
-        real_solve = shifted_covar_matrix.inverse().matmul(rhs_vector)
-        approx_solve = pivoted_cholesky.woodbury_solve(rhs_vector, piv_chol, woodbury_factor, torch.ones(100))
-
-        self.assertTrue(approx_equal(approx_solve, real_solve, 2e-4))
 
     def test_solve(self):
         size = 100
         train_x = torch.linspace(0, 1, size)
         covar_matrix = RBFKernel()(train_x, train_x).evaluate()
         piv_chol = pivoted_cholesky.pivoted_cholesky(covar_matrix, 10)
-        woodbury_factor = pivoted_cholesky.woodbury_factor(piv_chol, torch.ones(100))
+        woodbury_factor = woodbury.woodbury_factor(piv_chol, piv_chol, torch.ones(100))
 
         rhs_vector = torch.randn(100, 50)
         shifted_covar_matrix = covar_matrix + torch.eye(size)
         real_solve = shifted_covar_matrix.inverse().matmul(rhs_vector)
-        approx_solve = pivoted_cholesky.woodbury_solve(rhs_vector, piv_chol, woodbury_factor, torch.ones(100))
+        approx_solve = woodbury.woodbury_solve(rhs_vector, piv_chol, woodbury_factor, torch.ones(100))
 
         self.assertTrue(approx_equal(approx_solve, real_solve, 2e-4))
 
@@ -80,7 +66,7 @@ class TestPivotedCholeskyBatch(unittest.TestCase):
         ).unsqueeze(-1)
         covar_matrix = RBFKernel()(train_x, train_x).evaluate()
         piv_chol = pivoted_cholesky.pivoted_cholesky(covar_matrix, 10)
-        covar_approx = piv_chol.transpose(1, 2).matmul(piv_chol)
+        covar_approx = piv_chol @ piv_chol.transpose(-1, -2)
 
         self.assertTrue(approx_equal(covar_approx, covar_matrix, 2e-4))
 
@@ -91,7 +77,7 @@ class TestPivotedCholeskyBatch(unittest.TestCase):
         ).unsqueeze(-1)
         covar_matrix = RBFKernel()(train_x, train_x).evaluate()
         piv_chol = pivoted_cholesky.pivoted_cholesky(covar_matrix, 10)
-        woodbury_factor = pivoted_cholesky.woodbury_factor(piv_chol, torch.ones(2, 100))
+        woodbury_factor = woodbury.woodbury_factor(piv_chol, piv_chol, torch.ones(2, 100))
 
         rhs_vector = torch.randn(2, 100, 5)
         shifted_covar_matrix = covar_matrix + torch.eye(size)
@@ -102,7 +88,7 @@ class TestPivotedCholeskyBatch(unittest.TestCase):
             ],
             0,
         )
-        approx_solve = pivoted_cholesky.woodbury_solve(rhs_vector, piv_chol, woodbury_factor, torch.ones(2, 100))
+        approx_solve = woodbury.woodbury_solve(rhs_vector, piv_chol, woodbury_factor, torch.ones(2, 100))
 
         self.assertTrue(approx_equal(approx_solve, real_solve, 2e-4))
 
@@ -141,7 +127,7 @@ class TestPivotedCholeskyMultiBatch(unittest.TestCase):
         ).unsqueeze(-1)
         covar_matrix = RBFKernel()(train_x, train_x).evaluate().view(2, 2, 3, size, size)
         piv_chol = pivoted_cholesky.pivoted_cholesky(covar_matrix, 10)
-        covar_approx = piv_chol.transpose(-1, -2).matmul(piv_chol)
+        covar_approx = piv_chol @ piv_chol.transpose(-1, -2)
 
         self.assertTrue(approx_equal(covar_approx, covar_matrix, 2e-4))
 
@@ -166,7 +152,7 @@ class TestPivotedCholeskyMultiBatch(unittest.TestCase):
         ).unsqueeze(-1)
         covar_matrix = RBFKernel()(train_x, train_x).evaluate().view(2, 2, 3, size, size)
         piv_chol = pivoted_cholesky.pivoted_cholesky(covar_matrix, 10)
-        woodbury_factor = pivoted_cholesky.woodbury_factor(piv_chol, torch.ones(2, 2, 3, 100))
+        woodbury_factor = woodbury.woodbury_factor(piv_chol, piv_chol, torch.ones(2, 2, 3, 100))
 
         rhs_vector = torch.randn(2, 2, 3, 100, 5)
         shifted_covar_matrix = covar_matrix + torch.eye(size)
@@ -187,7 +173,7 @@ class TestPivotedCholeskyMultiBatch(unittest.TestCase):
             ],
             0,
         ).view_as(rhs_vector)
-        approx_solve = pivoted_cholesky.woodbury_solve(rhs_vector, piv_chol, woodbury_factor, torch.ones(2, 3, 100))
+        approx_solve = woodbury.woodbury_solve(rhs_vector, piv_chol, woodbury_factor, torch.ones(2, 3, 100))
 
         self.assertTrue(approx_equal(approx_solve, real_solve, 2e-4))
 


### PR DESCRIPTION
This PR does several things:

- Use lower-level BLAS calls for the woodbury formula. This improves the speed slightly
- Use lower-level BLAS calls for AddedDiagLazyTensor._matmul (the matmul function we use the most out of any LazyTensor)
- Move all woodbury stuff into its own file (we'll probably be reusing it for some future preconditioners and stuff)

The big thing that this PR does:

- Scale the diagonal component of the woodbury formula by its' smallest number. When the diagonal component of woodbury is very small, it's possible that dividing by the diagonal could be numerically unstable. This PR should improve stability by scaling before applying the formula and undoing the scale after.