### PR TITLE
Better psd_safe_cholesky, VI initialization

### DIFF
--- a/gpytorch/utils/cholesky.py
+++ b/gpytorch/utils/cholesky.py
@@ -31,7 +31,7 @@ def psd_safe_cholesky(A, upper=False, out=None, jitter=None):
         for i in range(3):
             jitter = jitter * (10 ** i)
             Aprime = A.clone()
-            Aprime.diagonal(dim1=-2, dim2=-1).mul_(jitter)
+            Aprime.diagonal(dim1=-2, dim2=-1).add_(jitter)
             try:
                 L = torch.cholesky(Aprime, upper=upper, out=out)
                 # TODO: Remove once fixed in pytorch (#16780)

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -7,6 +7,7 @@ from ..lazy import DiagLazyTensor, CachedCGLazyTensor, CholLazyTensor, PsdSumLaz
 from ..module import Module
 from ..distributions import MultivariateNormal
 from ..utils.memoize import cached
+from ..utils.cholesky import psd_safe_cholesky
 
 
 class VariationalStrategy(Module):
@@ -85,7 +86,7 @@ class VariationalStrategy(Module):
             prior_dist = self.prior_distribution
             eval_prior_dist = torch.distributions.MultivariateNormal(
                 loc=prior_dist.mean,
-                covariance_matrix=prior_dist.covariance_matrix
+                scale_tril=psd_safe_cholesky(prior_dist.covariance_matrix),
             )
             self.variational_distribution.initialize_variational_distribution(eval_prior_dist)
             self.variational_params_initialized.fill_(1)

--- a/test/utils/test_cholesky.py
+++ b/test/utils/test_cholesky.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import unittest
-import warnings
 from test._utils import least_used_cuda_device
 
 import torch
@@ -64,19 +63,13 @@ class TestPSDSafeCholesky(unittest.TestCase):
                 Aprime = A.clone()
                 Aprime[..., idx, idx] += 1e-6 if A.dtype == torch.float32 else 1e-8
                 L_exp = torch.cholesky(Aprime)
-                with warnings.catch_warnings(record=True) as ws:
-                    L_safe = psd_safe_cholesky(A)
-                    self.assertEqual(len(ws), 1)
-                    self.assertEqual(ws[-1].category, RuntimeWarning)
+                L_safe = psd_safe_cholesky(A)
                 self.assertTrue(torch.allclose(L_exp, L_safe))
                 # user-defined value
                 Aprime = A.clone()
                 Aprime[..., idx, idx] += 1e-2
                 L_exp = torch.cholesky(Aprime)
-                with warnings.catch_warnings(record=True) as ws:
-                    L_safe = psd_safe_cholesky(A, jitter=1e-2)
-                    self.assertEqual(len(ws), 1)
-                    self.assertEqual(ws[-1].category, RuntimeWarning)
+                L_safe = psd_safe_cholesky(A, jitter=1e-2)
                 self.assertTrue(torch.allclose(L_exp, L_safe))
 
     def test_psd_safe_cholesky_psd_cuda(self, cuda=False):


### PR DESCRIPTION
This PR makes two improvements:
1. If `psd_safe_cholesky` cant produce a positive definite matrix by adding jitter, it now tries to add increasing amounts of jitter for a few times to see if that will work.
2.  Our variational parameter initialization now uses `psd_safe_cholesky` instead of `torch.cholesky` by specifying `scale_tril`.