### PR TITLE
Use added loss terms for variational inference

### DIFF
--- a/gpytorch/mlls/variational_elbo.py
+++ b/gpytorch/mlls/variational_elbo.py
@@ -41,16 +41,28 @@ class VariationalELBO(MarginalLogLikelihood):
 
         kl_divergence = kl_divergence.div(self.num_data)
 
+        # Add any additional registered loss terms
+        added_loss = torch.zeros_like(kl_divergence)
+        had_added_losses = False
+        for added_loss_term in self.model.added_loss_terms():
+            added_loss.add(added_loss_term.loss())
+            had_added_losses = True
+
         if self.combine_terms:
             res = log_likelihood - kl_divergence
             for _, prior, closure, _ in self.named_priors():
                 res.add_(prior.log_prob(closure()).sum().div(self.num_data))
-            return res
+
+            return res + added_loss
         else:
             log_prior = torch.zeros_like(log_likelihood)
             for _, prior, closure, _ in self.named_priors():
                 log_prior.add_(prior.log_prob(closure()).sum())
-            return log_likelihood, kl_divergence, log_prior.div(self.num_data)
+
+            if had_added_losses:
+                return log_likelihood, kl_divergence, log_prior.div(self.num_data), added_loss
+            else:
+                return log_likelihood, kl_divergence, log_prior.div(self.num_data)
 
 
 class VariationalELBOEmpirical(VariationalELBO):


### PR DESCRIPTION
Right now users can register loss terms to be added for exact GPs, but these have no functionality for VI. This PR fixes this (necessary for deep GPs and GPRNs).