### PR TITLE
Detach train_train_covar for slow variance computation if requested.

### DIFF
--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -995,7 +995,11 @@ class LazyTensor(object):
 
     @property
     def requires_grad(self):
-        return any(arg.requires_grad for arg in tuple(self._args) + tuple(self._kwargs.values()))
+        return any(
+            arg.requires_grad
+            for arg in tuple(self._args) + tuple(self._kwargs.values())
+            if hasattr(arg, "requires_grad")
+        )
 
     @requires_grad.setter
     def requires_grad(self, val):


### PR DESCRIPTION
This fixes #554 by correctly detaching `train_train_covar` and ensuring that the pass through the likelihood happens in a `torch.no_grad` context if `gpytorch.settings.detach_test_caches` is on.

cc/ @Balandat @sdaulton 