### PR TITLE
Remove default batch dimension from kernels

### DIFF
--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -116,10 +116,14 @@ class _MultivariateNormalBase(TMultivariateNormal, Distribution):
 
         # Repeat the covar to match the batch shape of diff
         if diff.shape[:-1] != covar.batch_shape:
-            padded_batch_shape = (*(1 for _ in range(diff.dim() + 1 - covar.dim())), *covar.batch_shape)
-            covar = covar.repeat(
-                *(diff_size // covar_size for diff_size, covar_size in zip(diff.shape[:-1], padded_batch_shape)), 1, 1
-            )
+            if len(diff.shape[:-1]) < len(covar.batch_shape):
+                diff = diff.expand(covar.shape[:-1])
+            else:
+                padded_batch_shape = (*(1 for _ in range(diff.dim() + 1 - covar.dim())), *covar.batch_shape)
+                covar = covar.repeat(
+                    *(diff_size // covar_size for diff_size, covar_size in zip(diff.shape[:-1], padded_batch_shape)),
+                    1, 1
+                )
 
         # Get log determininat and first part of quadratic form
         inv_quad, logdet = covar.inv_quad_logdet(inv_quad_rhs=diff.unsqueeze(-1), logdet=True)

--- a/gpytorch/kernels/additive_structure_kernel.py
+++ b/gpytorch/kernels/additive_structure_kernel.py
@@ -49,7 +49,7 @@ class AdditiveStructureKernel(Kernel):
             evaluate = True
             res = NonLazyTensor(res)
 
-        res = res.sum(-3).unsqueeze(0)
+        res = res.sum(0)
 
         if evaluate:
             res = res.evaluate()

--- a/gpytorch/kernels/cosine_kernel.py
+++ b/gpytorch/kernels/cosine_kernel.py
@@ -23,7 +23,7 @@ class CosineKernel(Kernel):
     Args:
         :attr:`batch_shape` (torch.Size, optional):
             Set this if you want a separate lengthscale for each
-            batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `torch.Size([1])`
+            batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `torch.Size([])`
         :attr:`active_dims` (tuple of ints, optional):
             Set this if you want to compute the covariance of only a few input dimensions. The ints
             corresponds to the indices of the dimensions. Default: `None`.

--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -58,13 +58,13 @@ class GridKernel(Kernel):
         return self
 
     def forward(self, x1, x2, diag=False, batch_dims=None, **params):
-        grid = self.grid.unsqueeze(0)
+        grid = self.grid
 
         if not self.interpolation_mode:
-            full_grid = self.full_grid.unsqueeze(0) if self.full_grid.dim() == 2 else self.full_grid
-
-        x1 = x1.unsqueeze(0) if x1.dim() == 2 else x1
-        x2 = x2.unsqueeze(0) if x2.dim() == 2 else x2
+            if len(x1.shape[:-2]):
+                full_grid = self.full_grid.expand(*x1.shape[:-2], *self.full_grid.shape[-2:])
+            else:
+                full_grid = self.full_grid
 
         if self.interpolation_mode or (torch.equal(x1, full_grid) and torch.equal(x2, full_grid)):
             if not self.training and hasattr(self, "_cached_kernel_mat"):
@@ -73,19 +73,19 @@ class GridKernel(Kernel):
             n_dim = x1.size(-1)
 
             if settings.use_toeplitz.on():
-                first_item = grid[:, 0:1]
+                first_item = grid[0:1]
                 covar_columns = self.base_kernel(first_item, grid, diag=False, batch_dims=(0, 2), **params)
                 covar_columns = delazify(covar_columns).squeeze(-2)
                 if batch_dims == (0, 2):
-                    covars = [ToeplitzLazyTensor(covar_columns)]
+                    covars = [ToeplitzLazyTensor(covar_columns.squeeze(-2))]
                 else:
-                    covars = [ToeplitzLazyTensor(covar_columns[i : i + 1]) for i in range(n_dim)]
+                    covars = [ToeplitzLazyTensor(covar_columns[i : i + 1].squeeze(-2)) for i in range(n_dim)]
             else:
                 full_covar = self.base_kernel(grid, grid, batch_dims=(0, 2), **params)
                 if batch_dims == (0, 2):
                     covars = [full_covar]
                 else:
-                    covars = [full_covar[i : i + 1] for i in range(n_dim)]
+                    covars = [full_covar[i : i + 1].squeeze(0) for i in range(n_dim)]
 
             if len(covars) > 1:
                 covar = KroneckerProductLazyTensor(*covars[::-1])

--- a/gpytorch/kernels/multitask_kernel.py
+++ b/gpytorch/kernels/multitask_kernel.py
@@ -43,7 +43,8 @@ class MultitaskKernel(Kernel):
         if batch_dims == (0, 2):
             raise RuntimeError("AdditiveGridInterpolationKernel does not accept the batch_dims argument.")
         covar_i = self.task_covar_module.covar_matrix
-        covar_i = covar_i.repeat(x1.size(0), 1, 1)
+        if len(x1.shape[:-2]):
+            covar_i = covar_i.repeat(*x1.shape[:-2], 1, 1)
         covar_x = lazify(self.data_covar_module.forward(x1, x2, **params))
         res = KroneckerProductLazyTensor(covar_x, covar_i)
         return res.diag() if diag else res
@@ -55,6 +56,6 @@ class MultitaskKernel(Kernel):
         """
         non_batch_size = (self.num_tasks * x1.size(-2), self.num_tasks * x2.size(-2))
         if x1.ndimension() == 3:
-            return torch.Size((x1.size(0),) + non_batch_size)
+            return torch.Size(x1.shape[:-2] + non_batch_size)
         else:
             return torch.Size(non_batch_size)

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -35,7 +35,7 @@ class PeriodicKernel(Kernel):
     Args:
         :attr:`batch_shape` (torch.Size, optional):
             Set this if you want a separate lengthscale for each
-             batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `torch.Size([1])`.
+             batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `torch.Size([])`.
         :attr:`active_dims` (tuple of ints, optional):
             Set this if you want to compute the covariance of only a few input dimensions. The ints
             corresponds to the indices of the dimensions. Default: `None`.

--- a/gpytorch/kernels/product_structure_kernel.py
+++ b/gpytorch/kernels/product_structure_kernel.py
@@ -54,7 +54,7 @@ class ProductStructureKernel(Kernel):
             evaluate = True
             res = NonLazyTensor(res)
 
-        res = res.prod(-3).unsqueeze(0)
+        res = res.prod(0)
 
         if evaluate:
             res = res.evaluate()

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -36,7 +36,7 @@ class RBFKernel(Kernel):
             input dimension. It should be `d` if :attr:`x1` is a `n x d` matrix. Default: `None`
         :attr:`batch_shape` (torch.Size, optional):
             Set this if you want a separate lengthscale for each
-            batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `torch.Size([1])`.
+            batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `torch.Size([])`.
         :attr:`active_dims` (tuple of ints, optional):
             Set this if you want to compute the covariance of only a few input dimensions. The ints
             corresponds to the indices of the dimensions. Default: `None`.

--- a/gpytorch/kernels/white_noise_kernel.py
+++ b/gpytorch/kernels/white_noise_kernel.py
@@ -35,25 +35,12 @@ class WhiteNoiseKernel(Kernel):
         super(WhiteNoiseKernel, self).__init__()
         self.register_buffer("variances", variances)
 
-        # Enforce that variances are batch_size x data_size x task_size
-        # where batch_size and task_size are both 1 in the simplest case.
-        if variances.ndimension() == 3:
-            self.is_batch = True
-            self.variances = variances
-        elif variances.ndimension() == 2:
-            # By default, assume 2 dimensional data means data_size x task_size, and add a batch_size of 1
-            self.is_batch = False
-            self.variances = variances.unsqueeze(0)
-        else:
-            self.is_batch = False
-            self.variances = variances.unsqueeze(0).unsqueeze(-1)
-
     def forward(self, x1, x2, **params):
         if self.training and torch.equal(x1, x2):
             # Reshape into a batch of batch_size diagonal matrices, each of which is
             # (data_size * task_size) x (data_size * task_size)
-            return DiagLazyTensor(self.variances.view(self.variances.size(0), -1))
-        elif x1.size(-2) == x2.size(-2) and x1.size(-2) == self.variances.size(1) and torch.equal(x1, x2):
-            return DiagLazyTensor(self.variances.view(self.variances.size(0), -1))
+            return DiagLazyTensor(self.variances.view(*x1.shape[:-2], -1))
+        elif x1.size(-2) == x2.size(-2) and x1.size(-2) == self.variances.size(-1) and torch.equal(x1, x2):
+            return DiagLazyTensor(self.variances.view(*x1.shape[:-2], -1))
         else:
-            return ZeroLazyTensor(x1.size(-3), x1.size(-2), x2.size(-2), dtype=x1.dtype, device=x1.device)
+            return ZeroLazyTensor(*x1.shape[:-2], x1.size(-2), x2.size(-2), dtype=x1.dtype, device=x1.device)

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -46,6 +46,8 @@ class LazyEvaluatedKernelTensor(LazyTensor):
             x1 = x1.view(-1, x1.size(-1), 1)
         try:
             x1 = x1[(*batch_indices, row_index, _noop_index)]
+        # We're going to handle multi-batch indexing with a try-catch loop
+        # This way - in the default case, we can avoid doing expansions of x1 which can be timely
         except IndexError:
             if isinstance(batch_indices, slice):
                 x1 = x1.expand(1, *self.x1.shape[-2:])[(*batch_indices, row_index, _noop_index)]
@@ -65,6 +67,8 @@ class LazyEvaluatedKernelTensor(LazyTensor):
             x2 = x2.view(-1, x2.size(-1), 1)
         try:
             x2 = x2[(*batch_indices, col_index, _noop_index)]
+        # We're going to handle multi-batch indexing with a try-catch loop
+        # This way - in the default case, we can avoid doing expansions of x1 which can be timely
         except IndexError:
             if isinstance(batch_indices, slice):
                 x2 = x2.expand(1, *self.x2.shape[-2:])[(*batch_indices, row_index, _noop_index)]

--- a/gpytorch/utils/broadcasting.py
+++ b/gpytorch/utils/broadcasting.py
@@ -3,7 +3,7 @@
 import torch
 
 
-def _mul_broadcast_shape(*shapes):
+def _mul_broadcast_shape(*shapes, error_msg=None):
     """Compute dimension suggested by multiple tensor indices (supports broadcasting)"""
 
     # Pad each shape so they have the same number of dimensions
@@ -16,7 +16,10 @@ def _mul_broadcast_shape(*shapes):
         non_singleton_sizes = tuple(size for size in size_by_dim if size != 1)
         if len(non_singleton_sizes):
             if any(size != non_singleton_sizes[0] for size in non_singleton_sizes):
-                raise RuntimeError("Shapes {} are not broadcastable for mul operation")
+                if error_msg is None:
+                    raise RuntimeError("Shapes are not broadcastable for mul operation")
+                else:
+                    raise RuntimeError(error_msg)
             final_size.append(non_singleton_sizes[0])
         # In this case - all dimensions are singleton sizes
         else:

--- a/test/examples/test_batch_gp_regression.py
+++ b/test/examples/test_batch_gp_regression.py
@@ -38,16 +38,26 @@ class ExactGPModel(gpytorch.models.ExactGP):
     def __init__(self, train_inputs, train_targets, likelihood, batch_size=1):
         super(ExactGPModel, self).__init__(train_inputs, train_targets, likelihood)
         self.mean_module = ConstantMean(batch_size=batch_size, prior=gpytorch.priors.SmoothedBoxPrior(-1, 1))
-        self.covar_module = ScaleKernel(
-            RBFKernel(
-                batch_size=batch_size,
-                lengthscale_prior=gpytorch.priors.NormalPrior(
-                    loc=torch.zeros(batch_size, 1, 1), scale=torch.ones(batch_size, 1, 1)
+        if batch_size > 1:
+            self.covar_module = ScaleKernel(
+                RBFKernel(
+                    batch_size=batch_size,
+                    lengthscale_prior=gpytorch.priors.NormalPrior(
+                        loc=torch.zeros(batch_size, 1, 1), scale=torch.ones(batch_size, 1, 1)
+                    ),
                 ),
-            ),
-            batch_size=batch_size,
-            outputscale_prior=gpytorch.priors.SmoothedBoxPrior(-2, 2),
-        )
+                batch_size=batch_size,
+                outputscale_prior=gpytorch.priors.SmoothedBoxPrior(-2, 2),
+            )
+        else:
+            self.covar_module = ScaleKernel(
+                RBFKernel(
+                    lengthscale_prior=gpytorch.priors.NormalPrior(
+                        loc=torch.zeros(batch_size, 1, 1), scale=torch.ones(batch_size, 1, 1)
+                    ),
+                ),
+                outputscale_prior=gpytorch.priors.SmoothedBoxPrior(-2, 2),
+            )
 
     def forward(self, x):
         mean_x = self.mean_module(x)
@@ -184,9 +194,9 @@ class TestBatchGPRegression(unittest.TestCase):
     def test_train_on_batch_test_on_batch_shared_hypers_over_batch(self):
         # We're manually going to set the hyperparameters to something they shouldn't be
         likelihood = GaussianLikelihood(
-            noise_prior=gpytorch.priors.NormalPrior(loc=torch.zeros(2), scale=torch.ones(2)), batch_size=1
+            noise_prior=gpytorch.priors.NormalPrior(loc=torch.zeros(2), scale=torch.ones(2))
         )
-        gp_model = ExactGPModel(train_x12, train_y12, likelihood, batch_size=1)
+        gp_model = ExactGPModel(train_x12, train_y12, likelihood)
         mll = gpytorch.ExactMarginalLogLikelihood(likelihood, gp_model)
 
         # Find optimal model hyperparameters

--- a/test/examples/test_batch_multitask_gp_regression.py
+++ b/test/examples/test_batch_multitask_gp_regression.py
@@ -37,16 +37,27 @@ class ExactGPModel(gpytorch.models.ExactGP):
         self.mean_module = MultitaskMean(
             ConstantMean(batch_size=batch_size, prior=gpytorch.priors.SmoothedBoxPrior(-1, 1)), num_tasks=2
         )
-        self.covar_module = MultitaskKernel(
-            RBFKernel(
-                batch_size=batch_size,
-                lengthscale_prior=gpytorch.priors.NormalPrior(
-                    loc=torch.zeros(batch_size, 1, 1), scale=torch.ones(batch_size, 1, 1)
+        if batch_size > 1:
+            self.covar_module = MultitaskKernel(
+                RBFKernel(
+                    batch_size=batch_size,
+                    lengthscale_prior=gpytorch.priors.NormalPrior(
+                        loc=torch.zeros(batch_size, 1, 1), scale=torch.ones(batch_size, 1, 1)
+                    ),
                 ),
-            ),
-            num_tasks=2,
-            rank=1,
-        )
+                num_tasks=2,
+                rank=1,
+            )
+        else:
+            self.covar_module = MultitaskKernel(
+                RBFKernel(
+                    lengthscale_prior=gpytorch.priors.NormalPrior(
+                        loc=torch.zeros(batch_size, 1, 1), scale=torch.ones(batch_size, 1, 1)
+                    ),
+                ),
+                num_tasks=2,
+                rank=1,
+            )
 
     def forward(self, x):
         mean_x = self.mean_module(x)

--- a/test/examples/test_grid_gp_regression.py
+++ b/test/examples/test_grid_gp_regression.py
@@ -80,7 +80,7 @@ class TestGridGPRegression(unittest.TestCase):
 
         optimizer = optim.Adam(list(gp_model.parameters()) + list(likelihood.parameters()), lr=0.1)
         optimizer.n_iter = 0
-        with gpytorch.settings.debug(False):
+        with gpytorch.settings.debug(True):
             for _ in range(20):
                 optimizer.zero_grad()
                 output = gp_model(train_x)
@@ -89,7 +89,7 @@ class TestGridGPRegression(unittest.TestCase):
                 optimizer.n_iter += 1
                 optimizer.step()
 
-            for param in gp_model.parameters():
+            for name, param in gp_model.named_parameters():
                 self.assertTrue(param.grad is not None)
                 self.assertGreater(param.grad.norm().item(), 0)
             for param in likelihood.parameters():

--- a/test/kernels/test_cosine_kernel.py
+++ b/test/kernels/test_cosine_kernel.py
@@ -79,18 +79,18 @@ class TestCosineKernel(unittest.TestCase):
         self.assertLess(torch.norm(res - actual), 1e-5)
 
         # batch_dims
-        actual = torch.zeros(4, 3, 3)
+        actual = torch.zeros(2, 2, 3, 3)
         for k in range(2):
             for i in range(3):
                 for j in range(3):
                     for l in range(2):
-                        actual[k * 2 + l, i, j] = torch.cos(math.pi * ((a[k, i, l] - b[k, j, l]) / period[k]))
+                        actual[l, k, i, j] = torch.cos(math.pi * ((a[k, i, l] - b[k, j, l]) / period[k]))
         res = kernel(a, b, batch_dims=(0, 2)).evaluate()
         self.assertLess(torch.norm(res - actual), 1e-5)
 
         # batch_dims + diag
         res = kernel(a, b, batch_dims=(0, 2)).diag()
-        actual = torch.cat([actual[i].diag().unsqueeze(0) for i in range(actual.size(0))])
+        actual = actual.diagonal(dim1=-2, dim2=-1)
         self.assertLess(torch.norm(res - actual), 1e-5)
 
 

--- a/test/kernels/test_linear_kernel.py
+++ b/test/kernels/test_linear_kernel.py
@@ -67,14 +67,14 @@ class TestLinearKernel(unittest.TestCase, BaseKernelTestCase):
 
         # batch_dims
         dim_group_a = a
-        dim_group_a = dim_group_a.permute(0, 2, 1).contiguous().view(-1, 3)
-        actual = torch.mul(dim_group_a.unsqueeze(-1), dim_group_a.unsqueeze(-2))
+        dim_group_a = dim_group_a.unsqueeze(0).transpose(0, -1)
+        actual = dim_group_a.matmul(dim_group_a.transpose(-2, -1))
         res = kernel(a, a, batch_dims=(0, 2)).evaluate()
         self.assertLess(torch.norm(res - actual), 1e-4)
 
         # batch_dims + diag
         res = kernel(a, a, batch_dims=(0, 2)).diag()
-        actual = torch.cat([actual[i].diag().unsqueeze(0) for i in range(actual.size(0))])
+        actual = actual.diagonal(dim1=-2, dim2=-1)
         self.assertLess(torch.norm(res - actual), 1e-4)
 
 

--- a/test/kernels/test_matern_kernel.py
+++ b/test/kernels/test_matern_kernel.py
@@ -136,23 +136,21 @@ class TestMaternKernel(unittest.TestCase, BaseKernelTestCase):
         # batch_dims
         dist = torch.tensor(
             [
-                [[0, 0], [1, 1]],
-                [[1, 1], [0, 0]],
-                [[0, 0], [0, 0]],
-                [[0, 0], [0, 0]],
-                [[0, 0], [0, 0]],
-                [[4, 4], [0, 0]],
-            ],
-            dtype=torch.float,
+                [[[0.0, 0.0], [1.0, 1.0]], [[0.0, 0.0], [0.0, 0.0]]],
+                [[[1.0, 1.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0]]],
+                [[[0.0, 0.0], [0.0, 0.0]], [[4.0, 4.0], [0.0, 0.0]]],
+            ]
         )
+
         dist.mul_(math.sqrt(5))
+        dist = dist.view(3, 2, 2, 2)
         actual = (dist ** 2 / 3 + dist + 1).mul(torch.exp(-dist))
         res = kernel(a, b, batch_dims=(0, 2)).evaluate()
         self.assertLess(torch.norm(res - actual), 1e-5)
 
         # batch_dims + diag
         res = kernel(a, b, batch_dims=(0, 2)).diag()
-        actual = torch.cat([actual[i].diag().unsqueeze(0) for i in range(actual.size(0))])
+        actual = actual.diagonal(dim1=-2, dim2=-1)
         self.assertLess(torch.norm(res - actual), 1e-5)
 
 

--- a/test/kernels/test_spectral_mixture_kernel.py
+++ b/test/kernels/test_spectral_mixture_kernel.py
@@ -11,12 +11,14 @@ class TestSpectralMixtureKernel(unittest.TestCase):
         a = torch.tensor([[0, 1], [2, 2], [2, 0]], dtype=torch.float)
         means = torch.tensor([[1, 2], [2, 1]], dtype=torch.float)
         scales = torch.tensor([[0.5, 0.25], [0.25, 0.5]], dtype=torch.float)
-        weights = [4, 2]
+        scales = scales.unsqueeze(1)
+        means = means.unsqueeze(1)
+        weights = torch.tensor([4, 2], dtype=torch.float)
         kernel = SpectralMixtureKernel(num_mixtures=2, ard_num_dims=2)
         kernel.initialize(
-            mixture_weights=torch.tensor([[4, 2]], dtype=torch.float),
-            mixture_means=torch.tensor([[[[1, 2]], [[2, 1]]]], dtype=torch.float),
-            mixture_scales=torch.tensor([[[[0.5, 0.25]], [[0.25, 0.5]]]], dtype=torch.float),
+            mixture_weights=weights,
+            mixture_means=means,
+            mixture_scales=scales,
         )
         kernel.eval()
 

--- a/test/kernels/test_white_noise_kernel.py
+++ b/test/kernels/test_white_noise_kernel.py
@@ -61,7 +61,7 @@ class TestWhiteNoiseKernel(unittest.TestCase):
 
     def test_computes_diag_eval_batch(self):
         a = torch.tensor([[4, 2, 8], [4, 2, 8]], dtype=torch.float).view(2, 3, 1)
-        variances = torch.randn(2, 3, 1)
+        variances = torch.randn(2, 3)
         kernel = WhiteNoiseKernel(variances=variances)
         kernel.eval()
         actual = torch.cat(


### PR DESCRIPTION
Right now the default batch shape for kernels is `torch.Size([1])`, with some squeezing if the data is not supplied as batch data.

This makes the default `batch_shape=torch.Size([])`. Saved models with the old default batch shape still load (with deprecation warning).

(Note that this speeds up evaluation quite a bit with small amounts of data).