### PR TITLE
Implement parameter constraints, default noise lower bound

### DIFF
--- a/docs/source/constraints.rst
+++ b/docs/source/constraints.rst
@@ -1,0 +1,36 @@
+.. role:: hidden
+    :class: hidden-section
+
+gpytorch.means
+===================================
+
+.. automodule:: gpytorch.constraints
+.. currentmodule:: gpytorch.constraints
+
+
+Parameter Constraints
+-----------------------------
+
+:hidden:`Interval`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Interval
+   :members:
+
+:hidden:`GreaterThan`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: GreaterThan
+   :members:
+
+:hidden:`Positive`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Positive
+   :members:
+
+:hidden:`LessThan`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: LessThan
+   :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ GPyTorch's documentation
    kernels
    means
    marginal_log_likelihoods
+   constraints
    distributions
    priors
 

--- a/examples/05_Scalable_GP_Regression_Multidimensional/SVDKL_Regression_GridInterp_CUDA.ipynb
+++ b/examples/05_Scalable_GP_Regression_Multidimensional/SVDKL_Regression_GridInterp_CUDA.ipynb
@@ -153,8 +153,6 @@
     "from gpytorch.models import AbstractVariationalGP\n",
     "from gpytorch.variational import CholeskyVariationalDistribution, GridInterpolationVariationalStrategy\n",
     "\n",
-    "softplus = torch.functional.F.softplus\n",
-    "\n",
     "class GPRegressionLayer(AbstractVariationalGP):\n",
     "    def __init__(self, grid_size=32, grid_bounds=[(-1, 1), (-1, 1)]):\n",
     "        variational_distribution = CholeskyVariationalDistribution(num_inducing_points=grid_size*grid_size)\n",
@@ -164,9 +162,7 @@
     "                                                                    variational_distribution=variational_distribution)\n",
     "        super(GPRegressionLayer, self).__init__(variational_strategy)\n",
     "        self.mean_module = gpytorch.means.ConstantMean()\n",
-    "        self.covar_module = gpytorch.kernels.ScaleKernel(\n",
-    "            gpytorch.kernels.RBFKernel(param_transform=softplus), param_transform=softplus\n",
-    "        )\n",
+    "        self.covar_module = gpytorch.kernels.ScaleKernel(gpytorch.kernels.RBFKernel())\n",
     "\n",
     "    def forward(self, x):\n",
     "        mean_x = self.mean_module(x)\n",
@@ -206,7 +202,7 @@
     "        return res\n",
     "\n",
     "model = DKLModel(feature_extractor, num_features=num_features).cuda()\n",
-    "likelihood = gpytorch.likelihoods.GaussianLikelihood(param_transform=softplus).cuda()"
+    "likelihood = gpytorch.likelihoods.GaussianLikelihood().cuda()"
    ]
   },
   {
@@ -1589,7 +1585,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/examples/05_Scalable_GP_Regression_Multidimensional/SVDKL_Regression_SVGP_CUDA.ipynb
+++ b/examples/05_Scalable_GP_Regression_Multidimensional/SVDKL_Regression_SVGP_CUDA.ipynb
@@ -152,17 +152,13 @@
     "from gpytorch.variational import CholeskyVariationalDistribution\n",
     "from gpytorch.variational import WhitenedVariationalStrategy\n",
     "\n",
-    "softplus = torch.functional.F.softplus\n",
-    "\n",
     "class GPRegressionLayer(AbstractVariationalGP):\n",
     "    def __init__(self, inducing_points):\n",
     "        variational_distribution = CholeskyVariationalDistribution(inducing_points.size(0))\n",
     "        variational_strategy = WhitenedVariationalStrategy(self, inducing_points, variational_distribution, learn_inducing_locations=True)\n",
     "        super(GPRegressionLayer, self).__init__(variational_strategy)\n",
     "        self.mean_module = gpytorch.means.ConstantMean()\n",
-    "        self.covar_module = gpytorch.kernels.ScaleKernel(\n",
-    "            gpytorch.kernels.RBFKernel(param_transform=softplus), param_transform=softplus\n",
-    "        )\n",
+    "        self.covar_module = gpytorch.kernels.ScaleKernel(gpytorch.kernels.RBFKernel())\n",
     "        \n",
     "    def forward(self, x):\n",
     "        mean_x = self.mean_module(x)\n",
@@ -200,7 +196,7 @@
     "        return res\n",
     "inducing_points = feature_extractor(train_x[:500, :])\n",
     "model = DKLModel(inducing_points=inducing_points, feature_extractor=feature_extractor, num_features=num_features).cuda()\n",
-    "likelihood = gpytorch.likelihoods.GaussianLikelihood(param_transform=softplus).cuda()"
+    "likelihood = gpytorch.likelihoods.GaussianLikelihood().cuda()"
    ]
   },
   {
@@ -2456,7 +2452,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/gpytorch/constraints/__init__.py
+++ b/gpytorch/constraints/__init__.py
@@ -1,0 +1,8 @@
+from .constraints import GreaterThan, Interval, LessThan, Positive
+
+__all__ = [
+    "GreaterThan",
+    "Interval",
+    "LessThan",
+    "Positive",
+]

--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+import math
+import torch
+from torch.nn.functional import softplus, sigmoid
+from ..utils.transforms import _get_inv_param_transform
+from torch.nn import Module
+
+
+class Interval(Module):
+    def __init__(
+        self,
+        lower_bound,
+        upper_bound,
+        transform=sigmoid,
+        inv_transform=None,
+    ):
+        """
+        Defines an interval constraint for GP model parameters, specified by a lower bound and upper bound. For usage
+        details, see the documentation for :meth:`~gpytorch.module.Module.register_constraint`.
+
+        Args:
+            - lower_bound (float or torch.Tensor):
+        """
+        if upper_bound < math.inf and transform != sigmoid:
+            raise RuntimeError("Cannot enforce an upper bound with a non-sigmoid transform!")
+
+        super().__init__()
+
+        if not torch.is_tensor(lower_bound):
+            lower_bound = torch.tensor(lower_bound)
+
+        if not torch.is_tensor(upper_bound):
+            upper_bound = torch.tensor(upper_bound)
+
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+
+        self._transform = transform
+        if self.enforced and inv_transform is None:
+            self._inv_transform = _get_inv_param_transform(transform)
+
+    def _apply(self, fn):
+        self.lower_bound = fn(self.lower_bound)
+        self.upper_bound = fn(self.upper_bound)
+        return super()._apply(fn)
+
+    @property
+    def enforced(self):
+        return self._transform is not None
+
+    def intersect(self, other):
+        """
+        Returns a new Interval constraint that is the intersection of this one and another specified one.
+
+        Args:
+            other (Interval): Interval constraint to intersect with
+
+        Returns:
+            Interval: intersection if this interval with the other one.
+        """
+        if self.transform != other.transform:
+            raise RuntimeError("Cant intersect Interval constraints with conflicting transforms!")
+
+        lower_bound = torch.max(self.lower_bound, other.lower_bound)
+        upper_bound = torch.min(self.upper_bound, other.upper_bound)
+        return Interval(lower_bound, upper_bound)
+
+    def transform(self, tensor):
+        """
+        Transforms a tensor to satisfy the specified bounds.
+
+        If upper_bound is finite, we assume that `self.transform` saturates at 1 as tensor -> infinity. Similarly,
+        if lower_bound is finite, we assume that `self.transform` saturates at 0 as tensor -> -infinity.
+
+        Example transforms for one of the bounds being finite include torch.exp and torch.nn.functional.softplus.
+        An example transform for the case where both are finite is torch.nn.functional.sigmoid.
+        """
+        if not self.enforced:
+            return tensor
+
+        transformed_tensor = self._transform(tensor)
+
+        upper_bound = self.upper_bound.clone()
+        upper_bound[upper_bound == math.inf] = 1
+        lower_bound = self.lower_bound.clone()
+        lower_bound[lower_bound == -math.inf] = 0
+
+        transformed_tensor = transformed_tensor * upper_bound
+        transformed_tensor = transformed_tensor + lower_bound
+
+        return transformed_tensor
+
+    def inverse_transform(self, transformed_tensor):
+        """
+        Applies the inverse transformation.
+        """
+        if not self.enforced:
+            return transformed_tensor
+
+        upper_bound = self.upper_bound
+        upper_bound[upper_bound == math.inf] = 1
+        lower_bound = self.lower_bound
+        lower_bound[lower_bound == -math.inf] = 0
+
+        tensor = transformed_tensor - self.lower_bound
+        tensor = tensor / self.upper_bound
+
+        tensor = self._inv_transform(tensor)
+
+        return tensor
+
+
+class GreaterThan(Interval):
+    def __init__(
+        self,
+        lower_bound,
+        transform=softplus,
+        inv_transform=None,
+        active=True,
+    ):
+        super().__init__(
+            lower_bound=lower_bound,
+            upper_bound=math.inf,
+            transform=transform,
+            inv_transform=inv_transform
+        )
+
+
+class Positive(GreaterThan):
+    def __init__(self, transform=softplus, inv_transform=None):
+        super().__init__(
+            lower_bound=0.,
+            transform=transform,
+            inv_transform=inv_transform
+        )
+
+
+class LessThan(Interval):
+    def __init__(self, upper_bound, transform=softplus, inv_transform=None):
+        super().__init__(
+            lower_bound=-math.inf,
+            upper_bound=upper_bound,
+            transform=transform,
+            inv_transform=inv_transform
+        )
+
+    def transform(self, tensor):
+        if not self.enforced:
+            return tensor
+
+        transformed_tensor = -self.transform(-tensor)
+        transformed_tensor = transformed_tensor + self.upper_bound
+        return transformed_tensor
+
+    def inverse_transform(self, transformed_tensor):
+        if not self.enforced:
+            return transformed_tensor
+
+        tensor = transformed_tensor - self.upper_bound
+        tensor = -self._inv_transform(-tensor)
+        return tensor

--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -82,9 +82,9 @@ class Interval(Module):
         transformed_tensor = self._transform(tensor)
 
         upper_bound = self.upper_bound.clone()
-        upper_bound[upper_bound == math.inf] = 1
+        upper_bound[upper_bound == math.inf] = 1.
         lower_bound = self.lower_bound.clone()
-        lower_bound[lower_bound == -math.inf] = 0
+        lower_bound[lower_bound == -math.inf] = 0.
 
         transformed_tensor = transformed_tensor * upper_bound
         transformed_tensor = transformed_tensor + lower_bound

--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -15,7 +15,7 @@ class Interval(Module):
         details, see the documentation for :meth:`~gpytorch.module.Module.register_constraint`.
 
         Args:
-            - lower_bound (float or torch.Tensor):
+            lower_bound (float or torch.Tensor):
         """
         lower_bound = torch.as_tensor(lower_bound)
         upper_bound = torch.as_tensor(upper_bound)

--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -110,6 +110,16 @@ class Interval(Module):
 
         return tensor
 
+    def __repr__(self):
+        if self.lower_bound.numel() == 1 and self.upper_bound.numel() == 1:
+            return self._get_name() + f'({self.lower_bound}, {self.upper_bound})'
+        else:
+            return super().__repr__()
+
+    def __iter__(self):
+        yield self.lower_bound
+        yield self.upper_bound
+
 
 class GreaterThan(Interval):
     def __init__(
@@ -126,6 +136,12 @@ class GreaterThan(Interval):
             inv_transform=inv_transform
         )
 
+    def __repr__(self):
+        if self.lower_bound.numel() == 1:
+            return self._get_name() + f'({self.lower_bound})'
+        else:
+            return super().__repr__()
+
 
 class Positive(GreaterThan):
     def __init__(self, transform=softplus, inv_transform=None):
@@ -134,6 +150,9 @@ class Positive(GreaterThan):
             transform=transform,
             inv_transform=inv_transform
         )
+
+    def __repr__(self):
+        return self._get_name() + '()'
 
 
 class LessThan(Interval):
@@ -160,3 +179,6 @@ class LessThan(Interval):
         tensor = transformed_tensor - self.upper_bound
         tensor = -self._inv_transform(-tensor)
         return tensor
+
+    def __repr__(self):
+        return self._get_name() + f'({self.upper_bound})'

--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -3,18 +3,13 @@
 import math
 import torch
 from torch.nn.functional import softplus, sigmoid
-from ..utils.transforms import _get_inv_param_transform
+from ..utils.transforms import _get_inv_param_transform, inv_sigmoid, inv_softplus
 from torch.nn import Module
+from .. import settings
 
 
 class Interval(Module):
-    def __init__(
-        self,
-        lower_bound,
-        upper_bound,
-        transform=sigmoid,
-        inv_transform=None,
-    ):
+    def __init__(self, lower_bound, upper_bound, transform=sigmoid, inv_transform=inv_sigmoid):
         """
         Defines an interval constraint for GP model parameters, specified by a lower bound and upper bound. For usage
         details, see the documentation for :meth:`~gpytorch.module.Module.register_constraint`.
@@ -22,22 +17,21 @@ class Interval(Module):
         Args:
             - lower_bound (float or torch.Tensor):
         """
-        if upper_bound < math.inf and transform != sigmoid:
-            raise RuntimeError("Cannot enforce an upper bound with a non-sigmoid transform!")
+        lower_bound = torch.as_tensor(lower_bound)
+        upper_bound = torch.as_tensor(upper_bound)
+
+        if torch.any(lower_bound >= upper_bound):
+            raise RuntimeError("Got parameter bounds with empty intervals.")
 
         super().__init__()
-
-        if not torch.is_tensor(lower_bound):
-            lower_bound = torch.tensor(lower_bound)
-
-        if not torch.is_tensor(upper_bound):
-            upper_bound = torch.tensor(upper_bound)
 
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
 
         self._transform = transform
-        if self.enforced and inv_transform is None:
+        self._inv_transform = inv_transform
+
+        if transform is not None and inv_transform is None:
             self._inv_transform = _get_inv_param_transform(transform)
 
     def _apply(self, fn):
@@ -48,6 +42,9 @@ class Interval(Module):
     @property
     def enforced(self):
         return self._transform is not None
+
+    def check(self, tensor):
+        return torch.all(tensor <= self.upper_bound) and torch.all(tensor >= self.lower_bound)
 
     def intersect(self, other):
         """
@@ -79,15 +76,17 @@ class Interval(Module):
         if not self.enforced:
             return tensor
 
-        transformed_tensor = self._transform(tensor)
+        if settings.debug.on():
+            max_bound = torch.max(self.upper_bound)
+            min_bound = torch.min(self.lower_bound)
 
-        upper_bound = self.upper_bound.clone()
-        upper_bound[upper_bound == math.inf] = 1.
-        lower_bound = self.lower_bound.clone()
-        lower_bound[lower_bound == -math.inf] = 0.
+            if max_bound == math.inf or min_bound == -math.inf:
+                raise RuntimeError(
+                    "Cannot make an Interval directly with non-finite bounds. Use a derived class like "
+                    "GreaterThan or LessThan instead."
+                )
 
-        transformed_tensor = transformed_tensor * upper_bound
-        transformed_tensor = transformed_tensor + lower_bound
+        transformed_tensor = (self._transform(tensor) * self.upper_bound) + self.lower_bound
 
         return transformed_tensor
 
@@ -98,21 +97,23 @@ class Interval(Module):
         if not self.enforced:
             return transformed_tensor
 
-        upper_bound = self.upper_bound
-        upper_bound[upper_bound == math.inf] = 1
-        lower_bound = self.lower_bound
-        lower_bound[lower_bound == -math.inf] = 0
+        if settings.debug.on():
+            max_bound = torch.max(self.upper_bound)
+            min_bound = torch.min(self.lower_bound)
 
-        tensor = transformed_tensor - self.lower_bound
-        tensor = tensor / self.upper_bound
+            if max_bound == math.inf or min_bound == -math.inf:
+                raise RuntimeError(
+                    "Cannot make an Interval directly with non-finite bounds. Use a derived class like "
+                    "GreaterThan or LessThan instead."
+                )
 
-        tensor = self._inv_transform(tensor)
+        tensor = self._inv_transform((transformed_tensor - self.lower_bound) / self.upper_bound)
 
         return tensor
 
     def __repr__(self):
         if self.lower_bound.numel() == 1 and self.upper_bound.numel() == 1:
-            return self._get_name() + f'({self.lower_bound}, {self.upper_bound})'
+            return self._get_name() + f"({self.lower_bound}, {self.upper_bound})"
         else:
             return super().__repr__()
 
@@ -122,63 +123,55 @@ class Interval(Module):
 
 
 class GreaterThan(Interval):
-    def __init__(
-        self,
-        lower_bound,
-        transform=softplus,
-        inv_transform=None,
-        active=True,
-    ):
+    def __init__(self, lower_bound, transform=softplus, inv_transform=inv_softplus):
         super().__init__(
-            lower_bound=lower_bound,
-            upper_bound=math.inf,
-            transform=transform,
-            inv_transform=inv_transform
+            lower_bound=lower_bound, upper_bound=math.inf, transform=transform, inv_transform=inv_transform
         )
 
     def __repr__(self):
         if self.lower_bound.numel() == 1:
-            return self._get_name() + f'({self.lower_bound})'
+            return self._get_name() + f"({self.lower_bound})"
         else:
             return super().__repr__()
 
-
-class Positive(GreaterThan):
-    def __init__(self, transform=softplus, inv_transform=None):
-        super().__init__(
-            lower_bound=0.,
-            transform=transform,
-            inv_transform=inv_transform
-        )
-
-    def __repr__(self):
-        return self._get_name() + '()'
-
-
-class LessThan(Interval):
-    def __init__(self, upper_bound, transform=softplus, inv_transform=None):
-        super().__init__(
-            lower_bound=-math.inf,
-            upper_bound=upper_bound,
-            transform=transform,
-            inv_transform=inv_transform
-        )
-
     def transform(self, tensor):
-        if not self.enforced:
-            return tensor
-
-        transformed_tensor = -self.transform(-tensor)
-        transformed_tensor = transformed_tensor + self.upper_bound
+        transformed_tensor = self._transform(tensor) + self.lower_bound if self.enforced else tensor
         return transformed_tensor
 
     def inverse_transform(self, transformed_tensor):
-        if not self.enforced:
-            return transformed_tensor
+        tensor = self._inv_transform(transformed_tensor - self.lower_bound) if self.enforced else transformed_tensor
+        return tensor
 
-        tensor = transformed_tensor - self.upper_bound
-        tensor = -self._inv_transform(-tensor)
+
+class Positive(GreaterThan):
+    def __init__(self, transform=softplus, inv_transform=inv_softplus):
+        super().__init__(lower_bound=0.0, transform=transform, inv_transform=inv_transform)
+
+    def __repr__(self):
+        return self._get_name() + "()"
+
+    def transform(self, tensor):
+        transformed_tensor = self._transform(tensor) if self.enforced else tensor
+        return transformed_tensor
+
+    def inverse_transform(self, transformed_tensor):
+        tensor = self._inv_transform(transformed_tensor) if self.enforced else transformed_tensor
+        return tensor
+
+
+class LessThan(Interval):
+    def __init__(self, upper_bound, transform=softplus, inv_transform=inv_softplus):
+        super().__init__(
+            lower_bound=-math.inf, upper_bound=upper_bound, transform=transform, inv_transform=inv_transform
+        )
+
+    def transform(self, tensor):
+        transformed_tensor = -self._transform(-tensor) + self.upper_bound if self.enforced else tensor
+        return transformed_tensor
+
+    def inverse_transform(self, transformed_tensor):
+        tensor = -self._inv_transform(-(transformed_tensor - self.upper_bound)) if self.enforced else transformed_tensor
         return tensor
 
     def __repr__(self):
-        return self._get_name() + f'({self.upper_bound})'
+        return self._get_name() + f"({self.upper_bound})"

--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -113,7 +113,7 @@ class Interval(Module):
 
     def __repr__(self):
         if self.lower_bound.numel() == 1 and self.upper_bound.numel() == 1:
-            return self._get_name() + f"({self.lower_bound}, {self.upper_bound})"
+            return self._get_name() + f"({self.lower_bound:.3E}, {self.upper_bound:.3E})"
         else:
             return super().__repr__()
 
@@ -130,7 +130,7 @@ class GreaterThan(Interval):
 
     def __repr__(self):
         if self.lower_bound.numel() == 1:
-            return self._get_name() + f"({self.lower_bound})"
+            return self._get_name() + f"({self.lower_bound:.3E})"
         else:
             return super().__repr__()
 
@@ -174,4 +174,4 @@ class LessThan(Interval):
         return tensor
 
     def __repr__(self):
-        return self._get_name() + f"({self.upper_bound})"
+        return self._get_name() + f"({self.upper_bound:.3E})"

--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -20,7 +20,7 @@ class Interval(Module):
         lower_bound = torch.as_tensor(lower_bound)
         upper_bound = torch.as_tensor(upper_bound)
 
-        if torch.any(lower_bound >= upper_bound):
+        if torch.any(torch.ge(lower_bound, upper_bound)):
             raise RuntimeError("Got parameter bounds with empty intervals.")
 
         super().__init__()

--- a/gpytorch/kernels/cosine_kernel.py
+++ b/gpytorch/kernels/cosine_kernel.py
@@ -67,11 +67,11 @@ class CosineKernel(Kernel):
                 lambda v: self._set_period_length(v),
             )
 
-        self.register_constraint("period_length_constraint", period_length_constraint)
+        self.register_constraint("raw_period_length", period_length_constraint)
 
     @property
     def period_length(self):
-        return self.period_length_constraint.transform(self.raw_period_length)
+        return self.raw_period_length_constraint.transform(self.raw_period_length)
 
     @period_length.setter
     def period_length(self, value):
@@ -81,7 +81,7 @@ class CosineKernel(Kernel):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
 
-        self.initialize(raw_period_length=self.period_length_constraint.inverse_transform(value))
+        self.initialize(raw_period_length=self.raw_period_length_constraint.inverse_transform(value))
 
     def forward(self, x1, x2, **params):
         x1_ = x1.div(self.period_length)

--- a/gpytorch/kernels/cosine_kernel.py
+++ b/gpytorch/kernels/cosine_kernel.py
@@ -52,12 +52,15 @@ class CosineKernel(Kernel):
         >>> covar = covar_module(x)  # Output: LazyVariable of size (2 x 10 x 10)
     """
 
-    def __init__(self, period_length_prior=None, period_length_constraint=Positive(), **kwargs):
+    def __init__(self, period_length_prior=None, period_length_constraint=None, **kwargs):
         super(CosineKernel, self).__init__(**kwargs)
 
         self.register_parameter(
             name="raw_period_length", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, 1))
         )
+
+        if period_length_constraint is None:
+            period_length_constraint = Positive()
 
         if period_length_prior is not None:
             self.register_prior(

--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -44,12 +44,15 @@ class IndexKernel(Kernel):
         num_tasks,
         rank=1,
         prior=None,
-        var_constraint=Positive(),
+        var_constraint=None,
         **kwargs
     ):
         if rank > num_tasks:
             raise RuntimeError("Cannot create a task covariance matrix larger than the number of tasks")
         super().__init__(**kwargs)
+
+        if var_constraint is None:
+            var_constraint = Positive()
 
         self.register_parameter(
             name="covar_factor", parameter=torch.nn.Parameter(torch.randn(*self.batch_shape, num_tasks, rank))

--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -58,18 +58,18 @@ class IndexKernel(Kernel):
         if prior is not None:
             self.register_prior("IndexKernelPrior", prior, self._eval_covar_matrix)
 
-        self.register_constraint("var_constraint", var_constraint)
+        self.register_constraint("raw_var", var_constraint)
 
     @property
     def var(self):
-        return self.var_constraint.transform(self.raw_var)
+        return self.raw_var_constraint.transform(self.raw_var)
 
     @var.setter
     def var(self, value):
         self._set_var(value)
 
     def _set_var(self, value):
-        self.initialize(raw_var=self.var_constraint.inverse_transform(value))
+        self.initialize(raw_var=self.raw_var_constraint.inverse_transform(value))
 
     def _eval_covar_matrix(self):
         var = self.var

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -131,7 +131,7 @@ class Kernel(Module):
         batch_shape=torch.Size([1]),
         active_dims=None,
         lengthscale_prior=None,
-        lengthscale_constraint=Positive(),
+        lengthscale_constraint=None,
         eps=1e-6,
         **kwargs
     ):
@@ -149,6 +149,9 @@ class Kernel(Module):
         self.eps = eps
 
         param_transform = kwargs.get("param_transform")
+
+        if lengthscale_constraint is None:
+            lengthscale_constraint = Positive()
 
         if param_transform is not None:
             warnings.warn("The 'param_transform' argument is now deprecated. If you want to use a different "

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -155,7 +155,7 @@ class Kernel(Module):
 
         if param_transform is not None:
             warnings.warn("The 'param_transform' argument is now deprecated. If you want to use a different "
-                          "transformaton, specify a different 'lengthscale_constraint' instead.")
+                          "transformation, specify a different 'lengthscale_constraint' instead.")
 
         if has_lengthscale:
             lengthscale_num_dims = 1 if ard_num_dims is None else ard_num_dims

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -132,8 +132,6 @@ class Kernel(Module):
         active_dims=None,
         lengthscale_prior=None,
         lengthscale_constraint=Positive(),
-        param_transform=None,
-        inv_param_transform=None,
         eps=1e-6,
         **kwargs
     ):
@@ -149,6 +147,8 @@ class Kernel(Module):
 
         self.__has_lengthscale = has_lengthscale
         self.eps = eps
+
+        param_transform = kwargs.get("param_transform")
 
         if param_transform is not None:
             warnings.warn("The 'param_transform' argument is now deprecated. If you want to use a different "

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -165,7 +165,7 @@ class Kernel(Module):
                     "lengthscale_prior", lengthscale_prior, lambda: self.lengthscale, lambda v: self._set_lengthscale(v)
                 )
 
-            self.register_constraint("lengthscale_constraint", lengthscale_constraint)
+            self.register_constraint("raw_lengthscale", lengthscale_constraint)
 
         self.distance_module = None
         # TODO: Remove this on next official PyTorch release.
@@ -187,7 +187,7 @@ class Kernel(Module):
     @property
     def lengthscale(self):
         if self.has_lengthscale:
-            return self.lengthscale_constraint.transform(self.raw_lengthscale)
+            return self.raw_lengthscale_constraint.transform(self.raw_lengthscale)
         else:
             return None
 
@@ -202,7 +202,7 @@ class Kernel(Module):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
 
-        self.initialize(raw_lengthscale=self.lengthscale_constraint.inverse_transform(value))
+        self.initialize(raw_lengthscale=self.raw_lengthscale_constraint.inverse_transform(value))
 
     def size(self, x1, x2):
         expected_size = broadcasting._matmul_broadcast_shape(

--- a/gpytorch/kernels/linear_kernel.py
+++ b/gpytorch/kernels/linear_kernel.py
@@ -4,6 +4,7 @@ import torch
 import warnings
 from .kernel import Kernel
 from ..lazy import MatmulLazyTensor, RootLazyTensor
+from ..constraints import Positive
 
 
 class LinearKernel(Kernel):
@@ -34,12 +35,21 @@ class LinearKernel(Kernel):
     Args:
         :attr:`variance_prior` (:class:`gpytorch.priors.Prior`):
             Prior over the variance parameter (default `None`).
+        :attr:`variance_constraint` (Constraint, optional):
+            Constraint to place on variance parameter. Default: `Positive`.
         :attr:`active_dims` (list):
             List of data dimensions to operate on.
             `len(active_dims)` should equal `num_dimensions`.
     """
 
-    def __init__(self, num_dimensions=None, offset_prior=None, variance_prior=None, **kwargs):
+    def __init__(
+        self,
+        num_dimensions=None,
+        offset_prior=None,
+        variance_prior=None,
+        variance_constraint=Positive(),
+        **kwargs
+    ):
         super(LinearKernel, self).__init__(**kwargs)
         if num_dimensions is not None:
             warnings.warn(
@@ -66,9 +76,11 @@ class LinearKernel(Kernel):
                 lambda v: self._set_variance(v)
             )
 
+        self.register_constraint("variance_constraint", variance_constraint)
+
     @property
     def variance(self):
-        return self._param_transform(self.raw_variance)
+        return self.variance_constraint.transform(self.raw_variance)
 
     @variance.setter
     def variance(self, value):
@@ -77,7 +89,7 @@ class LinearKernel(Kernel):
     def _set_variance(self, value):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
-        self.initialize(raw_variance=self._inv_param_transform(value))
+        self.initialize(raw_variance=self.variance_constraint.inverse_transform(value))
 
     def forward(self, x1, x2, diag=False, batch_dims=None, **params):
         x1_ = x1 * self.variance.sqrt()

--- a/gpytorch/kernels/linear_kernel.py
+++ b/gpytorch/kernels/linear_kernel.py
@@ -76,11 +76,11 @@ class LinearKernel(Kernel):
                 lambda v: self._set_variance(v)
             )
 
-        self.register_constraint("variance_constraint", variance_constraint)
+        self.register_constraint("raw_variance", variance_constraint)
 
     @property
     def variance(self):
-        return self.variance_constraint.transform(self.raw_variance)
+        return self.raw_variance_constraint.transform(self.raw_variance)
 
     @variance.setter
     def variance(self, value):
@@ -89,7 +89,7 @@ class LinearKernel(Kernel):
     def _set_variance(self, value):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
-        self.initialize(raw_variance=self.variance_constraint.inverse_transform(value))
+        self.initialize(raw_variance=self.raw_variance_constraint.inverse_transform(value))
 
     def forward(self, x1, x2, diag=False, batch_dims=None, **params):
         x1_ = x1 * self.variance.sqrt()

--- a/gpytorch/kernels/linear_kernel.py
+++ b/gpytorch/kernels/linear_kernel.py
@@ -47,10 +47,13 @@ class LinearKernel(Kernel):
         num_dimensions=None,
         offset_prior=None,
         variance_prior=None,
-        variance_constraint=Positive(),
+        variance_constraint=None,
         **kwargs
     ):
         super(LinearKernel, self).__init__(**kwargs)
+        if variance_constraint is None:
+            variance_constraint = Positive()
+
         if num_dimensions is not None:
             warnings.warn(
                 "The `num_dimensions` argument is deprecated and no longer used.",

--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -47,14 +47,10 @@ class MaternKernel(Kernel):
             Set this if you want to
             compute the covariance of only a few input dimensions. The ints
             corresponds to the indices of the dimensions. Default: `None`.
-        :attr:`log_lengthscale_prior` (Prior, optional):
-            Set this if you want
-            to apply a prior to the lengthscale parameter.  Default: `None`
-        :attr:`param_transform` (function, optional):
-            Set this if you want to use something other than softplus to ensure positiveness of parameters.
-        :attr:`inv_param_transform` (function, optional):
-            Set this to allow setting parameters directly in transformed space and sampling from priors.
-            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
+        :attr:`lengthscale_prior` (Prior, optional):
+            Set this if you want to apply a prior to the lengthscale parameter.  Default: `None`
+        :attr:`lengthscale_constraint` (Constraint, optional):
+            Set this if you want to apply a constraint to the lengthscale parameter. Default: `Positive`.
         :attr:`eps` (float):
             The minimum value that the lengthscale can take (prevents divide by zero errors). Default: `1e-6`.
 

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -84,11 +84,11 @@ class PeriodicKernel(Kernel):
                 lambda v: self._set_period_length(v),
             )
 
-        self.register_constraint("period_length_constraint", period_length_constraint)
+        self.register_constraint("raw_period_length", period_length_constraint)
 
     @property
     def period_length(self):
-        return self.period_length_constraint.transform(self.raw_period_length)
+        return self.raw_period_length_constraint.transform(self.raw_period_length)
 
     @period_length.setter
     def period_length(self, value):
@@ -97,7 +97,7 @@ class PeriodicKernel(Kernel):
     def _set_period_length(self, value):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
-        self.initialize(raw_period_length=self.period_length_constraint.inverse_transform(value))
+        self.initialize(raw_period_length=self.raw_period_length_constraint.inverse_transform(value))
 
     def forward(self, x1, x2, **params):
         x1_ = x1.div(self.period_length)

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -70,8 +70,11 @@ class PeriodicKernel(Kernel):
         >>> covar = covar_module(x)  # Output: LazyVariable of size (2 x 10 x 10)
     """
 
-    def __init__(self, period_length_prior=None, period_length_constraint=Positive(), **kwargs):
+    def __init__(self, period_length_prior=None, period_length_constraint=None, **kwargs):
         super(PeriodicKernel, self).__init__(has_lengthscale=True, **kwargs)
+        if period_length_constraint is None:
+            period_length_constraint = Positive()
+
         self.register_parameter(
             name="raw_period_length",
             parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, 1)))

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -42,11 +42,8 @@ class RBFKernel(Kernel):
             corresponds to the indices of the dimensions. Default: `None`.
         :attr:`lengthscale_prior` (Prior, optional):
             Set this if you want to apply a prior to the lengthscale parameter.  Default: `None`.
-        :attr:`param_transform` (function, optional):
-            Set this if you want to use something other than softplus to ensure positiveness of parameters.
-        :attr:`inv_param_transform` (function, optional):
-            Set this to allow setting parameters directly in transformed space and sampling from priors.
-            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
+        :attr:`lengthscale_constraint` (Constraint, optional):
+            Set this if you want to apply a constraint to the lengthscale parameter. Default: `Positive`.
         :attr:`eps` (float):
             The minimum value that the lengthscale can take (prevents divide by zero errors). Default: `1e-6`.
 

--- a/gpytorch/kernels/rbf_kernel_grad.py
+++ b/gpytorch/kernels/rbf_kernel_grad.py
@@ -26,11 +26,8 @@ class RBFKernelGrad(RBFKernel):
             corresponds to the indices of the dimensions. Default: `None`.
         :attr:`lengthscale_prior` (Prior, optional):
             Set this if you want to apply a prior to the lengthscale parameter.  Default: `None`.
-        :attr:`param_transform` (function, optional):
-            Set this if you want to use something other than softplus to ensure positiveness of parameters.
-        :attr:`inv_param_transform` (function, optional):
-            Set this to allow setting parameters directly in transformed space and sampling from priors.
-            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
+        :attr:`lengthscale_constraint` (Constraint, optional):
+            Set this if you want to apply a constraint to the lengthscale parameter. Default: `Positive`.
         :attr:`eps` (float):
             The minimum value that the lengthscale can take (prevents divide by zero errors). Default: `1e-6`.
 

--- a/gpytorch/kernels/scale_kernel.py
+++ b/gpytorch/kernels/scale_kernel.py
@@ -59,12 +59,11 @@ class ScaleKernel(Kernel):
                 "outputscale_prior", outputscale_prior, lambda: self.outputscale, lambda v: self._set_outputscale(v)
             )
 
-        self.register_constraint("outputscale_constraint", outputscale_constraint)
+        self.register_constraint("raw_outputscale", outputscale_constraint)
 
     @property
     def outputscale(self):
-        constraint = self._constraints["outputscale_constraint"]
-        return constraint.transform(self.raw_outputscale)
+        return self.raw_outputscale_constraint.transform(self.raw_outputscale)
 
     @outputscale.setter
     def outputscale(self, value):
@@ -73,8 +72,7 @@ class ScaleKernel(Kernel):
     def _set_outputscale(self, value):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
-        constraint = self._constraints["outputscale_constraint"]
-        self.initialize(raw_outputscale=constraint.inverse_transform(value))
+        self.initialize(raw_outputscale=self.raw_outputscale_constraint.inverse_transform(value))
 
     def forward(self, x1, x2, batch_dims=None, diag=False, **params):
         outputscales = self.outputscale

--- a/gpytorch/kernels/scale_kernel.py
+++ b/gpytorch/kernels/scale_kernel.py
@@ -50,8 +50,11 @@ class ScaleKernel(Kernel):
         >>> covar = scaled_covar_module(x)  # Output: LazyTensor of size (10 x 10)
     """
 
-    def __init__(self, base_kernel, outputscale_prior=None, outputscale_constraint=Positive(), **kwargs):
+    def __init__(self, base_kernel, outputscale_prior=None, outputscale_constraint=None, **kwargs):
         super(ScaleKernel, self).__init__(has_lengthscale=False, **kwargs)
+        if outputscale_constraint is None:
+            outputscale_constraint = Positive()
+
         self.base_kernel = base_kernel
         self.register_parameter(name="raw_outputscale", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape)))
         if outputscale_prior is not None:

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -4,6 +4,7 @@ import logging
 import math
 import torch
 from .kernel import Kernel
+from ..constraints import Positive
 
 logger = logging.getLogger()
 
@@ -34,11 +35,6 @@ class SpectralMixtureKernel(Kernel):
         :attr:`active_dims` (tuple of ints, optional):
             Set this if you want to compute the covariance of only a few input dimensions. The ints
             corresponds to the indices of the dimensions. Default: `None`.
-        :attr:`param_transform` (function, optional):
-            Set this if you want to use something other than softplus to ensure positiveness of parameters.
-        :attr:`inv_param_transform` (function, optional):
-            Set this to allow setting parameters directly in transformed space and sampling from priors.
-            Automatically inferred for common transformations such as torch.exp or torch.nn.functional.softplus.
         :attr:`eps` (float):
             The minimum value that the lengthscale can take (prevents divide by zero errors). Default: `1e-6`.
 
@@ -72,8 +68,11 @@ class SpectralMixtureKernel(Kernel):
         ard_num_dims=1,
         batch_shape=torch.Size([1]),
         mixture_scales_prior=None,
+        mixture_scales_constraint=Positive(),
         mixture_means_prior=None,
+        mixture_means_constraint=Positive(),
         mixture_weights_prior=None,
+        mixture_weights_constraint=Positive(),
         **kwargs
     ):
         if num_mixtures is None:
@@ -95,9 +94,13 @@ class SpectralMixtureKernel(Kernel):
         self.register_parameter(name="raw_mixture_means", parameter=torch.nn.Parameter(torch.zeros(ms_shape)))
         self.register_parameter(name="raw_mixture_scales", parameter=torch.nn.Parameter(torch.zeros(ms_shape)))
 
+        self.register_constraint("mixture_scales_constraint", mixture_scales_constraint)
+        self.register_constraint("mixture_means_constraint", mixture_means_constraint)
+        self.register_constraint("mixture_weights_constraint", mixture_weights_constraint)
+
     @property
     def mixture_scales(self):
-        return self._param_transform(self.raw_mixture_scales).clamp(self.eps, 1e5)
+        return self.mixture_scales_constraint.transform(self.raw_mixture_scales)
 
     @mixture_scales.setter
     def mixture_scales(self, value):
@@ -106,11 +109,11 @@ class SpectralMixtureKernel(Kernel):
     def _set_mixture_scales(self, value):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
-        self.initialize(raw_mixture_scales=self._inv_param_transform(value))
+        self.initialize(raw_mixture_scales=self.mixture_scales_constraint.inverse_transform(value))
 
     @property
     def mixture_means(self):
-        return self._param_transform(self.raw_mixture_means).clamp(self.eps, 1e5)
+        return self.mixture_means_constraint.transform(self.raw_mixture_means)
 
     @mixture_means.setter
     def mixture_means(self, value):
@@ -119,11 +122,11 @@ class SpectralMixtureKernel(Kernel):
     def _set_mixture_means(self, value):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
-        self.initialize(raw_mixture_means=self._inv_param_transform(value))
+        self.initialize(raw_mixture_means=self.mixture_means_constraint.inverse_transform(value))
 
     @property
     def mixture_weights(self):
-        return self._param_transform(self.raw_mixture_weights).clamp(self.eps, 1e5)
+        return self.mixture_weights_constraint.transform(self.raw_mixture_weights)
 
     @mixture_weights.setter
     def mixture_weights(self, value):
@@ -132,7 +135,7 @@ class SpectralMixtureKernel(Kernel):
     def _set_mixture_weights(self, value):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
-        self.initialize(raw_mixture_weights=self._inv_param_transform(value))
+        self.initialize(raw_mixture_weights=self.mixture_weights_constraint.inverse_transform(value))
 
     def initialize_from_data(self, train_x, train_y, **kwargs):
         if not torch.is_tensor(train_x) or not torch.is_tensor(train_y):
@@ -151,13 +154,13 @@ class SpectralMixtureKernel(Kernel):
 
         # Inverse of lengthscales should be drawn from truncated Gaussian | N(0, max_dist^2) |
         self.raw_mixture_scales.data.normal_().mul_(max_dist).abs_().pow_(-1)
-        self.raw_mixture_scales.data = self._inv_param_transform(self.raw_mixture_scales.data)
+        self.raw_mixture_scales.data = self.mixture_scales_constraint.inverse_transform(self.raw_mixture_scales.data)
         # Draw means from Unif(0, 0.5 / minimum distance between two points)
         self.raw_mixture_means.data.uniform_().mul_(0.5).div_(min_dist)
-        self.raw_mixture_means.data = self._inv_param_transform(self.raw_mixture_means.data)
+        self.raw_mixture_means.data = self.mixture_means_constraint.inverse_transform(self.raw_mixture_means.data)
         # Mixture weights should be roughly the stdv of the y values divided by the number of mixtures
         self.raw_mixture_weights.data.fill_(train_y.std() / self.num_mixtures)
-        self.raw_mixture_weights.data = self._inv_param_transform(self.raw_mixture_weights.data)
+        self.raw_mixture_weights.data = self.mixture_weights_constraint.inverse_transform(self.raw_mixture_weights.data)
 
     def _create_input_grid(self, x1, x2, diag=False, batch_dims=None, **params):
         """

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -243,6 +243,6 @@ class SpectralMixtureKernel(Kernel):
         # Sum over mixtures
         mixture_weights = self.mixture_weights
         while mixture_weights.dim() < res.dim():
-            mixture_weights.unsqueeze_(-1)
+            mixture_weights = mixture_weights.unsqueeze(-1)
         res = (res * mixture_weights).sum(1)
         return res

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -69,11 +69,11 @@ class SpectralMixtureKernel(Kernel):
         ard_num_dims=1,
         batch_shape=torch.Size([1]),
         mixture_scales_prior=None,
-        mixture_scales_constraint=Positive(),
+        mixture_scales_constraint=None,
         mixture_means_prior=None,
-        mixture_means_constraint=Positive(),
+        mixture_means_constraint=None,
         mixture_weights_prior=None,
-        mixture_weights_constraint=Positive(),
+        mixture_weights_constraint=None,
         **kwargs
     ):
         if num_mixtures is None:
@@ -87,6 +87,15 @@ class SpectralMixtureKernel(Kernel):
         # This kernel does not use the default lengthscale
         super(SpectralMixtureKernel, self).__init__(ard_num_dims=ard_num_dims, batch_shape=batch_shape, **kwargs)
         self.num_mixtures = num_mixtures
+
+        if mixture_scales_constraint is None:
+            mixture_scales_constraint = Positive()
+
+        if mixture_means_constraint is None:
+            mixture_means_constraint = Positive()
+
+        if mixture_weights_constraint is None:
+            mixture_weights_constraint = Positive()
 
         self.register_parameter(
             name="raw_mixture_weights", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, self.num_mixtures))

--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -6,7 +6,7 @@ import warnings
 from .. import settings
 from ..likelihoods import Likelihood
 from ..distributions import base_distributions
-from ..constraints import Positive
+from ..constraints import GreaterThan
 from .noise_models import HomoskedasticNoise
 
 
@@ -42,7 +42,7 @@ class _GaussianLikelihoodBase(Likelihood):
 
 
 class GaussianLikelihood(_GaussianLikelihoodBase):
-    def __init__(self, noise_prior=None, noise_constraint=Positive(), batch_size=1, **kwargs):
+    def __init__(self, noise_prior=None, noise_constraint=GreaterThan(1e-4), batch_size=1, **kwargs):
         noise_covar = HomoskedasticNoise(
             noise_prior=noise_prior,
             noise_constraint=noise_constraint,

--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -6,7 +6,6 @@ import warnings
 from .. import settings
 from ..likelihoods import Likelihood
 from ..distributions import base_distributions
-from ..constraints import GreaterThan
 from .noise_models import HomoskedasticNoise
 
 
@@ -43,7 +42,7 @@ class _GaussianLikelihoodBase(Likelihood):
 
 
 class GaussianLikelihood(_GaussianLikelihoodBase):
-    def __init__(self, noise_prior=None, noise_constraint=GreaterThan(1e-4), batch_size=1, **kwargs):
+    def __init__(self, noise_prior=None, noise_constraint=None, batch_size=1, **kwargs):
         noise_covar = HomoskedasticNoise(
             noise_prior=noise_prior,
             noise_constraint=noise_constraint,

--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -13,8 +13,9 @@ from .noise_models import HomoskedasticNoise
 class _GaussianLikelihoodBase(Likelihood):
     """Base class for Gaussian Likelihoods, supporting general heteroskedastic noise models. """
 
-    def __init__(self, noise_covar, param_transform=None, inv_param_transform=None, **kwargs):
+    def __init__(self, noise_covar, **kwargs):
         super().__init__()
+        param_transform = kwargs.get("param_transform")
         if param_transform is not None:
             warnings.warn("The 'param_transform' argument is now deprecated. If you want to use a different "
                           "transformaton, specify a different 'lengthscale_constraint' instead.")

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -4,7 +4,7 @@ import torch
 import warnings
 
 from .. import settings
-from ..constraints import Positive
+from ..constraints import GreaterThan
 from ..functions import add_diag
 from ..lazy import (
     lazify,
@@ -137,7 +137,7 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
         task_correlation_prior=None,
         batch_size=1,
         noise_prior=None,
-        noise_constraint=Positive(),
+        noise_constraint=GreaterThan(1e-4),
         **kwargs
     ):
         """
@@ -160,6 +160,7 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
         super().__init__(
             num_tasks=num_tasks,
             noise_covar=noise_covar,
+            noise_constraint=GreaterThan(1e-4),
             rank=rank,
             task_correlation_prior=task_correlation_prior,
             batch_size=batch_size,
@@ -167,7 +168,7 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
         )
 
         self.register_parameter(name="raw_noise", parameter=torch.nn.Parameter(torch.zeros(batch_size, 1)))
-        self.register_constraint("noise_constraint", Positive())
+        self.register_constraint("noise_constraint", noise_constraint)
 
     @property
     def noise(self):
@@ -212,7 +213,7 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
         task_prior=None,
         batch_size=1,
         noise_prior=None,
-        noise_constraint=Positive(),
+        noise_constraint=GreaterThan(1e-4),
         **kwargs
     ):
         """

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 import torch
-from torch.nn.functional import softplus
+import warnings
 
 from .. import settings
+from ..constraints import Positive
 from ..functions import add_diag
 from ..lazy import (
     lazify,
@@ -14,14 +15,23 @@ from ..lazy import (
     RootLazyTensor,
 )
 from ..likelihoods import Likelihood, _GaussianLikelihoodBase
-from ..utils.transforms import _get_inv_param_transform
 from .noise_models import MultitaskHomoskedasticNoise
 
 
 class _MultitaskGaussianLikelihoodBase(_GaussianLikelihoodBase):
     """Base class for multi-task Gaussian Likelihoods, supporting general heteroskedastic noise models. """
 
-    def __init__(self, num_tasks, noise_covar, rank=0, task_correlation_prior=None, batch_size=1):
+    def __init__(
+        self,
+        num_tasks,
+        noise_covar,
+        rank=0,
+        task_correlation_prior=None,
+        batch_size=1,
+        param_transform=None,
+        inv_param_transform=None,
+        **kwargs,
+    ):
         """
         Args:
             num_tasks (int):
@@ -37,6 +47,10 @@ class _MultitaskGaussianLikelihoodBase(_GaussianLikelihoodBase):
             batch_size (int):
                 Number of batches.
         """
+        if param_transform is not None:
+            warnings.warn("The 'param_transform' argument is now deprecated. If you want to use a different "
+                          "transformaton, specify a different 'lengthscale_constraint' instead.")
+
         super().__init__(noise_covar=noise_covar)
         if rank != 0:
             self.register_parameter(
@@ -123,8 +137,7 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
         task_correlation_prior=None,
         batch_size=1,
         noise_prior=None,
-        param_transform=softplus,
-        inv_param_transform=None,
+        noise_constraint=Positive(),
         **kwargs
     ):
         """
@@ -141,9 +154,8 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
         noise_covar = MultitaskHomoskedasticNoise(
             num_tasks=num_tasks,
             noise_prior=noise_prior,
+            noise_constraint=noise_constraint,
             batch_size=batch_size,
-            param_transform=param_transform,
-            inv_param_transform=inv_param_transform,
         )
         super().__init__(
             num_tasks=num_tasks,
@@ -151,14 +163,15 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
             rank=rank,
             task_correlation_prior=task_correlation_prior,
             batch_size=batch_size,
+            **kwargs,
         )
-        self._param_transform = param_transform
-        self._inv_param_transform = _get_inv_param_transform(param_transform, inv_param_transform)
+
         self.register_parameter(name="raw_noise", parameter=torch.nn.Parameter(torch.zeros(batch_size, 1)))
+        self.register_constraint("noise_constraint", Positive())
 
     @property
     def noise(self):
-        return self._param_transform(self.raw_noise)
+        return self.noise_constraint.transform(self.raw_noise)
 
     @noise.setter
     def noise(self, value):
@@ -167,7 +180,7 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
     def _set_noise(self, value):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
-        self.initialize(raw_noise=self._inv_param_transform(value))
+        self.initialize(raw_noise=self.noise_constraint.inverse_transform(value))
 
     def _shaped_noise_covar(self, base_shape, *params):
         noise_covar = super()._shaped_noise_covar(base_shape, *params)
@@ -199,8 +212,7 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
         task_prior=None,
         batch_size=1,
         noise_prior=None,
-        param_transform=softplus,
-        inv_param_transform=None,
+        noise_constraint=Positive(),
         **kwargs
     ):
         """
@@ -215,8 +227,6 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
 
         """
         super(Likelihood, self).__init__()
-        self._param_transform = param_transform
-        self._inv_param_transform = _get_inv_param_transform(param_transform, inv_param_transform)
         self.register_parameter(name="raw_noise", parameter=torch.nn.Parameter(torch.zeros(batch_size, 1)))
         if rank == 0:
             self.register_parameter(
@@ -233,16 +243,18 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
         self.num_tasks = num_tasks
         self.rank = rank
 
+        self.register_constraint("noise_constraint", noise_constraint)
+
     @property
     def noise(self):
-        return self._param_transform(self.raw_noise)
+        return self.noise_constraint.transform(self.raw_noise)
 
     @noise.setter
     def noise(self, value):
         self._set_noise(value)
 
     def _set_noise(self, value):
-        self.initialize(raw_noise=self._inv_param_transform(value))
+        self.initialize(raw_noise=self.noise_constraint.inverse_transform(value))
 
     def _eval_covar_matrix(self):
         covar_factor = self.task_noise_covar_factor
@@ -276,7 +288,7 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
         mean, covar = function_dist.mean, function_dist.lazy_covariance_matrix
 
         if self.rank == 0:
-            task_noises = self._param_transform(self.raw_task_noises)
+            task_noises = self.noise_constraint.transform(self.raw_task_noises)
             if covar.ndimension() == 2:
                 if settings.debug.on() and task_noises.size(0) > 1:
                     raise RuntimeError(

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -136,7 +136,7 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
         task_correlation_prior=None,
         batch_size=1,
         noise_prior=None,
-        noise_constraint=GreaterThan(1e-4),
+        noise_constraint=None,
         **kwargs
     ):
         """
@@ -150,6 +150,10 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
             Only used when `rank` > 0.
 
         """
+
+        if noise_constraint is None:
+            noise_constraint = GreaterThan(1e-4)
+
         noise_covar = MultitaskHomoskedasticNoise(
             num_tasks=num_tasks,
             noise_prior=noise_prior,
@@ -159,7 +163,7 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
         super().__init__(
             num_tasks=num_tasks,
             noise_covar=noise_covar,
-            noise_constraint=GreaterThan(1e-4),
+            noise_constraint=noise_constraint,
             rank=rank,
             task_correlation_prior=task_correlation_prior,
             batch_size=batch_size,
@@ -212,7 +216,7 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
         task_prior=None,
         batch_size=1,
         noise_prior=None,
-        noise_constraint=GreaterThan(1e-4),
+        noise_constraint=None,
         **kwargs
     ):
         """
@@ -227,6 +231,8 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
 
         """
         super(Likelihood, self).__init__()
+        if noise_constraint is None:
+            noise_constraint = GreaterThan(1e-4)
         self.register_parameter(name="raw_noise", parameter=torch.nn.Parameter(torch.zeros(batch_size, 1)))
         if rank == 0:
             self.register_parameter(

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -28,8 +28,6 @@ class _MultitaskGaussianLikelihoodBase(_GaussianLikelihoodBase):
         rank=0,
         task_correlation_prior=None,
         batch_size=1,
-        param_transform=None,
-        inv_param_transform=None,
         **kwargs,
     ):
         """
@@ -47,6 +45,7 @@ class _MultitaskGaussianLikelihoodBase(_GaussianLikelihoodBase):
             batch_size (int):
                 Number of batches.
         """
+        param_transform = kwargs.get("param_transform")
         if param_transform is not None:
             warnings.warn("The 'param_transform' argument is now deprecated. If you want to use a different "
                           "transformaton, specify a different 'lengthscale_constraint' instead.")

--- a/gpytorch/likelihoods/noise_models.py
+++ b/gpytorch/likelihoods/noise_models.py
@@ -2,27 +2,26 @@
 
 import torch
 from torch.nn import Parameter
-from torch.nn.functional import softplus
 
+from ..constraints import Positive
 from ..distributions import MultivariateNormal
 from ..lazy import DiagLazyTensor
 from ..module import Module
 from ..utils.broadcasting import _mul_broadcast_shape
-from ..utils.transforms import _get_inv_param_transform
 
 
 class _HomoskedasticNoiseBase(Module):
-    def __init__(self, noise_prior=None, batch_size=1, param_transform=softplus, inv_param_transform=None, num_tasks=1):
+    def __init__(self, noise_prior=None, noise_constraint=Positive(), batch_size=1, num_tasks=1):
         super().__init__()
-        self._param_transform = param_transform
-        self._inv_param_transform = _get_inv_param_transform(param_transform, inv_param_transform)
         self.register_parameter(name="raw_noise", parameter=Parameter(torch.zeros(batch_size, num_tasks)))
         if noise_prior is not None:
             self.register_prior("noise_prior", noise_prior, lambda: self.noise, lambda v: self._set_noise(v))
 
+        self.register_constraint("noise_constraint", noise_constraint)
+
     @property
     def noise(self):
-        return self._param_transform(self.raw_noise)
+        return self.noise_constraint.transform(self.raw_noise)
 
     @noise.setter
     def noise(self, value):
@@ -31,7 +30,7 @@ class _HomoskedasticNoiseBase(Module):
     def _set_noise(self, value):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
-        self.initialize(raw_noise=self._inv_param_transform(value))
+        self.initialize(raw_noise=self.noise_constraint.inverse_transform(value))
 
     def forward(self, *params, shape=None):
         """In the homoskedastic case, the parameters are only used to infer the required shape.
@@ -68,34 +67,31 @@ class _HomoskedasticNoiseBase(Module):
 
 
 class HomoskedasticNoise(_HomoskedasticNoiseBase):
-    def __init__(self, noise_prior=None, batch_size=1, param_transform=softplus, inv_param_transform=None):
+    def __init__(self, noise_prior=None, noise_constraint=Positive(), batch_size=1):
         super().__init__(
             noise_prior=noise_prior,
+            noise_constraint=noise_constraint,
             batch_size=batch_size,
-            param_transform=param_transform,
-            inv_param_transform=inv_param_transform,
             num_tasks=1,
         )
 
 
 class MultitaskHomoskedasticNoise(_HomoskedasticNoiseBase):
-    def __init__(self, num_tasks, noise_prior=None, batch_size=1, param_transform=softplus, inv_param_transform=None):
+    def __init__(self, num_tasks, noise_prior=None, noise_constraint=Positive(), batch_size=1):
         super().__init__(
             noise_prior=noise_prior,
+            noise_constraint=noise_constraint,
             batch_size=batch_size,
-            param_transform=param_transform,
-            inv_param_transform=inv_param_transform,
             num_tasks=num_tasks,
         )
 
 
 class HeteroskedasticNoise(Module):
-    def __init__(self, noise_model, noise_indices=None, noise_transform=torch.exp):
+    def __init__(self, noise_model, noise_indices=None, noise_constraint=Positive()):
         super().__init__()
         self.noise_model = noise_model
-        self._noise_transform = noise_transform
+        self._noise_constraint = noise_constraint
         self._noise_indices = noise_indices
-        self._noise_transform = noise_transform
 
     def forward(self, *params, batch_shape=None, shape=None):
         if len(params) == 1 and not torch.is_tensor(params[0]):
@@ -107,4 +103,4 @@ class HeteroskedasticNoise(Module):
         # note: this also works with MultitaskMultivariateNormal, where this
         # will return a batched DiagLazyTensors of size n x num_tasks x num_tasks
         noise_diag = output.mean if self._noise_indices is None else output.mean[..., self._noise_indices]
-        return DiagLazyTensor(self._noise_transform(noise_diag))
+        return DiagLazyTensor(self._noise_constraint.transform(noise_diag))

--- a/gpytorch/likelihoods/noise_models.py
+++ b/gpytorch/likelihoods/noise_models.py
@@ -3,7 +3,7 @@
 import torch
 from torch.nn import Parameter
 
-from ..constraints import Positive
+from ..constraints import GreaterThan
 from ..distributions import MultivariateNormal
 from ..lazy import DiagLazyTensor
 from ..module import Module
@@ -11,7 +11,7 @@ from ..utils.broadcasting import _mul_broadcast_shape
 
 
 class _HomoskedasticNoiseBase(Module):
-    def __init__(self, noise_prior=None, noise_constraint=Positive(), batch_size=1, num_tasks=1):
+    def __init__(self, noise_prior=None, noise_constraint=GreaterThan(1e-4), batch_size=1, num_tasks=1):
         super().__init__()
         self.register_parameter(name="raw_noise", parameter=Parameter(torch.zeros(batch_size, num_tasks)))
         if noise_prior is not None:
@@ -67,7 +67,7 @@ class _HomoskedasticNoiseBase(Module):
 
 
 class HomoskedasticNoise(_HomoskedasticNoiseBase):
-    def __init__(self, noise_prior=None, noise_constraint=Positive(), batch_size=1):
+    def __init__(self, noise_prior=None, noise_constraint=GreaterThan(1e-4), batch_size=1):
         super().__init__(
             noise_prior=noise_prior,
             noise_constraint=noise_constraint,
@@ -77,7 +77,7 @@ class HomoskedasticNoise(_HomoskedasticNoiseBase):
 
 
 class MultitaskHomoskedasticNoise(_HomoskedasticNoiseBase):
-    def __init__(self, num_tasks, noise_prior=None, noise_constraint=Positive(), batch_size=1):
+    def __init__(self, num_tasks, noise_prior=None, noise_constraint=GreaterThan(1e-4), batch_size=1):
         super().__init__(
             noise_prior=noise_prior,
             noise_constraint=noise_constraint,
@@ -87,7 +87,7 @@ class MultitaskHomoskedasticNoise(_HomoskedasticNoiseBase):
 
 
 class HeteroskedasticNoise(Module):
-    def __init__(self, noise_model, noise_indices=None, noise_constraint=Positive()):
+    def __init__(self, noise_model, noise_indices=None, noise_constraint=GreaterThan(1e-4)):
         super().__init__()
         self.noise_model = noise_model
         self._noise_constraint = noise_constraint

--- a/gpytorch/likelihoods/noise_models.py
+++ b/gpytorch/likelihoods/noise_models.py
@@ -11,8 +11,11 @@ from ..utils.broadcasting import _mul_broadcast_shape
 
 
 class _HomoskedasticNoiseBase(Module):
-    def __init__(self, noise_prior=None, noise_constraint=GreaterThan(1e-4), batch_size=1, num_tasks=1):
+    def __init__(self, noise_prior=None, noise_constraint=None, batch_size=1, num_tasks=1):
         super().__init__()
+        if noise_constraint is None:
+            noise_constraint = GreaterThan(1e-4)
+
         self.register_parameter(name="raw_noise", parameter=Parameter(torch.zeros(batch_size, num_tasks)))
         if noise_prior is not None:
             self.register_prior("noise_prior", noise_prior, lambda: self.noise, lambda v: self._set_noise(v))
@@ -67,7 +70,7 @@ class _HomoskedasticNoiseBase(Module):
 
 
 class HomoskedasticNoise(_HomoskedasticNoiseBase):
-    def __init__(self, noise_prior=None, noise_constraint=GreaterThan(1e-4), batch_size=1):
+    def __init__(self, noise_prior=None, noise_constraint=None, batch_size=1):
         super().__init__(
             noise_prior=noise_prior,
             noise_constraint=noise_constraint,
@@ -77,7 +80,7 @@ class HomoskedasticNoise(_HomoskedasticNoiseBase):
 
 
 class MultitaskHomoskedasticNoise(_HomoskedasticNoiseBase):
-    def __init__(self, num_tasks, noise_prior=None, noise_constraint=GreaterThan(1e-4), batch_size=1):
+    def __init__(self, num_tasks, noise_prior=None, noise_constraint=None, batch_size=1):
         super().__init__(
             noise_prior=noise_prior,
             noise_constraint=noise_constraint,
@@ -87,7 +90,9 @@ class MultitaskHomoskedasticNoise(_HomoskedasticNoiseBase):
 
 
 class HeteroskedasticNoise(Module):
-    def __init__(self, noise_model, noise_indices=None, noise_constraint=GreaterThan(1e-4)):
+    def __init__(self, noise_model, noise_indices=None, noise_constraint=None):
+        if noise_constraint is None:
+            noise_constraint = GreaterThan(1e-4)
         super().__init__()
         self.noise_model = noise_model
         self._noise_constraint = noise_constraint

--- a/gpytorch/likelihoods/noise_models.py
+++ b/gpytorch/likelihoods/noise_models.py
@@ -17,11 +17,11 @@ class _HomoskedasticNoiseBase(Module):
         if noise_prior is not None:
             self.register_prior("noise_prior", noise_prior, lambda: self.noise, lambda v: self._set_noise(v))
 
-        self.register_constraint("noise_constraint", noise_constraint)
+        self.register_constraint("raw_noise", noise_constraint)
 
     @property
     def noise(self):
-        return self.noise_constraint.transform(self.raw_noise)
+        return self.raw_noise_constraint.transform(self.raw_noise)
 
     @noise.setter
     def noise(self, value):
@@ -30,7 +30,7 @@ class _HomoskedasticNoiseBase(Module):
     def _set_noise(self, value):
         if not torch.is_tensor(value):
             value = torch.tensor(value)
-        self.initialize(raw_noise=self.noise_constraint.inverse_transform(value))
+        self.initialize(raw_noise=self.raw_noise_constraint.inverse_transform(value))
 
     def forward(self, *params, shape=None):
         """In the homoskedastic case, the parameters are only used to infer the required shape.

--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -307,5 +307,5 @@ def _extract_named_constraints(module, memo=None, prefix=""):
                 yield full_name, constraint
     for mname, module_ in module.named_children():
         submodule_prefix = prefix + ("." if prefix else "") + mname
-        for name, constriant in _extract_named_constraints(module_, memo=memo, prefix=submodule_prefix):
+        for name, constraint in _extract_named_constraints(module_, memo=memo, prefix=submodule_prefix):
             yield name, constraint

--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -41,6 +41,10 @@ class Module(nn.Module):
     def forward(self, *inputs, **kwargs):
         raise NotImplementedError
 
+    def constraints(self):
+        for _, constraint in self.named_constraints():
+            yield constraint
+
     def hyperparameters(self):
         for _, param in self.named_hyperparameters():
             yield param

--- a/gpytorch/utils/transforms.py
+++ b/gpytorch/utils/transforms.py
@@ -1,14 +1,14 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
+#!/usr/bin/env python3
 
 import torch
 
 
 def inv_softplus(x):
     return torch.log(torch.exp(x) - 1)
+
+
+def inv_sigmoid(x):
+    return torch.log(x / (1 - x))
 
 
 def _get_inv_param_transform(param_transform, inv_param_transform=None):
@@ -22,4 +22,8 @@ def _get_inv_param_transform(param_transform, inv_param_transform=None):
     return reg_inv_tf
 
 
-TRANSFORM_REGISTRY = {torch.exp: torch.log, torch.nn.functional.softplus: inv_softplus}
+TRANSFORM_REGISTRY = {
+    torch.exp: torch.log,
+    torch.nn.functional.softplus: inv_softplus,
+    torch.nn.functional.sigmoid: inv_sigmoid,
+}

--- a/test/constraints/test_constraints.py
+++ b/test/constraints/test_constraints.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+import torch
+import unittest
+import gpytorch
+
+from torch.nn.functional import softplus, sigmoid
+from test._base_test_case import BaseTestCase
+
+
+class TestInterval(unittest.TestCase, BaseTestCase):
+    def test_transform_float_bounds(self):
+        constraint = gpytorch.constraints.Interval(1., 5.)
+
+        v = torch.tensor(-3.)
+
+        value = constraint.transform(v)
+        actual_value = (5. * sigmoid(v)) + 1.
+
+        self.assertAllClose(value, actual_value)
+
+    def test_inverse_transform_float_bounds(self):
+        constraint = gpytorch.constraints.Interval(1., 5.)
+
+        v = torch.tensor(-3.)
+
+        value = constraint.inverse_transform(constraint.transform(v))
+
+        self.assertAllClose(v, value)
+
+    def test_transform_tensor_bounds(self):
+        constraint = gpytorch.constraints.Interval(torch.tensor([1., 2.]), torch.tensor([3., 4.]))
+
+        v = torch.tensor([-3., -2.])
+
+        value = constraint.transform(v)
+        actual_value = v.clone()
+        actual_value[0] = 3. * sigmoid(v[0]) + 1.
+        actual_value[1] = 4. * sigmoid(v[1]) + 2.
+
+        self.assertAllClose(value, actual_value)
+
+    def test_inverse_transform_tensor_bounds(self):
+        constraint = gpytorch.constraints.Interval(torch.tensor([1., 2.]), torch.tensor([3., 4.]))
+
+        v = torch.tensor([-3., -2.])
+
+        value = constraint.inverse_transform(constraint.transform(v))
+
+        self.assertAllClose(v, value)
+
+
+class TestGreaterThan(unittest.TestCase, BaseTestCase):
+    def test_transform_float_greater_than(self):
+        constraint = gpytorch.constraints.GreaterThan(1.)
+
+        v = torch.tensor(-3.)
+
+        value = constraint.transform(v)
+        actual_value = softplus(v) + 1.
+
+        self.assertAllClose(value, actual_value)
+
+    def test_transform_tensor_greater_than(self):
+        constraint = gpytorch.constraints.GreaterThan([1., 2.])
+
+        v = torch.tensor([-3., -2.])
+
+        value = constraint.transform(v)
+        actual_value = v.clone()
+        actual_value[0] = softplus(v[0]) + 1.
+        actual_value[1] = softplus(v[1]) + 2.
+
+        self.assertAllClose(value, actual_value)
+
+    def test_inverse_transform_float_greater_than(self):
+        constraint = gpytorch.constraints.GreaterThan(1.)
+
+        v = torch.tensor(-3.)
+
+        value = constraint.inverse_transform(constraint.transform(v))
+
+        self.assertAllClose(value, v)
+
+    def test_inverse_transform_tensor_greater_than(self):
+        constraint = gpytorch.constraints.GreaterThan([1., 2.])
+
+        v = torch.tensor([-3., -2.])
+
+        value = constraint.inverse_transform(constraint.transform(v))
+
+        self.assertAllClose(value, v)
+
+
+class TestLessThan(unittest.TestCase, BaseTestCase):
+    def test_transform_float_less_than(self):
+        constraint = gpytorch.constraints.LessThan(1.)
+
+        v = torch.tensor(-3.)
+
+        value = constraint.transform(v)
+        actual_value = -softplus(-v) + 1.
+
+        self.assertAllClose(value, actual_value)
+
+    def test_transform_tensor_less_than(self):
+        constraint = gpytorch.constraints.LessThan([1., 2.])
+
+        v = torch.tensor([-3., -2.])
+
+        value = constraint.transform(v)
+        actual_value = v.clone()
+        actual_value[0] = -softplus(-v[0]) + 1.
+        actual_value[1] = -softplus(-v[1]) + 2.
+
+        self.assertAllClose(value, actual_value)
+
+    def test_inverse_transform_float_less_than(self):
+        constraint = gpytorch.constraints.LessThan(1.)
+
+        v = torch.tensor(-3.)
+
+        value = constraint.inverse_transform(constraint.transform(v))
+
+        self.assertAllClose(value, v)
+
+    def test_inverse_transform_tensor_less_than(self):
+        constraint = gpytorch.constraints.LessThan([1., 2.])
+
+        v = torch.tensor([-3., -2.])
+
+        value = constraint.inverse_transform(constraint.transform(v))
+
+        self.assertAllClose(value, v)
+
+
+class TestPositive(unittest.TestCase, BaseTestCase):
+    def test_transform_float_positive(self):
+        constraint = gpytorch.constraints.Positive()
+
+        v = torch.tensor(-3.)
+
+        value = constraint.transform(v)
+        actual_value = softplus(v)
+
+        self.assertAllClose(value, actual_value)
+
+    def test_transform_tensor_positive(self):
+        constraint = gpytorch.constraints.Positive()
+
+        v = torch.tensor([-3., -2.])
+
+        value = constraint.transform(v)
+        actual_value = v.clone()
+        actual_value[0] = softplus(v[0])
+        actual_value[1] = softplus(v[1])
+
+        self.assertAllClose(value, actual_value)
+
+    def test_inverse_transform_float_positive(self):
+        constraint = gpytorch.constraints.Positive()
+
+        v = torch.tensor(-3.)
+
+        value = constraint.inverse_transform(constraint.transform(v))
+
+        self.assertAllClose(value, v)
+
+    def test_inverse_transform_tensor_positive(self):
+        constraint = gpytorch.constraints.Positive()
+
+        v = torch.tensor([-3., -2.])
+
+        value = constraint.inverse_transform(constraint.transform(v))
+
+        self.assertAllClose(value, v)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/constraints/test_constraints.py
+++ b/test/constraints/test_constraints.py
@@ -8,6 +8,19 @@ from torch.nn.functional import softplus, sigmoid
 from test._base_test_case import BaseTestCase
 
 
+# Basic exact GP model for testing parameter + constraint name resolution
+class ExactGPModel(gpytorch.models.ExactGP):
+    def __init__(self, train_x, train_y, likelihood):
+        super(ExactGPModel, self).__init__(train_x, train_y, likelihood)
+        self.mean_module = gpytorch.means.ConstantMean()
+        self.covar_module = gpytorch.kernels.ScaleKernel(gpytorch.kernels.RBFKernel())
+
+    def forward(self, x):
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
+        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+
+
 class TestInterval(unittest.TestCase, BaseTestCase):
     def test_transform_float_bounds(self):
         constraint = gpytorch.constraints.Interval(1., 5.)
@@ -174,6 +187,35 @@ class TestPositive(unittest.TestCase, BaseTestCase):
         value = constraint.inverse_transform(constraint.transform(v))
 
         self.assertAllClose(value, v)
+
+
+class TestConstraintNaming(unittest.TestCase, BaseTestCase):
+    def test_constraint_by_name(self):
+        likelihood = gpytorch.likelihoods.GaussianLikelihood()
+        model = ExactGPModel(None, None, likelihood)
+
+        constraint = model.constraint_for_parameter_name("likelihood.noise_covar.raw_noise")
+        self.assertIsInstance(constraint, gpytorch.constraints.GreaterThan)
+
+        constraint = model.constraint_for_parameter_name("covar_module.base_kernel.raw_lengthscale")
+        self.assertIsInstance(constraint, gpytorch.constraints.Positive)
+
+        constraint = model.constraint_for_parameter_name("mean_module.constant")
+        self.assertIsNone(constraint)
+
+    def test_named_parameters_and_constraints(self):
+        likelihood = gpytorch.likelihoods.GaussianLikelihood()
+        model = ExactGPModel(None, None, likelihood)
+
+        for name, param, constraint in model.named_parameters_and_constraints():
+            if name == "likelihood.noise_covar.raw_noise":
+                self.assertIsInstance(constraint, gpytorch.constraints.GreaterThan)
+            elif name == "mean_module.constant":
+                self.assertIsNone(constraint)
+            elif name == "covar_module.raw_outputscale":
+                self.assertIsInstance(constraint, gpytorch.constraints.Positive)
+            elif name == "covar_module.base_kernel.raw_lengthscale":
+                self.assertIsInstance(constraint, gpytorch.constraints.Positive)
 
 
 if __name__ == "__main__":

--- a/test/distributions/test_multivariate_normal.py
+++ b/test/distributions/test_multivariate_normal.py
@@ -3,7 +3,7 @@
 import math
 import unittest
 from test._utils import least_used_cuda_device
-from .._base_test_case import BaseTestCase
+from test._base_test_case import BaseTestCase
 
 import torch
 from gpytorch.distributions import MultivariateNormal

--- a/test/examples/test_simple_gp_regression.py
+++ b/test/examples/test_simple_gp_regression.py
@@ -12,7 +12,7 @@ from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.means import ConstantMean
 from gpytorch.priors import SmoothedBoxPrior
 from torch import optim
-from .._base_test_case import BaseTestCase
+from test._base_test_case import BaseTestCase
 
 
 class ExactGPModel(gpytorch.models.ExactGP):

--- a/test/examples/test_svgp_gp_regression.py
+++ b/test/examples/test_svgp_gp_regression.py
@@ -12,7 +12,7 @@ from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.models import AbstractVariationalGP
 from gpytorch.variational import CholeskyVariationalDistribution, VariationalStrategy
 from torch import optim
-from .._base_test_case import BaseTestCase
+from test._base_test_case import BaseTestCase
 
 
 def train_data(cuda=False):

--- a/test/examples/test_whitened_svgp_gp_regression.py
+++ b/test/examples/test_whitened_svgp_gp_regression.py
@@ -6,7 +6,7 @@ import warnings
 import unittest
 from unittest.mock import MagicMock, patch
 from test._utils import least_used_cuda_device
-from .._base_test_case import BaseTestCase
+from test._base_test_case import BaseTestCase
 
 import gpytorch
 import torch

--- a/test/functions/test_inv_quad_log_det.py
+++ b/test/functions/test_inv_quad_log_det.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import gpytorch
 from gpytorch.lazy import RootLazyTensor
-from .._base_test_case import BaseTestCase
+from test._base_test_case import BaseTestCase
 
 
 class TestInvQuadLogDetNonBatch(BaseTestCase, unittest.TestCase):

--- a/test/lazy/_lazy_tensor_test_case.py
+++ b/test/lazy/_lazy_tensor_test_case.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import gpytorch
 import torch
-from .._base_test_case import BaseTestCase
+from test._base_test_case import BaseTestCase
 
 
 class RectangularLazyTensorTestCase(BaseTestCase):


### PR DESCRIPTION
This is a refactor of `param_transform` to be first class `Constraint` objects that get registered to GPyTorch modules. The idea is that `gpytorch.Module` exposes a `register_constraint` method so that the following all work:
```python
self.covar_module.register_constraint("raw_lengthscale", Positive())
self.covar_module.register_constraint("raw_lengthscale", GreaterThan(1.))
self.covar_module.register_constraint("raw_lengthscale", LessThan(5.))
self.covar_module.register_constraint("raw_lengthscale", Interval(1., 5.))
print(list(self.named_constraints()))
self.covar_module.register_constraint("raw_lengthscale", Positive(transform=torch.exp))
...
```

The idea is that the `param_transforms` are now handled by registering default `Positive` constraints on the parameters that need it, probably changing `raw_lengthscale` to have a lower bound by default, and users can register their own constraints if they want.

If you wanted to use LBFGS-B with no warping, you could do:
```python
identity = lambda x: x
self.covar_module.register_constraint('raw_lengthscale', Interval(1., 5., transform=identity, inv_transform=identity)
```
And then use `model.named_constraints()` to get the bounds to pass L-BFGS-B.

Right now I just changed the lengthscale to this interface, and I doubt the tests pass. This is an RFC on the interface.

Fixes #563 