### PR TITLE
Fix bug in setting training data for ExactGP if training inputs are None

### DIFF
--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -45,7 +45,16 @@ class ExactGP(GP):
         return super(ExactGP, self)._apply(fn)
 
     def set_train_data(self, inputs=None, targets=None, strict=True):
-        """Set training data (does not re-fit model hyper-parameters)"""
+        """
+        Set training data (does not re-fit model hyper-parameters).
+
+        Args:
+            - :attr:`inputs` the new training inputs
+            - :attr:`targets` the new training targets
+            - :attr:`strict`
+                if `True`, the new inputs and targets must have the same shape, dtype, and device
+                as the current inputs and targets. Otherwise, any shape/dtype/device are allowed.
+        """
         if inputs is not None:
             if torch.is_tensor(inputs):
                 inputs = (inputs,)

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -50,15 +50,17 @@ class ExactGP(GP):
             if torch.is_tensor(inputs):
                 inputs = (inputs,)
             inputs = tuple(input_.unsqueeze(-1) if input_.ndimension() == 1 else input_ for input_ in inputs)
-            for input, t_input in zip(inputs, self.train_inputs):
-                for attr in {"shape", "dtype", "device"}:
-                    if strict and getattr(input, attr) != getattr(t_input, attr):
-                        raise RuntimeError("Cannot modify {attr} of inputs".format(attr=attr))
+            if strict:
+                for input, t_input in zip(inputs, self.train_inputs):
+                    for attr in {"shape", "dtype", "device"}:
+                        if getattr(input, attr) != getattr(t_input, attr):
+                            raise RuntimeError("Cannot modify {attr} of inputs".format(attr=attr))
             self.train_inputs = inputs
         if targets is not None:
-            for attr in {"shape", "dtype", "device"}:
-                if strict and getattr(targets, attr) != getattr(self.train_targets, attr):
-                    raise RuntimeError("Cannot modify {attr} of targets".format(attr=attr))
+            if strict:
+                for attr in {"shape", "dtype", "device"}:
+                    if getattr(targets, attr) != getattr(self.train_targets, attr):
+                        raise RuntimeError("Cannot modify {attr} of targets".format(attr=attr))
             self.train_targets = targets
         self.prediction_strategy = None
 

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -51,16 +51,24 @@ class ExactGP(GP):
                 inputs = (inputs,)
             inputs = tuple(input_.unsqueeze(-1) if input_.ndimension() == 1 else input_ for input_ in inputs)
             if strict:
-                for input, t_input in zip(inputs, self.train_inputs):
+                for input_, t_input in zip(inputs, self.train_inputs or (None,)):
                     for attr in {"shape", "dtype", "device"}:
-                        if getattr(input, attr) != getattr(t_input, attr):
-                            raise RuntimeError("Cannot modify {attr} of inputs".format(attr=attr))
+                        expected_attr = getattr(t_input, attr, None)
+                        found_attr = getattr(input_, attr, None)
+                        if expected_attr != found_attr:
+                            msg = "Cannot modify {attr} of inputs (expected {e_attr}, found {f_attr})."
+                            msg = msg.format(attr=attr, e_attr=expected_attr, f_attr=found_attr)
+                            raise RuntimeError(msg)
             self.train_inputs = inputs
         if targets is not None:
             if strict:
                 for attr in {"shape", "dtype", "device"}:
-                    if getattr(targets, attr) != getattr(self.train_targets, attr):
-                        raise RuntimeError("Cannot modify {attr} of targets".format(attr=attr))
+                    expected_attr = getattr(self.train_targets, attr, None)
+                    found_attr = getattr(targets, attr, None)
+                    if expected_attr != found_attr:
+                        msg = "Cannot modify {attr} of targets (expected {e_attr}, found {f_attr})."
+                        msg = msg.format(attr=attr, e_attr=expected_attr, f_attr=found_attr)
+                        raise RuntimeError(msg)
             self.train_targets = targets
         self.prediction_strategy = None
 


### PR DESCRIPTION
It appears valid for a GP to have its training inputs/labels set to `None`. However, if you call `set_train_data` when the current training inputs are `None`, you'll get an error at `for input, t_input in zip(inputs, self.train_inputs)` (because `None` is not iterable and thus can't be `zip`ped). This PR moves the check for `if strict` up so that, if `strict == False`, the entire checking section is skipped and it doesn't matter whether the training data was `None` or not.

When `strict == True`, the error messages have been improved a bit. Now they'll say both what the expected attribute (e.g. shape) was and what shape was found. To get a more informative error, I also ensured that if the training inputs/targets are `None`, the shape, etc. will be viewed as `None` so you'll still get the expected `RuntimeError` (instead of an error at `zip` that is harder to diagnose).

This passed `flake8` fine, and I think the only errors I got in the tests were for CUDA out of memory.