### PR TITLE
Use Cholesky for small inv_matmul calls

### DIFF
--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -794,6 +794,17 @@ class LazyTensor(ABC):
                     )
                 )
 
+        if self.size(-1) < settings.max_cholesky_numel.value() and left_tensor is None:
+            squeeze_res = False
+            if right_tensor.dim() == 1:
+                # torch.potrs doesn't let you run with vectors why
+                right_tensor = right_tensor.unsqueeze(-1)
+                squeeze_res = True
+            res = torch.potrs(right_tensor, self.evaluate().cholesky(), upper=False)
+            if squeeze_res:
+                res = res.squeeze(-1)
+            return res
+
         func = InvMatmul(
             self.representation_tree(),
             has_left=(left_tensor is not None),


### PR DESCRIPTION
This PR changes `LazyTensor.inv_matmul` to evaluate and use Cholesky by default for matrices less than the setting size (currently 256 by default).

Here's where I'm coming from:
- On the CPU with matrices this small, Cholesky is still a bit faster than CG.
- With this little data, a GPU is still slower than a CPU (up until around 300 data points in my testing).
- This PR is independent of @gpleiss's proposed `use_cholesky` flag that will be useful for debugging. I think this is just the right thing to do _by default_ in the very small data regime.
- We should try to use the best tool for any given linear algebra task.

For training where we don't need as low tolerances, CG actually is still faster than Cholesky even in this tiny data regime. This is why I changed `inv_matmul` and not `inv_quad_logdet`.