### PR TITLE
CG Improvements

### DIFF
--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -292,8 +292,9 @@ class ExactGP(GP):
             test_test_covar = full_covar[..., num_train:, num_train:]
             test_train_covar = full_covar[..., num_train:, :num_train]
 
-            predictive_mean = self.prediction_strategy.exact_predictive_mean(test_mean, test_train_covar)
-            predictive_covar = self.prediction_strategy.exact_predictive_covar(test_test_covar, test_train_covar)
+            with settings._use_eval_tolerance():
+                predictive_mean = self.prediction_strategy.exact_predictive_mean(test_mean, test_train_covar)
+                predictive_covar = self.prediction_strategy.exact_predictive_covar(test_test_covar, test_train_covar)
 
             if num_tasks > 1:
                 if train_targets.ndimension() == 2:

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -284,21 +284,21 @@ class lazily_evaluate_kernels(_feature_flag):
 class max_cg_iterations(_value_context):
     """
     The maximum number of conjugate gradient iterations to perform (when computing
-    matrix solves). More values results in more accurate solves
-    Default: 20
+    matrix solves). A higher value rarely results in more accurate solves -- instead, lower the CG tolerance.
+    Default: 1000
     """
 
-    _global_value = 100
+    _global_value = 1000
 
 
 class cg_tolerance(_value_context):
     """
     Relative residual tolerance to use for terminating CG.
 
-    Default: 0.05
+    Default: 1
     """
 
-    _global_value = 0.05
+    _global_value = 1
 
 
 class preconditioner_tolerance(_value_context):

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -311,6 +311,20 @@ class preconditioner_tolerance(_value_context):
     _global_value = 1e-3
 
 
+class eval_cg_tolerance(_value_context):
+    """
+    Relative residual tolerance to use for terminating CG when making predictions.
+
+    Default: 0.01
+    """
+
+    _global_value = 0.01
+
+
+class _use_eval_tolerance(_feature_flag):
+    _state = False
+
+
 class max_cholesky_numel(_value_context):
     """
     If the number of elements of a LazyTensor is less than `max_cholesky_numel`,

--- a/gpytorch/utils/linear_cg.py
+++ b/gpytorch/utils/linear_cg.py
@@ -112,7 +112,10 @@ def linear_cg(
     if initial_guess is None:
         initial_guess = torch.zeros_like(rhs)
     if tolerance is None:
-        tolerance = settings.cg_tolerance.value()
+        if settings._use_eval_tolerance.on():
+            tolerance = settings.eval_cg_tolerance.value()
+        else:
+            tolerance = settings.cg_tolerance.value()
     if preconditioner is None:
         preconditioner = _default_preconditioner
         precond = False

--- a/gpytorch/utils/linear_cg.py
+++ b/gpytorch/utils/linear_cg.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import torch
+import warnings
 from .. import settings
 
 
@@ -192,6 +193,10 @@ def linear_cg(
 
     update_tridiag = True
     last_tridiag_iter = 0
+
+    # It's conceivable we reach the tolerance on the last iteration, so can't just check iteration number.
+    tolerance_reached = False
+
     # Start the iteration
     for k in range(n_iter):
         # Get next alpha
@@ -251,6 +256,7 @@ def linear_cg(
         torch.lt(residual_norm, stop_updating_after, out=has_converged)
 
         if k >= 10 and bool(residual_norm.mean() < tolerance) and not (n_tridiag and k < n_tridiag_iter):
+            tolerance_reached = True
             break
 
         # Update tridiagonal matrices, if applicable
@@ -279,6 +285,13 @@ def linear_cg(
 
     # Un-normalize
     result.mul_(rhs_norm)
+
+    if not tolerance_reached:
+        warnings.warn(
+            "CG terminated before reaching the tolerance specified by gpytorch.settings.cg_tolerance. If performance"
+            " is affected, consider raising the maximum number of CG iterations by running code in"
+            " a gpytorch.settings.max_cg_iterations(value) context."
+        )
 
     if is_vector:
         result = result.squeeze(-1)


### PR DESCRIPTION
This PR makes the following changes:

- Separate the CG tolerance used for predictions from the one used for training.
- Set CG tolerances for training and prediction based on performance using a battery of benchmark datasets.
- Increase the maximum number of CG iterations to 1000 so that we essentially never terminate due to reaching the maximum, which is not desirable.
- Linear CG now throws a warning whenever termination happened due to reaching the maximum number of iterations, and suggests a course of action (increasing it).

This had essentially 0 effect on the running times of our unit tests (<1s) compared to master, but should significantly improve the package's ability to automatically adjust to the poorly conditioned kernel matrix setting by spending more time where necessary. By separating the eval and train CG tolerances, we should see a performance improvement for training. Finally, the warning should help alert users to when model performance issues are likely due to numerical problems in core linear algebra routines, and how to debug the issue.