### PR TITLE
Fix shared inducing point locations for batch mode VI

### DIFF
--- a/gpytorch/variational/cholesky_variational_distribution.py
+++ b/gpytorch/variational/cholesky_variational_distribution.py
@@ -30,6 +30,7 @@ class CholeskyVariationalDistribution(VariationalDistribution):
             mean_init = mean_init.repeat(batch_size, 1)
             covar_init = covar_init.repeat(batch_size, 1, 1)
 
+        self.batch_size = batch_size
         self.register_parameter(name="variational_mean", parameter=torch.nn.Parameter(mean_init))
         self.register_parameter(name="chol_variational_covar", parameter=torch.nn.Parameter(covar_init))
 

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -52,6 +52,7 @@ class VariationalStrategy(Module):
 
         self.variational_distribution = variational_distribution
         self.register_buffer("variational_params_initialized", torch.tensor(0))
+        self.batch_size = self.variational_distribution.batch_size
 
     @property
     @cached(name="prior_distribution_memo")
@@ -61,7 +62,11 @@ class VariationalStrategy(Module):
         GP prior distribution of the inducing points, e.g. :math:`p(u) \sim N(\mu(X_u), K(X_u, X_u))`. Most commonly,
         this is done simply by calling the user defined GP prior on the inducing point data directly.
         """
-        out = self.model.forward(self.inducing_points)
+        if self.batch_size is not None:
+            inducing_points = self.inducing_points.expand(self.batch_size, *self.inducing_points.shape[-2:])
+        else:
+            inducing_points = self.inducing_points
+        out = self.model.forward(inducing_points)
         res = MultivariateNormal(
             out.mean, out.lazy_covariance_matrix.evaluate_kernel().add_jitter()
         )


### PR DESCRIPTION
This fixes an issue where inducing point locations couldn't be shared across the independent GPs when doing VI in batch mode.