### PR TITLE
fix mul shape broadcasting in batch mode

### DIFF
--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -830,6 +830,8 @@ class LazyTensor(object):
         if not (torch.is_tensor(other) or isinstance(other, LazyTensor)) or (
             torch.is_tensor(other) and (other.numel() == 1 or (self.dim() == 3 and other.numel() == self.size(0)))
         ):
+            if torch.is_tensor(other) and self.dim() == 3 and other.numel() == self.size(0):
+                other = other.view(self.size(0))
             from .constant_mul_lazy_tensor import ConstantMulLazyTensor
 
             return ConstantMulLazyTensor(self, other)


### PR DESCRIPTION
Versions:
python - 3.7.0
pytorch-nightly - 1.0.0.dev20190201
gpytorch - master (commit [b04c7e43293da18f630eb4ec483906a75ec72929](https://github.com/samuelstanton/gpytorch/commit/b04c7e43293da18f630eb4ec483906a75ec72929))

Motivation:
It's often desirable to preprocess training inputs and targets by mean subtracting and scaling by the standard deviation. Of course post-prediction you have to account for this by adding back the target mean to the rescaled predictive means and rescaling the predictive variances. In the batch setting this translates to multiplying the `[b x t x t]` test covariance lazy tensor by a `[b]` dimensional scaling tensor

Issue: 
To perform this multiplication on a tensor, you would have
```
import torch
a = torch.rand(2, 3, 3)
b = torch.rand(2, 1, 1)
prod = a.mul(b)
```
To perform the same operation on a `LazyTensor`, you would do
```
from gpytorch.lazy import NonLazyTensor
a = NonLazyTensor(torch.rand(2, 3, 3))
b = torch.rand(2)
prod = a.mul(b)
```
However,
```
a = torch.rand(2, 3, 3)
b = torch.rand(2)
prod = a.mul(b)
``` 
yields
`RuntimeError: The size of tensor a (3) must match the size of tensor b (2) at non-singleton dimension 2`

Setting aside the inconsistency here, the key issue is that `LazyTensor.mul` does _not_ check for unexpected batch scale sizes, so if a user performs the multiplication in the way one would expect, he sees this behavior
```
a = NonLazyTensor(torch.rand(2, 3, 3))
b = torch.rand(2, 1, 1)
prod = a.mul(b)
print(prod.size())
print(prod.evaluate().size())
```
```
torch.Size([2, 3, 3])
torch.Size([2, 1, 2, 3, 3])
```

Fix:
Rather than coerce the user into inconsistent usage, if in batch mode, `LazyTensor.mul` now squeezes `other` to a 1-D tensor before passing it to `ConstantMulLazyTensor`, yielding the desired behavior
```
a = NonLazyTensor(torch.rand(2, 3, 3))
b = torch.rand(2, 1, 1)
prod = a.mul(b)
print(prod.size())
print(prod.evaluate().size())
```
```
torch.Size([2, 3, 3])
torch.Size([2, 3, 3])
```