### PR TITLE
Update readthedocs to use python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ matrix:
       addons:
         apt_packages:
           - pandoc
-      python: "3.5"
+      python: "3.6"
       install: pip install IPython ipykernel sphinx sphinx_rtd_theme nbsphinx m2r
       script: python setup.py build_sphinx

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,4 @@
+build:
+  image: latest
+python:
+  version: 3.6


### PR DESCRIPTION
I believe this is the minimal change necessary to get readthedocs to build on python 3.6. See http://blog.readthedocs.com/python-36-support/
