### PR TITLE
Add interleaved option to MTMVN

### DIFF
--- a/gpytorch/distributions/multitask_multivariate_normal.py
+++ b/gpytorch/distributions/multitask_multivariate_normal.py
@@ -34,6 +34,7 @@ class MultitaskMultivariateNormal(MultivariateNormal):
             raise RuntimeError("mean should be a matrix or a batch matrix (batch mode)")
 
         self._output_shape = mean.shape
+        # TODO: Instead of transpose / view operations, use a PermutationLazyTensor (see #539) to handle interleaving
         self._interleaved = interleaved
         if self._interleaved:
             mean_mvn = mean.view(*mean.shape[:-2], -1)

--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -40,9 +40,7 @@ class _MultivariateNormalBase(TMultivariateNormal, Distribution):
             # TODO: Integrate argument validation for LazyTensors into torch.distribution validation logic
             super(TMultivariateNormal, self).__init__(batch_shape, event_shape, validate_args=False)
         else:
-            super().__init__(
-                loc=mean, covariance_matrix=covariance_matrix, validate_args=validate_args
-            )
+            super().__init__(loc=mean, covariance_matrix=covariance_matrix, validate_args=validate_args)
 
     @property
     def _unbroadcasted_scale_tril(self):
@@ -148,7 +146,7 @@ class _MultivariateNormalBase(TMultivariateNormal, Distribution):
                 )
 
             # Determine what the appropriate sample_shape parameter is
-            sample_shape = base_samples.shape[:base_samples.dim() - self.loc.dim()]
+            sample_shape = base_samples.shape[: base_samples.dim() - self.loc.dim()]
 
             # Reshape samples to be batch_size x num_dim x num_samples
             # or num_bim x num_samples

--- a/test/distributions/test_multivariate_normal.py
+++ b/test/distributions/test_multivariate_normal.py
@@ -4,7 +4,7 @@ import math
 import os
 import random
 import unittest
-from test._utils import approx_equal, least_used_cuda_device
+from test._utils import least_used_cuda_device
 
 import torch
 from gpytorch.distributions import MultivariateNormal
@@ -27,33 +27,34 @@ class TestMultivariateNormal(unittest.TestCase):
 
     def test_multivariate_normal_non_lazy(self, cuda=False):
         device = torch.device("cuda") if cuda else torch.device("cpu")
-        mean = torch.tensor([0, 1, 2], dtype=torch.float, device=device)
-        covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device))
-        mvn = MultivariateNormal(mean=mean, covariance_matrix=covmat, validate_args=True)
-        self.assertTrue(torch.is_tensor(mvn.covariance_matrix))
-        self.assertIsInstance(mvn.lazy_covariance_matrix, LazyTensor)
-        self.assertTrue(approx_equal(mvn.variance, torch.diag(covmat)))
-        self.assertTrue(approx_equal(mvn.scale_tril, covmat.sqrt()))
-        mvn_plus1 = mvn + 1
-        self.assertTrue(torch.equal(mvn_plus1.mean, mvn.mean + 1))
-        self.assertTrue(torch.equal(mvn_plus1.covariance_matrix, mvn.covariance_matrix))
-        mvn_times2 = mvn * 2
-        self.assertTrue(torch.equal(mvn_times2.mean, mvn.mean * 2))
-        self.assertTrue(torch.equal(mvn_times2.covariance_matrix, mvn.covariance_matrix * 4))
-        mvn_divby2 = mvn / 2
-        self.assertTrue(torch.equal(mvn_divby2.mean, mvn.mean / 2))
-        self.assertTrue(torch.equal(mvn_divby2.covariance_matrix, mvn.covariance_matrix / 4))
-        self.assertAlmostEqual(mvn.entropy().item(), 4.3157, places=4)
-        self.assertAlmostEqual(mvn.log_prob(torch.zeros(3, device=device)).item(), -4.8157, places=4)
-        logprob = mvn.log_prob(torch.zeros(2, 3, device=device))
-        logprob_expected = torch.tensor([-4.8157, -4.8157], device=device)
-        self.assertTrue(approx_equal(logprob, logprob_expected))
-        conf_lower, conf_upper = mvn.confidence_region()
-        self.assertTrue(approx_equal(conf_lower, mvn.mean - 2 * mvn.stddev))
-        self.assertTrue(approx_equal(conf_upper, mvn.mean + 2 * mvn.stddev))
-        self.assertTrue(mvn.sample().shape == torch.Size([3]))
-        self.assertTrue(mvn.sample(torch.Size([2])).shape == torch.Size([2, 3]))
-        self.assertTrue(mvn.sample(torch.Size([2, 4])).shape == torch.Size([2, 4, 3]))
+        for dtype in (torch.float, torch.double):
+            mean = torch.tensor([0, 1, 2], device=device, dtype=dtype)
+            covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device, dtype=dtype))
+            mvn = MultivariateNormal(mean=mean, covariance_matrix=covmat, validate_args=True)
+            self.assertTrue(torch.is_tensor(mvn.covariance_matrix))
+            self.assertIsInstance(mvn.lazy_covariance_matrix, LazyTensor)
+            self.assertTrue(torch.allclose(mvn.variance, torch.diag(covmat)))
+            self.assertTrue(torch.allclose(mvn.scale_tril, covmat.sqrt()))
+            mvn_plus1 = mvn + 1
+            self.assertTrue(torch.equal(mvn_plus1.mean, mvn.mean + 1))
+            self.assertTrue(torch.equal(mvn_plus1.covariance_matrix, mvn.covariance_matrix))
+            mvn_times2 = mvn * 2
+            self.assertTrue(torch.equal(mvn_times2.mean, mvn.mean * 2))
+            self.assertTrue(torch.equal(mvn_times2.covariance_matrix, mvn.covariance_matrix * 4))
+            mvn_divby2 = mvn / 2
+            self.assertTrue(torch.equal(mvn_divby2.mean, mvn.mean / 2))
+            self.assertTrue(torch.equal(mvn_divby2.covariance_matrix, mvn.covariance_matrix / 4))
+            self.assertAlmostEqual(mvn.entropy().item(), 4.3157, places=4)
+            self.assertAlmostEqual(mvn.log_prob(torch.zeros(3, device=device, dtype=dtype)).item(), -4.8157, places=4)
+            logprob = mvn.log_prob(torch.zeros(2, 3, device=device, dtype=dtype))
+            logprob_expected = torch.tensor([-4.8157, -4.8157], device=device, dtype=dtype)
+            self.assertTrue(torch.allclose(logprob, logprob_expected))
+            conf_lower, conf_upper = mvn.confidence_region()
+            self.assertTrue(torch.allclose(conf_lower, mvn.mean - 2 * mvn.stddev))
+            self.assertTrue(torch.allclose(conf_upper, mvn.mean + 2 * mvn.stddev))
+            self.assertTrue(mvn.sample().shape == torch.Size([3]))
+            self.assertTrue(mvn.sample(torch.Size([2])).shape == torch.Size([2, 3]))
+            self.assertTrue(mvn.sample(torch.Size([2, 4])).shape == torch.Size([2, 4, 3]))
 
     def test_multivariate_normal_non_lazy_cuda(self):
         if torch.cuda.is_available():
@@ -62,35 +63,38 @@ class TestMultivariateNormal(unittest.TestCase):
 
     def test_multivariate_normal_batch_non_lazy(self, cuda=False):
         device = torch.device("cuda") if cuda else torch.device("cpu")
-        mean = torch.tensor([0, 1, 2], dtype=torch.float, device=device)
-        covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device))
-        mvn = MultivariateNormal(mean=mean.repeat(2, 1), covariance_matrix=covmat.repeat(2, 1, 1), validate_args=True)
-        self.assertTrue(torch.is_tensor(mvn.covariance_matrix))
-        self.assertIsInstance(mvn.lazy_covariance_matrix, LazyTensor)
-        self.assertTrue(approx_equal(mvn.variance, covmat.diag().repeat(2, 1)))
-        self.assertTrue(approx_equal(mvn.scale_tril, torch.diag(covmat.diag().sqrt()).repeat(2, 1, 1)))
-        mvn_plus1 = mvn + 1
-        self.assertTrue(torch.equal(mvn_plus1.mean, mvn.mean + 1))
-        self.assertTrue(torch.equal(mvn_plus1.covariance_matrix, mvn.covariance_matrix))
-        mvn_times2 = mvn * 2
-        self.assertTrue(torch.equal(mvn_times2.mean, mvn.mean * 2))
-        self.assertTrue(torch.equal(mvn_times2.covariance_matrix, mvn.covariance_matrix * 4))
-        mvn_divby2 = mvn / 2
-        self.assertTrue(torch.equal(mvn_divby2.mean, mvn.mean / 2))
-        self.assertTrue(torch.equal(mvn_divby2.covariance_matrix, mvn.covariance_matrix / 4))
-        self.assertTrue(approx_equal(mvn.entropy(), 4.3157 * torch.ones(2, device=device)))
-        logprob = mvn.log_prob(torch.zeros(2, 3, device=device))
-        logprob_expected = -4.8157 * torch.ones(2, device=device)
-        self.assertTrue(approx_equal(logprob, logprob_expected))
-        logprob = mvn.log_prob(torch.zeros(2, 2, 3, device=device))
-        logprob_expected = -4.8157 * torch.ones(2, 2, device=device)
-        self.assertTrue(approx_equal(logprob, logprob_expected))
-        conf_lower, conf_upper = mvn.confidence_region()
-        self.assertTrue(approx_equal(conf_lower, mvn.mean - 2 * mvn.stddev))
-        self.assertTrue(approx_equal(conf_upper, mvn.mean + 2 * mvn.stddev))
-        self.assertTrue(mvn.sample().shape == torch.Size([2, 3]))
-        self.assertTrue(mvn.sample(torch.Size([2])).shape == torch.Size([2, 2, 3]))
-        self.assertTrue(mvn.sample(torch.Size([2, 4])).shape == torch.Size([2, 4, 2, 3]))
+        for dtype in (torch.float, torch.double):
+            mean = torch.tensor([0, 1, 2], device=device, dtype=dtype)
+            covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device, dtype=dtype))
+            mvn = MultivariateNormal(
+                mean=mean.repeat(2, 1), covariance_matrix=covmat.repeat(2, 1, 1), validate_args=True
+            )
+            self.assertTrue(torch.is_tensor(mvn.covariance_matrix))
+            self.assertIsInstance(mvn.lazy_covariance_matrix, LazyTensor)
+            self.assertTrue(torch.allclose(mvn.variance, covmat.diag().repeat(2, 1)))
+            self.assertTrue(torch.allclose(mvn.scale_tril, torch.diag(covmat.diag().sqrt()).repeat(2, 1, 1)))
+            mvn_plus1 = mvn + 1
+            self.assertTrue(torch.equal(mvn_plus1.mean, mvn.mean + 1))
+            self.assertTrue(torch.equal(mvn_plus1.covariance_matrix, mvn.covariance_matrix))
+            mvn_times2 = mvn * 2
+            self.assertTrue(torch.equal(mvn_times2.mean, mvn.mean * 2))
+            self.assertTrue(torch.equal(mvn_times2.covariance_matrix, mvn.covariance_matrix * 4))
+            mvn_divby2 = mvn / 2
+            self.assertTrue(torch.equal(mvn_divby2.mean, mvn.mean / 2))
+            self.assertTrue(torch.equal(mvn_divby2.covariance_matrix, mvn.covariance_matrix / 4))
+            self.assertTrue(torch.allclose(mvn.entropy(), 4.3157 * torch.ones(2, device=device, dtype=dtype)))
+            logprob = mvn.log_prob(torch.zeros(2, 3, device=device, dtype=dtype))
+            logprob_expected = -4.8157 * torch.ones(2, device=device, dtype=dtype)
+            self.assertTrue(torch.allclose(logprob, logprob_expected))
+            logprob = mvn.log_prob(torch.zeros(2, 2, 3, device=device, dtype=dtype))
+            logprob_expected = -4.8157 * torch.ones(2, 2, device=device, dtype=dtype)
+            self.assertTrue(torch.allclose(logprob, logprob_expected))
+            conf_lower, conf_upper = mvn.confidence_region()
+            self.assertTrue(torch.allclose(conf_lower, mvn.mean - 2 * mvn.stddev))
+            self.assertTrue(torch.allclose(conf_upper, mvn.mean + 2 * mvn.stddev))
+            self.assertTrue(mvn.sample().shape == torch.Size([2, 3]))
+            self.assertTrue(mvn.sample(torch.Size([2])).shape == torch.Size([2, 2, 3]))
+            self.assertTrue(mvn.sample(torch.Size([2, 4])).shape == torch.Size([2, 4, 2, 3]))
 
     def test_multivariate_normal_batch_non_lazy_cuda(self):
         if torch.cuda.is_available():
@@ -99,42 +103,43 @@ class TestMultivariateNormal(unittest.TestCase):
 
     def test_multivariate_normal_lazy(self, cuda=False):
         device = torch.device("cuda") if cuda else torch.device("cpu")
-        mean = torch.tensor([0, 1, 2], dtype=torch.float, device=device)
-        covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device))
-        covmat_chol = torch.cholesky(covmat)
-        mvn = MultivariateNormal(mean=mean, covariance_matrix=NonLazyTensor(covmat))
-        self.assertTrue(torch.is_tensor(mvn.covariance_matrix))
-        self.assertIsInstance(mvn.lazy_covariance_matrix, LazyTensor)
-        self.assertTrue(torch.equal(mvn.variance, torch.diag(covmat)))
-        self.assertTrue(torch.equal(mvn.covariance_matrix, covmat))
-        self.assertTrue(torch.equal(mvn._unbroadcasted_scale_tril, covmat_chol))
-        mvn_plus1 = mvn + 1
-        self.assertTrue(torch.equal(mvn_plus1.mean, mvn.mean + 1))
-        self.assertTrue(torch.equal(mvn_plus1.covariance_matrix, mvn.covariance_matrix))
-        self.assertTrue(torch.equal(mvn_plus1._unbroadcasted_scale_tril, covmat_chol))
-        mvn_times2 = mvn * 2
-        self.assertTrue(torch.equal(mvn_times2.mean, mvn.mean * 2))
-        self.assertTrue(torch.equal(mvn_times2.covariance_matrix, mvn.covariance_matrix * 4))
-        self.assertTrue(torch.equal(mvn_times2._unbroadcasted_scale_tril, covmat_chol * 2))
-        mvn_divby2 = mvn / 2
-        self.assertTrue(torch.equal(mvn_divby2.mean, mvn.mean / 2))
-        self.assertTrue(torch.equal(mvn_divby2.covariance_matrix, mvn.covariance_matrix / 4))
-        self.assertTrue(torch.equal(mvn_divby2._unbroadcasted_scale_tril, covmat_chol / 2))
-        # TODO: Add tests for entropy, log_prob, etc. - this an issue b/c it
-        # uses using root_decomposition which is not very reliable
-        # self.assertAlmostEqual(mvn.entropy().item(), 4.3157, places=4)
-        # self.assertAlmostEqual(mvn.log_prob(torch.zeros(3)).item(), -4.8157, places=4)
-        # self.assertTrue(
-        #     approx_equal(
-        #         mvn.log_prob(torch.zeros(2, 3)), -4.8157 * torch.ones(2))
-        #     )
-        # )
-        conf_lower, conf_upper = mvn.confidence_region()
-        self.assertTrue(approx_equal(conf_lower, mvn.mean - 2 * mvn.stddev))
-        self.assertTrue(approx_equal(conf_upper, mvn.mean + 2 * mvn.stddev))
-        self.assertTrue(mvn.sample().shape == torch.Size([3]))
-        self.assertTrue(mvn.sample(torch.Size([2])).shape == torch.Size([2, 3]))
-        self.assertTrue(mvn.sample(torch.Size([2, 4])).shape == torch.Size([2, 4, 3]))
+        for dtype in (torch.float, torch.double):
+            mean = torch.tensor([0, 1, 2], device=device, dtype=dtype)
+            covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device, dtype=dtype))
+            covmat_chol = torch.cholesky(covmat)
+            mvn = MultivariateNormal(mean=mean, covariance_matrix=NonLazyTensor(covmat))
+            self.assertTrue(torch.is_tensor(mvn.covariance_matrix))
+            self.assertIsInstance(mvn.lazy_covariance_matrix, LazyTensor)
+            self.assertTrue(torch.equal(mvn.variance, torch.diag(covmat)))
+            self.assertTrue(torch.equal(mvn.covariance_matrix, covmat))
+            self.assertTrue(torch.equal(mvn._unbroadcasted_scale_tril, covmat_chol))
+            mvn_plus1 = mvn + 1
+            self.assertTrue(torch.equal(mvn_plus1.mean, mvn.mean + 1))
+            self.assertTrue(torch.equal(mvn_plus1.covariance_matrix, mvn.covariance_matrix))
+            self.assertTrue(torch.equal(mvn_plus1._unbroadcasted_scale_tril, covmat_chol))
+            mvn_times2 = mvn * 2
+            self.assertTrue(torch.equal(mvn_times2.mean, mvn.mean * 2))
+            self.assertTrue(torch.equal(mvn_times2.covariance_matrix, mvn.covariance_matrix * 4))
+            self.assertTrue(torch.equal(mvn_times2._unbroadcasted_scale_tril, covmat_chol * 2))
+            mvn_divby2 = mvn / 2
+            self.assertTrue(torch.equal(mvn_divby2.mean, mvn.mean / 2))
+            self.assertTrue(torch.equal(mvn_divby2.covariance_matrix, mvn.covariance_matrix / 4))
+            self.assertTrue(torch.equal(mvn_divby2._unbroadcasted_scale_tril, covmat_chol / 2))
+            # TODO: Add tests for entropy, log_prob, etc. - this an issue b/c it
+            # uses using root_decomposition which is not very reliable
+            # self.assertAlmostEqual(mvn.entropy().item(), 4.3157, places=4)
+            # self.assertAlmostEqual(mvn.log_prob(torch.zeros(3)).item(), -4.8157, places=4)
+            # self.assertTrue(
+            #     torch.allclose(
+            #         mvn.log_prob(torch.zeros(2, 3)), -4.8157 * torch.ones(2))
+            #     )
+            # )
+            conf_lower, conf_upper = mvn.confidence_region()
+            self.assertTrue(torch.allclose(conf_lower, mvn.mean - 2 * mvn.stddev))
+            self.assertTrue(torch.allclose(conf_upper, mvn.mean + 2 * mvn.stddev))
+            self.assertTrue(mvn.sample().shape == torch.Size([3]))
+            self.assertTrue(mvn.sample(torch.Size([2])).shape == torch.Size([2, 3]))
+            self.assertTrue(mvn.sample(torch.Size([2, 4])).shape == torch.Size([2, 4, 3]))
 
     def test_multivariate_normal_lazy_cuda(self):
         if torch.cuda.is_available():
@@ -143,41 +148,42 @@ class TestMultivariateNormal(unittest.TestCase):
 
     def test_multivariate_normal_batch_lazy(self, cuda=False):
         device = torch.device("cuda") if cuda else torch.device("cpu")
-        mean = torch.tensor([0, 1, 2], dtype=torch.float, device=device).repeat(2, 1)
-        covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device)).repeat(2, 1, 1)
-        covmat_chol = torch.cholesky(covmat)
-        mvn = MultivariateNormal(mean=mean, covariance_matrix=NonLazyTensor(covmat))
-        self.assertTrue(torch.is_tensor(mvn.covariance_matrix))
-        self.assertIsInstance(mvn.lazy_covariance_matrix, LazyTensor)
-        self.assertTrue(approx_equal(mvn.variance, torch.diagonal(covmat, dim1=-2, dim2=-1)))
-        self.assertTrue(torch.equal(mvn._unbroadcasted_scale_tril, covmat_chol))
-        mvn_plus1 = mvn + 1
-        self.assertTrue(torch.equal(mvn_plus1.mean, mvn.mean + 1))
-        self.assertTrue(torch.equal(mvn_plus1.covariance_matrix, mvn.covariance_matrix))
-        self.assertTrue(torch.equal(mvn_plus1._unbroadcasted_scale_tril, covmat_chol))
-        mvn_times2 = mvn * 2
-        self.assertTrue(torch.equal(mvn_times2.mean, mvn.mean * 2))
-        self.assertTrue(torch.equal(mvn_times2.covariance_matrix, mvn.covariance_matrix * 4))
-        self.assertTrue(torch.equal(mvn_times2._unbroadcasted_scale_tril, covmat_chol * 2))
-        mvn_divby2 = mvn / 2
-        self.assertTrue(torch.equal(mvn_divby2.mean, mvn.mean / 2))
-        self.assertTrue(torch.equal(mvn_divby2.covariance_matrix, mvn.covariance_matrix / 4))
-        self.assertTrue(torch.equal(mvn_divby2._unbroadcasted_scale_tril, covmat_chol / 2))
-        # TODO: Add tests for entropy, log_prob, etc. - this an issue b/c it
-        # uses using root_decomposition which is not very reliable
-        # self.assertTrue(approx_equal(mvn.entropy(), 4.3157 * torch.ones(2)))
-        # self.assertTrue(
-        #     approx_equal(mvn.log_prob(torch.zeros(2, 3)), -4.8157 * torch.ones(2))
-        # )
-        # self.assertTrue(
-        #     approx_equal(mvn.log_prob(torch.zeros(2, 2, 3)), -4.8157 * torch.ones(2, 2))
-        # )
-        conf_lower, conf_upper = mvn.confidence_region()
-        self.assertTrue(approx_equal(conf_lower, mvn.mean - 2 * mvn.stddev))
-        self.assertTrue(approx_equal(conf_upper, mvn.mean + 2 * mvn.stddev))
-        self.assertTrue(mvn.sample().shape == torch.Size([2, 3]))
-        self.assertTrue(mvn.sample(torch.Size([2])).shape == torch.Size([2, 2, 3]))
-        self.assertTrue(mvn.sample(torch.Size([2, 4])).shape == torch.Size([2, 4, 2, 3]))
+        for dtype in (torch.float, torch.double):
+            mean = torch.tensor([0, 1, 2], device=device, dtype=dtype).repeat(2, 1)
+            covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device, dtype=dtype)).repeat(2, 1, 1)
+            covmat_chol = torch.cholesky(covmat)
+            mvn = MultivariateNormal(mean=mean, covariance_matrix=NonLazyTensor(covmat))
+            self.assertTrue(torch.is_tensor(mvn.covariance_matrix))
+            self.assertIsInstance(mvn.lazy_covariance_matrix, LazyTensor)
+            self.assertTrue(torch.allclose(mvn.variance, torch.diagonal(covmat, dim1=-2, dim2=-1)))
+            self.assertTrue(torch.equal(mvn._unbroadcasted_scale_tril, covmat_chol))
+            mvn_plus1 = mvn + 1
+            self.assertTrue(torch.equal(mvn_plus1.mean, mvn.mean + 1))
+            self.assertTrue(torch.equal(mvn_plus1.covariance_matrix, mvn.covariance_matrix))
+            self.assertTrue(torch.equal(mvn_plus1._unbroadcasted_scale_tril, covmat_chol))
+            mvn_times2 = mvn * 2
+            self.assertTrue(torch.equal(mvn_times2.mean, mvn.mean * 2))
+            self.assertTrue(torch.equal(mvn_times2.covariance_matrix, mvn.covariance_matrix * 4))
+            self.assertTrue(torch.equal(mvn_times2._unbroadcasted_scale_tril, covmat_chol * 2))
+            mvn_divby2 = mvn / 2
+            self.assertTrue(torch.equal(mvn_divby2.mean, mvn.mean / 2))
+            self.assertTrue(torch.equal(mvn_divby2.covariance_matrix, mvn.covariance_matrix / 4))
+            self.assertTrue(torch.equal(mvn_divby2._unbroadcasted_scale_tril, covmat_chol / 2))
+            # TODO: Add tests for entropy, log_prob, etc. - this an issue b/c it
+            # uses using root_decomposition which is not very reliable
+            # self.assertTrue(torch.allclose(mvn.entropy(), 4.3157 * torch.ones(2)))
+            # self.assertTrue(
+            #     torch.allclose(mvn.log_prob(torch.zeros(2, 3)), -4.8157 * torch.ones(2))
+            # )
+            # self.assertTrue(
+            #     torch.allclose(mvn.log_prob(torch.zeros(2, 2, 3)), -4.8157 * torch.ones(2, 2))
+            # )
+            conf_lower, conf_upper = mvn.confidence_region()
+            self.assertTrue(torch.allclose(conf_lower, mvn.mean - 2 * mvn.stddev))
+            self.assertTrue(torch.allclose(conf_upper, mvn.mean + 2 * mvn.stddev))
+            self.assertTrue(mvn.sample().shape == torch.Size([2, 3]))
+            self.assertTrue(mvn.sample(torch.Size([2])).shape == torch.Size([2, 2, 3]))
+            self.assertTrue(mvn.sample(torch.Size([2, 4])).shape == torch.Size([2, 4, 2, 3]))
 
     def test_multivariate_normal_batch_lazy_cuda(self):
         if torch.cuda.is_available():
@@ -186,15 +192,14 @@ class TestMultivariateNormal(unittest.TestCase):
 
     def test_multivariate_normal_correlated_samples(self, cuda=False):
         device = torch.device("cuda") if cuda else torch.device("cpu")
-        mean = torch.tensor([0, 1, 2], dtype=torch.float, device=device)
-        covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device))
-        mvn = MultivariateNormal(mean=mean, covariance_matrix=NonLazyTensor(covmat))
-
-        base_samples = mvn.get_base_samples(torch.Size((3, 4)))
-        self.assertTrue(mvn.sample(base_samples=base_samples).shape == torch.Size([3, 4, 3]))
-
-        base_samples = mvn.get_base_samples()
-        self.assertTrue(mvn.sample(base_samples=base_samples).shape == torch.Size([3]))
+        for dtype in (torch.float, torch.double):
+            mean = torch.tensor([0, 1, 2], device=device, dtype=dtype)
+            covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device, dtype=dtype))
+            mvn = MultivariateNormal(mean=mean, covariance_matrix=NonLazyTensor(covmat))
+            base_samples = mvn.get_base_samples(torch.Size([3, 4]))
+            self.assertTrue(mvn.sample(base_samples=base_samples).shape == torch.Size([3, 4, 3]))
+            base_samples = mvn.get_base_samples()
+            self.assertTrue(mvn.sample(base_samples=base_samples).shape == torch.Size([3]))
 
     def test_multivariate_normal_correlated_samples_cuda(self):
         if torch.cuda.is_available():
@@ -203,59 +208,74 @@ class TestMultivariateNormal(unittest.TestCase):
 
     def test_multivariate_normal_batch_correlated_samples(self, cuda=False):
         device = torch.device("cuda") if cuda else torch.device("cpu")
-        mean = torch.tensor([0, 1, 2], dtype=torch.float, device=device)
-        covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device))
-        mvn = MultivariateNormal(mean=mean.repeat(2, 1), covariance_matrix=NonLazyTensor(covmat).repeat(2, 1, 1))
-
-        base_samples = mvn.get_base_samples(torch.Size((3, 4)))
-        self.assertTrue(mvn.sample(base_samples=base_samples).shape == torch.Size([3, 4, 2, 3]))
-
-        base_samples = mvn.get_base_samples()
-        self.assertTrue(mvn.sample(base_samples=base_samples).shape == torch.Size([2, 3]))
+        for dtype in (torch.float, torch.double):
+            mean = torch.tensor([0, 1, 2], device=device, dtype=dtype)
+            covmat = torch.diag(torch.tensor([1, 0.75, 1.5], device=device, dtype=dtype))
+            mvn = MultivariateNormal(mean=mean.repeat(2, 1), covariance_matrix=NonLazyTensor(covmat).repeat(2, 1, 1))
+            base_samples = mvn.get_base_samples(torch.Size((3, 4)))
+            self.assertTrue(mvn.sample(base_samples=base_samples).shape == torch.Size([3, 4, 2, 3]))
+            base_samples = mvn.get_base_samples()
+            self.assertTrue(mvn.sample(base_samples=base_samples).shape == torch.Size([2, 3]))
 
     def test_multivariate_normal_batch_correlated_samples_cuda(self):
         if torch.cuda.is_available():
             with least_used_cuda_device():
                 self.test_multivariate_normal_batch_correlated_samples(cuda=True)
 
-    def test_log_prob(self):
-        mean = torch.randn(4)
-        var = torch.randn(4).abs_()
-        values = torch.randn(4)
+    def test_log_prob(self, cuda=False):
+        device = torch.device("cuda") if cuda else torch.device("cpu")
+        for dtype in (torch.float, torch.double):
+            mean = torch.randn(4, device=device, dtype=dtype)
+            var = torch.randn(4, device=device, dtype=dtype).abs_()
+            values = torch.randn(4, device=device, dtype=dtype)
 
-        res = MultivariateNormal(mean, DiagLazyTensor(var)).log_prob(values)
-        actual = TMultivariateNormal(mean, torch.eye(4) * var).log_prob(values)
-        self.assertLess((res - actual).div(res).abs().item(), 1e-2)
+            res = MultivariateNormal(mean, DiagLazyTensor(var)).log_prob(values)
+            actual = TMultivariateNormal(mean, torch.eye(4, device=device, dtype=dtype) * var).log_prob(values)
+            self.assertLess((res - actual).div(res).abs().item(), 1e-2)
 
-        mean = torch.randn(3, 4)
-        var = torch.randn(3, 4).abs_()
-        values = torch.randn(3, 4)
+            mean = torch.randn(3, 4, device=device, dtype=dtype)
+            var = torch.randn(3, 4, device=device, dtype=dtype).abs_()
+            values = torch.randn(3, 4, device=device, dtype=dtype)
 
-        res = MultivariateNormal(mean, DiagLazyTensor(var)).log_prob(values)
-        actual = TMultivariateNormal(mean, var.unsqueeze(-1) * torch.eye(4).repeat(3, 1, 1)).log_prob(values)
-        self.assertLess((res - actual).div(res).abs().norm(), 1e-2)
+            res = MultivariateNormal(mean, DiagLazyTensor(var)).log_prob(values)
+            actual = TMultivariateNormal(
+                mean, var.unsqueeze(-1) * torch.eye(4, device=device, dtype=dtype).repeat(3, 1, 1)
+            ).log_prob(values)
+            self.assertLess((res - actual).div(res).abs().norm(), 1e-2)
 
-    def test_kl_divergence(self):
-        mean0 = torch.randn(4)
-        mean1 = mean0 + 1
-        var0 = torch.randn(4).abs_()
-        var1 = var0 * math.exp(2)
+    def test_log_prob_cuda(self):
+        if torch.cuda.is_available():
+            with least_used_cuda_device():
+                self.test_log_prob(cuda=True)
 
-        dist_a = MultivariateNormal(mean0, DiagLazyTensor(var0))
-        dist_b = MultivariateNormal(mean1, DiagLazyTensor(var0))
-        dist_c = MultivariateNormal(mean0, DiagLazyTensor(var1))
+    def test_kl_divergence(self, cuda=False):
+        device = torch.device("cuda") if cuda else torch.device("cpu")
+        for dtype in (torch.float, torch.double):
+            mean0 = torch.randn(4, device=device, dtype=dtype)
+            mean1 = mean0 + 1
+            var0 = torch.randn(4, device=device, dtype=dtype).abs_()
+            var1 = var0 * math.exp(2)
 
-        res = torch.distributions.kl.kl_divergence(dist_a, dist_a)
-        actual = 0.0
-        self.assertLess((res - actual).abs().item(), 1e-2)
+            dist_a = MultivariateNormal(mean0, DiagLazyTensor(var0))
+            dist_b = MultivariateNormal(mean1, DiagLazyTensor(var0))
+            dist_c = MultivariateNormal(mean0, DiagLazyTensor(var1))
 
-        res = torch.distributions.kl.kl_divergence(dist_b, dist_a)
-        actual = var0.reciprocal().sum().div(2.0)
-        self.assertLess((res - actual).div(res).abs().item(), 1e-2)
+            res = torch.distributions.kl.kl_divergence(dist_a, dist_a)
+            actual = 0.0
+            self.assertLess((res - actual).abs().item(), 1e-2)
 
-        res = torch.distributions.kl.kl_divergence(dist_a, dist_c)
-        actual = 0.5 * (8 - 4 + 4 * math.exp(-2))
-        self.assertLess((res - actual).div(res).abs().item(), 1e-2)
+            res = torch.distributions.kl.kl_divergence(dist_b, dist_a)
+            actual = var0.reciprocal().sum().div(2.0)
+            self.assertLess((res - actual).div(res).abs().item(), 1e-2)
+
+            res = torch.distributions.kl.kl_divergence(dist_a, dist_c)
+            actual = 0.5 * (8 - 4 + 4 * math.exp(-2))
+            self.assertLess((res - actual).div(res).abs().item(), 1e-2)
+
+    def test_kl_divergence_cuda(self):
+        if torch.cuda.is_available():
+            with least_used_cuda_device():
+                self.test_kl_divergence(cuda=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds an `interleaved` flag to the MTMVN constructor (defaults to True).

- If True, covariance matrix is interpreted as block-diagonal w.r.t. inter-task covariances for each observation. This is the status quo behavior.
- If False, it is interpreted as block-diagonal w.r.t. inter-observation covariance for each task. This makes it much easier to construct a MTMVN from independent MVNs. It also potentially allows for more efficient computations by exploiting structure more effectively. For instance the internal covariance matrix generated by `from_independent_mvns` is now block-diagonal, so it can be efficiently cholesky-decomposed in batch mode (this is handled inside the LazyTensor implementation).

This also cleans up and streamlines some code, and improves test coverage (in particular, tests cover both data types on both the GPU and CPU).

This addresses #537