### PR TITLE
Dont apply active dims twice when doing lazy eval

### DIFF
--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -258,9 +258,12 @@ class LazyEvaluatedKernelTensor(LazyTensor):
             x2 = self.x2
 
         with settings.lazily_evaluate_kernels(False):
+            temp_active_dims = self.kernel.active_dims
+            self.kernel.active_dims = None
             res = self.kernel(
                 x1, x2, diag=False, batch_dims=self.batch_dims, **self.params
             )
+            self.kernel.active_dims = temp_active_dims
         if self.squeeze_row:
             res.squeeze_(-2)
         if self.squeeze_col:

--- a/test/kernels/_base_kernel_test_case.py
+++ b/test/kernels/_base_kernel_test_case.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+from abc import abstractmethod
+import torch
+
+
+class BaseKernelTestCase(object):
+    @abstractmethod
+    def create_kernel_no_ard(self, **kwargs):
+        raise NotImplementedError()
+
+    def test_active_dims_list(self):
+        kernel = self.create_kernel_no_ard(active_dims=[0, 2, 4, 6])
+        x = torch.randn(50, 10)
+        covar_mat = kernel(x).evaluate_kernel().evaluate()
+        kernel_basic = self.create_kernel_no_ard()
+        covar_mat_actual = kernel_basic(x[:, [0, 2, 4, 6]]).evaluate_kernel().evaluate()
+
+        self.assertLess(torch.norm(covar_mat - covar_mat_actual), 1e-5)
+
+    def test_active_dims_range(self):
+        active_dims = list(range(3, 9))
+        kernel = self.create_kernel_no_ard(active_dims=active_dims)
+        x = torch.randn(50, 10)
+        covar_mat = kernel(x).evaluate_kernel().evaluate()
+        kernel_basic = self.create_kernel_no_ard()
+        covar_mat_actual = kernel_basic(x[:, active_dims]).evaluate_kernel().evaluate()
+
+        self.assertLess(torch.norm(covar_mat - covar_mat_actual), 1e-5)

--- a/test/kernels/test_linear_kernel.py
+++ b/test/kernels/test_linear_kernel.py
@@ -3,9 +3,13 @@
 import torch
 import unittest
 from gpytorch.kernels import LinearKernel
+from test.kernels._base_kernel_test_case import BaseKernelTestCase
 
 
-class TestLinearKernel(unittest.TestCase):
+class TestLinearKernel(unittest.TestCase, BaseKernelTestCase):
+    def create_kernel_no_ard(self, **kwargs):
+        return LinearKernel(num_dimensions=10, **kwargs)
+
     def test_computes_linear_function_rectangular(self):
         a = torch.tensor([4, 2, 8], dtype=torch.float).view(3, 1)
         b = torch.tensor([0, 2, 1], dtype=torch.float).view(3, 1)

--- a/test/kernels/test_matern_kernel.py
+++ b/test/kernels/test_matern_kernel.py
@@ -4,9 +4,13 @@ import math
 import torch
 import unittest
 from gpytorch.kernels import MaternKernel
+from test.kernels._base_kernel_test_case import BaseKernelTestCase
 
 
-class TestMaternKernel(unittest.TestCase):
+class TestMaternKernel(unittest.TestCase, BaseKernelTestCase):
+    def create_kernel_no_ard(self, **kwargs):
+        return MaternKernel(nu=1.5, **kwargs)
+
     def test_forward_nu_1_over_2(self):
         a = torch.tensor([4, 2, 8], dtype=torch.float).view(3, 1)
         b = torch.tensor([0, 2], dtype=torch.float).view(2, 1)

--- a/test/kernels/test_rbf_kernel.py
+++ b/test/kernels/test_rbf_kernel.py
@@ -4,9 +4,13 @@ import math
 import torch
 import unittest
 from gpytorch.kernels import RBFKernel
+from test.kernels._base_kernel_test_case import BaseKernelTestCase
 
 
-class TestRBFKernel(unittest.TestCase):
+class TestRBFKernel(unittest.TestCase, BaseKernelTestCase):
+    def create_kernel_no_ard(self, **kwargs):
+        return RBFKernel(**kwargs)
+
     def test_ard(self):
         a = torch.tensor([[[1, 2], [2, 4]]], dtype=torch.float)
         b = torch.tensor([[[1, 3], [0, 4]]], dtype=torch.float)


### PR DESCRIPTION
Right now in certain cases we are trying to slice the data to restrict it to the `active_dims` argument twice for kernels: once when the kernel is first called, and again when the kernel is actually evaluated.

We should not do this.

Fixes #575 

cc/ @Duane321