### PR TITLE
Improve kernel compositions, fix ProductKernel for non-symmetric case.

### DIFF
--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -459,6 +459,7 @@ class ProductKernel(Kernel):
         x1_eq_x2 = torch.equal(x1, x2)
 
         if not x1_eq_x2:
+            # If x1 != x2, then we can't make a MulLazyTensor because the kernel won't necessarily be square/symmetric
             res = delazify(self.kernels[0](x1, x2, **params))
         else:
             res = lazify(self.kernels[0](x1, x2, **params))
@@ -466,6 +467,7 @@ class ProductKernel(Kernel):
         for kern in self.kernels[1:]:
             next_term = kern(x1, x2, **params)
             if not x1_eq_x2:
+                # Again delazify if x1 != x2
                 res = res * delazify(next_term)
             else:
                 res = res * lazify(next_term)

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -827,6 +827,14 @@ class LazyTensor(object):
             :obj:`gpytorch.lazy.ConstantMulLazyTensor`. If other was
             another matrix, this will likely be a :obj:`gpytorch.lazy.MulLazyTensor`.
         """
+        from .zero_lazy_tensor import ZeroLazyTensor
+        from .diag_lazy_tensor import DiagLazyTensor
+
+        if isinstance(other, ZeroLazyTensor):
+            return other
+        elif isinstance(other, DiagLazyTensor):
+            return other * self
+
         if not (torch.is_tensor(other) or isinstance(other, LazyTensor)) or (
             torch.is_tensor(other) and (other.numel() == 1 or (self.dim() == 3 and other.numel() == self.size(0)))
         ):
@@ -1363,14 +1371,6 @@ class LazyTensor(object):
         Convenience alias of :meth:`~gpytorch.lazy.LazyTensor.mul` that allows the standard product operator to be
         used.
         """
-        from .zero_lazy_tensor import ZeroLazyTensor
-        from .diag_lazy_tensor import DiagLazyTensor
-
-        if isinstance(other, ZeroLazyTensor):
-            return other
-        elif isinstance(other, DiagLazyTensor):
-            return other * self
-
         return self.mul(other)
 
     def __setattr__(self, name, val):

--- a/gpytorch/lazy/non_lazy_tensor.py
+++ b/gpytorch/lazy/non_lazy_tensor.py
@@ -62,6 +62,18 @@ class NonLazyTensor(LazyTensor):
     def evaluate(self):
         return self.tensor
 
+    def __add__(self, other):
+        if isinstance(other, NonLazyTensor):
+            return NonLazyTensor(self.tensor + other.tensor)
+        else:
+            return super(NonLazyTensor, self).__add__(other)
+
+    def mul(self, other):
+        if isinstance(other, NonLazyTensor):
+            return NonLazyTensor(self.tensor * other.tensor)
+        else:
+            return super(NonLazyTensor, self).mul(other)
+
 
 def lazify(obj):
     """


### PR DESCRIPTION
- Fixes #527: `ProductKernel` now evaluates to `NonLazyTensors` in the rectangular or nonsymmetric case, since the use of `MulLazyTensor` is not applicable.
- `NonLazyTensor` now overrides `__add__` and `mul` so that adding or elementwise multiplying against another `NonLazyTensor` produces another `NonLazyTensor`. Having a `SumLazyTensor` that consists only of `NonLazyTensors` is unnecessarily slow in CG.

The merger of `__mul__` and `mul` here in `LazyTensor` very minorly conflicts with the same operation done on #492, but I am strongly in favor of merging this before #492.