### PR TITLE
Make InvMatmul, InvQuadLogDet, and InvQuad twice differentiable

### DIFF
--- a/gpytorch/functions/_inv_matmul.py
+++ b/gpytorch/functions/_inv_matmul.py
@@ -4,107 +4,108 @@ import torch
 from torch.autograd import Function
 from .. import settings
 
+def _solve(lazy_tsr, rhs):
+    if settings.fast_computations.solves.off() or lazy_tsr.size(-1) <= settings.max_cholesky_size.value():
+        return lazy_tsr._cholesky()._cholesky_solve(rhs)
+    else:
+        with torch.no_grad():
+            preconditioner = lazy_tsr.detach()._inv_matmul_preconditioner()
+        return lazy_tsr._solve(rhs, preconditioner)
 
 class InvMatmul(Function):
-    def __init__(self, representation_tree, has_left=False):
-        self.representation_tree = representation_tree
-        self.has_left = has_left
-
-    def _solve(self, lazy_tsr, rhs):
-        if settings.fast_computations.solves.off() or lazy_tsr.size(-1) <= settings.max_cholesky_size.value():
-            return lazy_tsr._cholesky()._cholesky_solve(rhs)
-        else:
-            with torch.no_grad():
-                preconditioner = lazy_tsr.detach()._inv_matmul_preconditioner()
-            return lazy_tsr._solve(rhs, preconditioner)
-
-    def forward(self, *args):
+    @staticmethod
+    def forward(ctx, representation_tree, has_left, *args):
         left_tensor = None
         right_tensor = None
         matrix_args = None
-        if self.has_left:
+
+        ctx.representation_tree = representation_tree
+        ctx.has_left = has_left
+
+        if ctx.has_left:
             left_tensor, right_tensor, *matrix_args = args
         else:
             right_tensor, *matrix_args = args
         orig_right_tensor = right_tensor
-        lazy_tsr = self.representation_tree(*matrix_args)
+        lazy_tsr = ctx.representation_tree(*matrix_args)
 
-        self.is_vector = False
+        ctx.is_vector = False
         if right_tensor.ndimension() == 1:
             right_tensor = right_tensor.unsqueeze(-1)
-            self.is_vector = True
+            ctx.is_vector = True
 
         # Perform solves (for inv_quad) and tridiagonalization (for estimating logdet)
-        if self.has_left:
+        if ctx.has_left:
             rhs = torch.cat([left_tensor.transpose(-1, -2), right_tensor], -1)
-            solves = self._solve(lazy_tsr, rhs)
+            solves = _solve(lazy_tsr, rhs)
             res = solves[..., left_tensor.size(-2):]
             res = left_tensor @ res
         else:
-            solves = self._solve(lazy_tsr, right_tensor)
+            solves = _solve(lazy_tsr, right_tensor)
             res = solves
 
-        if self.is_vector:
+        if ctx.is_vector:
             res = res.squeeze(-1)
 
-        if self.has_left:
+        if ctx.has_left:
             args = [solves, left_tensor, orig_right_tensor] + list(matrix_args)
         else:
             args = [solves, orig_right_tensor] + list(matrix_args)
-        self.save_for_backward(*args)
+        ctx.save_for_backward(*args)
         if settings.memory_efficient.off():
-            self._lazy_tsr = lazy_tsr
+            ctx._lazy_tsr = lazy_tsr
 
         return res
 
-    def backward(self, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         # Extract items that were saved
-        if self.has_left:
-            solves, left_tensor, right_tensor, *matrix_args = self.saved_tensors
+        if ctx.has_left:
+            solves, left_tensor, right_tensor, *matrix_args = ctx.saved_tensors
             left_solves = solves[..., :left_tensor.size(-2)]
             right_solves = solves[..., left_tensor.size(-2):]
         else:
-            right_solves, right_tensor, *matrix_args = self.saved_tensors
+            right_solves, right_tensor, *matrix_args = ctx.saved_tensors
 
         # Get matrix functions
-        if hasattr(self, "_lazy_tsr"):
-            lazy_tsr = self._lazy_tsr
+        if hasattr(ctx, "_lazy_tsr"):
+            lazy_tsr = ctx._lazy_tsr
         else:
-            lazy_tsr = self.representation_tree(*matrix_args)
+            lazy_tsr = ctx.representation_tree(*matrix_args)
 
         # Define gradient placeholders
         arg_grads = [None] * len(matrix_args)
         left_grad = None
         right_grad = None
-        if any(self.needs_input_grad):
+        if any(ctx.needs_input_grad):
             # De-vectorize objects
-            if self.is_vector:
+            if ctx.is_vector:
                 right_tensor = right_tensor.unsqueeze(-1)
                 grad_output = grad_output.unsqueeze(-1)
 
-            if not self.has_left:
+            if not ctx.has_left:
                 # Compute self^{-1} grad_output
-                left_solves = self._solve(lazy_tsr, grad_output)
+                left_solves = InvMatmul.apply(ctx.representation_tree, False, grad_output, *matrix_args)
 
-                if any(self.needs_input_grad[1:]):
+                if any(ctx.needs_input_grad[3:]):
                     arg_grads = lazy_tsr._quad_form_derivative(left_solves, right_solves.mul(-1))
-                if self.needs_input_grad[0]:
+                if ctx.needs_input_grad[2]:
                     right_grad = left_solves
-                    if self.is_vector:
+                    if ctx.is_vector:
                         right_grad.squeeze_(-1)
 
-                return tuple([right_grad] + list(arg_grads))
+                return tuple([None, None] + [right_grad] + list(arg_grads))
 
             else:
                 left_solves = left_solves @ grad_output
 
-                if self.needs_input_grad[1]:
+                if ctx.needs_input_grad[3]:
                     left_grad = grad_output @ right_solves.transpose(-1, -2)
-                if any(self.needs_input_grad[2:]):
+                if any(ctx.needs_input_grad[4:]):
                     arg_grads = lazy_tsr._quad_form_derivative(left_solves, right_solves.mul(-1))
-                if self.needs_input_grad[0]:
+                if ctx.needs_input_grad[2]:
                     right_grad = left_solves
-                    if self.is_vector:
+                    if ctx.is_vector:
                         right_grad.squeeze_(-1)
 
-                return tuple([left_grad, right_grad] + list(arg_grads))
+                return tuple([None, None] + [left_grad, right_grad] + list(arg_grads))

--- a/gpytorch/functions/_inv_matmul.py
+++ b/gpytorch/functions/_inv_matmul.py
@@ -4,6 +4,7 @@ import torch
 from torch.autograd import Function
 from .. import settings
 
+
 def _solve(lazy_tsr, rhs):
     if settings.fast_computations.solves.off() or lazy_tsr.size(-1) <= settings.max_cholesky_size.value():
         return lazy_tsr._cholesky()._cholesky_solve(rhs)
@@ -11,6 +12,7 @@ def _solve(lazy_tsr, rhs):
         with torch.no_grad():
             preconditioner = lazy_tsr.detach()._inv_matmul_preconditioner()
         return lazy_tsr._solve(rhs, preconditioner)
+
 
 class InvMatmul(Function):
     @staticmethod

--- a/gpytorch/functions/_inv_quad.py
+++ b/gpytorch/functions/_inv_quad.py
@@ -70,6 +70,8 @@ class InvQuad(Function):
         inv_quad_grad_output = inv_quad_grad_output.unsqueeze(-2)
         neg_inv_quad_solves_times_grad_out = inv_quad_solves.mul(inv_quad_grad_output).mul(-1)
 
+        matrix_arg_grads = [None] * len(matrix_args)
+
         # input_1 gradient
         if any(ctx.needs_input_grad[2:]):
             left_factors = neg_inv_quad_solves_times_grad_out

--- a/gpytorch/functions/_inv_quad.py
+++ b/gpytorch/functions/_inv_quad.py
@@ -5,83 +5,84 @@ from torch.autograd import Function
 from .. import settings
 
 
+def _solve(lazy_tsr, rhs):
+    if (
+        settings.fast_computations.solves.off()
+        or settings.fast_computations.log_prob.off()
+        or lazy_tsr.size(-1) <= settings.max_cholesky_size.value()
+    ):
+        return lazy_tsr._cholesky()._cholesky_solve(rhs)
+    else:
+        with torch.no_grad():
+            preconditioner = lazy_tsr.detach()._inv_matmul_preconditioner()
+        return lazy_tsr._solve(rhs, preconditioner)
+
+
 class InvQuad(Function):
     """
     Given a PSD matrix A (or a batch of PSD matrices A), this function computes b A^{-1} b
     where b is a vector or batch of vectors
     """
-
-    def __init__(self, representation_tree):
-        self.representation_tree = representation_tree
-
-    def _solve(self, lazy_tsr, rhs):
-        with torch.no_grad():
-            if settings.fast_computations.solves.off() or settings.fast_computations.log_prob.off() or \
-                    lazy_tsr.size(-1) <= settings.max_cholesky_size.value():
-                return lazy_tsr._cholesky()._cholesky_solve(rhs)
-            else:
-                if not hasattr(self, "_preconditioner_memo"):
-                    self._preconditioner_memo = lazy_tsr.detach()._inv_matmul_preconditioner()
-                return lazy_tsr._solve(rhs, self._preconditioner_memo)
-
-    def forward(self, *args):
+    @staticmethod
+    def forward(ctx, representation_tree, *args):
         """
         *args - The arguments representing the PSD matrix A (or batch of PSD matrices A)
-        If self.inv_quad is true, the first entry in *args is inv_quad_rhs (Tensor)
+        If inv_quad is true, the first entry in *args is inv_quad_rhs (Tensor)
         - the RHS of the matrix solves.
 
         Returns:
-        - (Scalar) The inverse quadratic form (or None, if self.inv_quad is False)
-        - (Scalar) The log determinant (or None, self.if logdet is False)
+        - (Scalar) The inverse quadratic form (or None, if inv_quad is False)
+        - (Scalar) The log determinant (or None, if logdet is False)
         """
         inv_quad_rhs, *matrix_args = args
-
+        ctx.representation_tree = representation_tree
         # Get closure for matmul
-        lazy_tsr = self.representation_tree(*matrix_args)
+        lazy_tsr = ctx.representation_tree(*matrix_args)
 
         # RHS for inv_quad
-        self.is_vector = False
+        ctx.is_vector = False
         if inv_quad_rhs.ndimension() == 1:
             inv_quad_rhs = inv_quad_rhs.unsqueeze(-1)
-            self.is_vector = True
+            ctx.is_vector = True
 
         # Perform solves (for inv_quad) and tridiagonalization (for estimating logdet)
-        inv_quad_solves = self._solve(lazy_tsr, inv_quad_rhs)
+        inv_quad_solves = _solve(lazy_tsr, inv_quad_rhs)
         inv_quad_term = (inv_quad_solves * inv_quad_rhs).sum(-2)
 
         to_save = matrix_args + [inv_quad_solves]
-        self.save_for_backward(*to_save)
+        ctx.save_for_backward(*to_save)
 
         if settings.memory_efficient.off():
-            self._lazy_tsr = lazy_tsr
+            ctx._lazy_tsr = lazy_tsr
 
         return inv_quad_term
 
-    def backward(self, inv_quad_grad_output):
-        *matrix_args, inv_quad_solves = self.saved_tensors
+    @staticmethod
+    def backward(ctx, inv_quad_grad_output):
+        *matrix_args, inv_quad_solves = ctx.saved_tensors
 
-        if hasattr(self, "_lazy_tsr"):
-            lazy_tsr = self._lazy_tsr
+        if hasattr(ctx, "_lazy_tsr"):
+            lazy_tsr = ctx._lazy_tsr
         else:
-            lazy_tsr = self.representation_tree(*matrix_args)
+            lazy_tsr = ctx.representation_tree(*matrix_args)
 
         # Fix grad_output sizes
         inv_quad_grad_output = inv_quad_grad_output.unsqueeze(-2)
-        neg_inv_quad_solves_times_grad_out = inv_quad_solves.mul(inv_quad_grad_output).mul_(-1)
+        neg_inv_quad_solves_times_grad_out = inv_quad_solves.mul(inv_quad_grad_output).mul(-1)
 
         # input_1 gradient
-        if any(self.needs_input_grad[1:]):
+        if any(ctx.needs_input_grad[2:]):
             left_factors = neg_inv_quad_solves_times_grad_out
             right_factors = inv_quad_solves
             matrix_arg_grads = lazy_tsr._quad_form_derivative(left_factors, right_factors)
 
         # input_2 gradients
-        if self.needs_input_grad[0]:
-            inv_quad_rhs_grad = neg_inv_quad_solves_times_grad_out.mul_(-2)
+        if ctx.needs_input_grad[1]:
+            inv_quad_rhs_grad = neg_inv_quad_solves_times_grad_out.mul(-2)
         else:
             inv_quad_rhs_grad = torch.zeros_like(inv_quad_solves)
-        if self.is_vector:
+        if ctx.is_vector:
             inv_quad_rhs_grad.squeeze_(-1)
 
-        res = tuple([inv_quad_rhs_grad] + list(matrix_arg_grads))
+        res = tuple([None] + [inv_quad_rhs_grad] + list(matrix_arg_grads))
         return tuple(res)

--- a/gpytorch/functions/_inv_quad_log_det.py
+++ b/gpytorch/functions/_inv_quad_log_det.py
@@ -14,9 +14,9 @@ class InvQuadLogDet(Function):
     - The matrix solves A^{-1} b
     - logdet(A)
     """
-
-    def __init__(
-        self,
+    @staticmethod
+    def forward(
+        ctx,
         representation_tree,
         dtype,
         device,
@@ -26,17 +26,28 @@ class InvQuadLogDet(Function):
         logdet=False,
         probe_vectors=None,
         probe_vector_norms=None,
+        *args
     ):
+        """
+        *args - The arguments representing the PSD matrix A (or batch of PSD matrices A)
+        If self.inv_quad is true, the first entry in *args is inv_quad_rhs (Tensor)
+        - the RHS of the matrix solves.
+
+        Returns:
+        - (Scalar) The inverse quadratic form (or None, if self.inv_quad is False)
+        - (Scalar) The log determinant (or None, self.if logdet is False)
+        """
+
         if not (inv_quad or logdet):
             raise RuntimeError("Either inv_quad or logdet must be true (or both)")
 
-        self.representation_tree = representation_tree
-        self.dtype = dtype
-        self.device = device
-        self.matrix_shape = matrix_shape
-        self.batch_shape = batch_shape
-        self.inv_quad = inv_quad
-        self.logdet = logdet
+        ctx.representation_tree = representation_tree
+        ctx.dtype = dtype
+        ctx.device = device
+        ctx.matrix_shape = matrix_shape
+        ctx.batch_shape = batch_shape
+        ctx.inv_quad = inv_quad
+        ctx.logdet = logdet
 
         if (probe_vectors is None or probe_vector_norms is None) and logdet:
             num_random_probes = settings.num_trace_samples.value()
@@ -48,32 +59,22 @@ class InvQuadLogDet(Function):
                 probe_vector_norms = probe_vector_norms.expand(*batch_shape, 1, num_random_probes)
             probe_vectors = probe_vectors.div(probe_vector_norms)
 
-        self.probe_vectors = probe_vectors
-        self.probe_vector_norms = probe_vector_norms
+        ctx.probe_vectors = probe_vectors
+        ctx.probe_vector_norms = probe_vector_norms
 
-        if self.logdet and not self.probe_vectors.numel():
+        if ctx.logdet and not ctx.probe_vectors.numel():
             raise RuntimeError("Probe vectors were not supplied for logdet computation")
 
-    def forward(self, *args):
-        """
-        *args - The arguments representing the PSD matrix A (or batch of PSD matrices A)
-        If self.inv_quad is true, the first entry in *args is inv_quad_rhs (Tensor)
-        - the RHS of the matrix solves.
-
-        Returns:
-        - (Scalar) The inverse quadratic form (or None, if self.inv_quad is False)
-        - (Scalar) The log determinant (or None, self.if logdet is False)
-        """
         matrix_args = None
         inv_quad_rhs = None
-        if self.inv_quad:
+        if ctx.inv_quad:
             matrix_args = args[1:]
             inv_quad_rhs = args[0]
         else:
             matrix_args = args
 
         # Get closure for matmul
-        lazy_tsr = self.representation_tree(*matrix_args)
+        lazy_tsr = ctx.representation_tree(*matrix_args)
         with torch.no_grad():
             preconditioner, logdet_correction = lazy_tsr.detach()._preconditioner()
 
@@ -84,82 +85,83 @@ class InvQuadLogDet(Function):
         num_inv_quad_solves = 0
 
         # RHS for logdet
-        if self.logdet:
-            rhs_list.append(self.probe_vectors)
-            num_random_probes = self.probe_vectors.size(-1)
+        if ctx.logdet:
+            rhs_list.append(ctx.probe_vectors)
+            num_random_probes = ctx.probe_vectors.size(-1)
 
         # RHS for inv_quad
-        self.is_vector = False
-        if self.inv_quad:
+        ctx.is_vector = False
+        if ctx.inv_quad:
             if inv_quad_rhs.ndimension() == 1:
                 inv_quad_rhs = inv_quad_rhs.unsqueeze(-1)
-                self.is_vector = True
+                ctx.is_vector = True
             rhs_list.append(inv_quad_rhs)
             num_inv_quad_solves = inv_quad_rhs.size(-1)
 
         # Perform solves (for inv_quad) and tridiagonalization (for estimating logdet)
         rhs = torch.cat(rhs_list, -1)
         t_mat = None
-        if self.logdet and settings.skip_logdet_forward.off():
+        if ctx.logdet and settings.skip_logdet_forward.off():
             solves, t_mat = lazy_tsr._solve(rhs, preconditioner, num_tridiag=num_random_probes)
 
         else:
             solves = lazy_tsr._solve(rhs, preconditioner, num_tridiag=0)
 
         # Final values to return
-        logdet_term = torch.zeros(lazy_tsr.batch_shape, dtype=self.dtype, device=self.device)
-        inv_quad_term = torch.zeros(lazy_tsr.batch_shape, dtype=self.dtype, device=self.device)
+        logdet_term = torch.zeros(lazy_tsr.batch_shape, dtype=ctx.dtype, device=ctx.device)
+        inv_quad_term = torch.zeros(lazy_tsr.batch_shape, dtype=ctx.dtype, device=ctx.device)
 
         # Compute logdet from tridiagonalization
-        if self.logdet and settings.skip_logdet_forward.off():
+        if ctx.logdet and settings.skip_logdet_forward.off():
             if torch.any(torch.isnan(t_mat)).item():
-                logdet_term = torch.tensor(float("nan"), dtype=self.dtype, device=self.device)
+                logdet_term = torch.tensor(float("nan"), dtype=ctx.dtype, device=ctx.device)
             else:
-                if self.batch_shape is None:
+                if ctx.batch_shape is None:
                     t_mat = t_mat.unsqueeze(1)
                 eigenvalues, eigenvectors = lanczos_tridiag_to_diag(t_mat)
                 slq = StochasticLQ()
-                logdet_term, = slq.evaluate(self.matrix_shape, eigenvalues, eigenvectors, [lambda x: x.log()])
+                logdet_term, = slq.evaluate(ctx.matrix_shape, eigenvalues, eigenvectors, [lambda x: x.log()])
 
                 # Add correction
                 if logdet_correction is not None:
                     logdet_term = logdet_term + logdet_correction
 
         # Extract inv_quad solves from all the solves
-        if self.inv_quad:
+        if ctx.inv_quad:
             inv_quad_solves = solves.narrow(-1, num_random_probes, num_inv_quad_solves)
             inv_quad_term = (inv_quad_solves * inv_quad_rhs).sum(-2)
 
-        self.num_random_probes = num_random_probes
-        self.num_inv_quad_solves = num_inv_quad_solves
+        ctx.num_random_probes = num_random_probes
+        ctx.num_inv_quad_solves = num_inv_quad_solves
 
         to_save = list(matrix_args) + [solves, ]
-        self.save_for_backward(*to_save)
+        ctx.save_for_backward(*to_save)
 
         if settings.memory_efficient.off():
-            self._lazy_tsr = lazy_tsr
+            ctx._lazy_tsr = lazy_tsr
 
         return inv_quad_term, logdet_term
 
-    def backward(self, inv_quad_grad_output, logdet_grad_output):
+    @staticmethod
+    def backward(ctx, inv_quad_grad_output, logdet_grad_output):
         matrix_arg_grads = None
         inv_quad_rhs_grad = None
 
         # Which backward passes should we compute?
-        compute_inv_quad_grad = inv_quad_grad_output.abs().sum() and self.inv_quad
-        compute_logdet_grad = logdet_grad_output.abs().sum() and self.logdet
+        compute_inv_quad_grad = inv_quad_grad_output.abs().sum() and ctx.inv_quad
+        compute_logdet_grad = logdet_grad_output.abs().sum() and ctx.logdet
 
         # Get input arguments, and get gradients in the proper form
-        matrix_args = self.saved_tensors[:-1]
-        solves = self.saved_tensors[-1]
+        matrix_args = ctx.saved_tensors[:-1]
+        solves = ctx.saved_tensors[-1]
 
-        if hasattr(self, "_lazy_tsr"):
-            lazy_tsr = self._lazy_tsr
+        if hasattr(ctx, "_lazy_tsr"):
+            lazy_tsr = ctx._lazy_tsr
         else:
-            lazy_tsr = self.representation_tree(*matrix_args)
+            lazy_tsr = ctx.representation_tree(*matrix_args)
 
         # Fix grad_output sizes
-        if self.inv_quad:
+        if ctx.inv_quad:
             inv_quad_grad_output = inv_quad_grad_output.unsqueeze(-2)
         if compute_logdet_grad:
             logdet_grad_output = logdet_grad_output.unsqueeze(-1)
@@ -170,16 +172,16 @@ class InvQuadLogDet(Function):
         inv_quad_solves = None
         neg_inv_quad_solves_times_grad_out = None
         if compute_logdet_grad:
-            coef = 1.0 / self.probe_vectors.size(-1)
-            probe_vector_solves = solves.narrow(-1, 0, self.num_random_probes).mul(coef)
-            probe_vector_solves.mul_(self.probe_vector_norms).mul_(logdet_grad_output)
-            probe_vectors = self.probe_vectors.mul(self.probe_vector_norms)
-        if self.inv_quad:
-            inv_quad_solves = solves.narrow(-1, self.num_random_probes, self.num_inv_quad_solves)
+            coef = 1.0 / ctx.probe_vectors.size(-1)
+            probe_vector_solves = solves.narrow(-1, 0, ctx.num_random_probes).mul(coef)
+            probe_vector_solves.mul_(ctx.probe_vector_norms).mul_(logdet_grad_output)
+            probe_vectors = ctx.probe_vectors.mul(ctx.probe_vector_norms)
+        if ctx.inv_quad:
+            inv_quad_solves = solves.narrow(-1, ctx.num_random_probes, ctx.num_inv_quad_solves)
             neg_inv_quad_solves_times_grad_out = inv_quad_solves.mul(inv_quad_grad_output).mul_(-1)
 
         # input_1 gradient
-        if any(self.needs_input_grad):
+        if any(ctx.needs_input_grad):
             # Collect terms for arg grads
             left_factors_list = []
             right_factors_list = []
@@ -197,16 +199,16 @@ class InvQuadLogDet(Function):
             matrix_arg_grads = lazy_tsr._quad_form_derivative(left_factors, right_factors)
 
         # input_2 gradients
-        if compute_inv_quad_grad and self.needs_input_grad[0]:
+        if compute_inv_quad_grad and ctx.needs_input_grad[9]:
             inv_quad_rhs_grad = neg_inv_quad_solves_times_grad_out.mul_(-2)
-        elif self.inv_quad:
+        elif ctx.inv_quad:
             inv_quad_rhs_grad = torch.zeros_like(inv_quad_solves)
-        if self.is_vector:
+        if ctx.is_vector:
             inv_quad_rhs_grad.squeeze_(-1)
 
-        if self.inv_quad:
+        if ctx.inv_quad:
             res = tuple([inv_quad_rhs_grad] + list(matrix_arg_grads))
         else:
             res = matrix_arg_grads
 
-        return tuple(res)
+        return tuple([None] * 9 + [res])

--- a/gpytorch/functions/_inv_quad_log_det.py
+++ b/gpytorch/functions/_inv_quad_log_det.py
@@ -207,8 +207,8 @@ class InvQuadLogDet(Function):
             inv_quad_rhs_grad.squeeze_(-1)
 
         if ctx.inv_quad:
-            res = tuple([inv_quad_rhs_grad] + list(matrix_arg_grads))
+            res = [inv_quad_rhs_grad] + list(matrix_arg_grads)
         else:
             res = matrix_arg_grads
 
-        return tuple([None] * 9 + [res])
+        return tuple([None] * 9 + res)

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -942,7 +942,8 @@ class LazyTensor(ABC):
             )
 
         args = (tensor,) + self.representation()
-        inv_quad_term = InvQuad(representation_tree=self.representation_tree())(*args)
+        func = InvQuad.apply
+        inv_quad_term = func(self.representation_tree(), *args)
 
         if reduce_inv_quad:
             inv_quad_term = inv_quad_term.sum(-1)

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -885,14 +885,22 @@ class LazyTensor(ABC):
                     )
                 )
 
-        func = InvMatmul(
-            self.representation_tree(),
-            has_left=(left_tensor is not None),
-        )
+        func = InvMatmul
         if left_tensor is None:
-            return func(right_tensor, *self.representation())
+            return func.apply(
+                self.representation_tree(),
+                False,
+                right_tensor,
+                *self.representation(),
+            )
         else:
-            return func(left_tensor, right_tensor, *self.representation())
+            return func.apply(
+                self.representation_tree(),
+                True,
+                left_tensor,
+                right_tensor,
+                *self.representation(),
+            )
 
     def inv_quad(self, tensor, reduce_inv_quad=True):
         """

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1001,17 +1001,21 @@ class LazyTensor(ABC):
             args = [inv_quad_rhs] + list(args)
 
         probe_vectors, probe_vector_norms = self._probe_vectors_and_norms()
-        inv_quad_term, logdet_term = InvQuadLogDet(
-            representation_tree=self.representation_tree(),
-            matrix_shape=self.matrix_shape,
-            batch_shape=self.batch_shape,
-            dtype=self.dtype,
-            device=self.device,
-            inv_quad=(inv_quad_rhs is not None),
-            logdet=logdet,
-            probe_vectors=probe_vectors,
-            probe_vector_norms=probe_vector_norms,
-        )(*args)
+
+        func = InvQuadLogDet.apply
+
+        inv_quad_term, logdet_term = func(
+            self.representation_tree(),
+            self.dtype,
+            self.device,
+            self.matrix_shape,
+            self.batch_shape,
+            (inv_quad_rhs is not None),
+            logdet,
+            probe_vectors,
+            probe_vector_norms,
+            *args,
+        )
 
         if inv_quad_term.numel() and reduce_inv_quad:
             inv_quad_term = inv_quad_term.sum(-1)


### PR DESCRIPTION
Two changes in this PR:
- InvMatmul, InvQuadLogDet, and InvQuad now use the PyTorch 1.0.0 style function definition instead of the legacy definition.
- InvMatmul now calls `InvMatmul.apply` in the backward pass solve rather than `_solve` directly so that in a second derivative call we don't back prop through CG.

As a result of these changes, all three functions are now twice differentiable with respect to the lazy tensor args.

cc/ @martinjankowiak 