### PR TITLE
Less lazy kernel evaluation for small predictions

### DIFF
--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -218,6 +218,10 @@ class LazyEvaluatedKernelTensor(LazyTensor):
     def evaluate(self):
         return self.evaluate_kernel().evaluate()
 
+    def ndimension(self):
+        # TODO: fix this with the remove_batch_dim PR
+        return max(self.x2.dim(), self.x2.dim())
+
     def repeat(self, *repeats):
         if len(repeats) == 1 and hasattr(repeats[0], "__iter__"):
             repeats = repeats[0]

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -5,7 +5,8 @@ import torch
 from .. import settings
 from ..distributions import MultivariateNormal
 from ..lazy import (
-    InterpolatedLazyTensor, LazyTensor, MatmulLazyTensor, RootLazyTensor, SumLazyTensor, ZeroLazyTensor
+    InterpolatedLazyTensor, LazyTensor, MatmulLazyTensor, RootLazyTensor, SumLazyTensor, ZeroLazyTensor,
+    lazify
 )
 from ..utils.interpolation import left_interp, left_t_interp
 from ..utils.memoize import cached
@@ -306,8 +307,6 @@ class DefaultPredictionStrategy(object):
             :obj:`gpytorch.lazy.LazyTensor`: A LazyTensor representing the predictive posterior covariance of the
                                                test points
         """
-        from ..distributions import MultivariateNormal
-
         if settings.fast_pred_var.on():
             self._last_test_train_covar = test_train_covar
 
@@ -327,12 +326,22 @@ class DefaultPredictionStrategy(object):
             test_train_covar = test_train_covar.evaluate()
             train_test_covar = test_train_covar.transpose(-1, -2)
             covar_correction_rhs = train_train_covar.inv_matmul(train_test_covar).mul(-1)
-            return test_test_covar + MatmulLazyTensor(test_train_covar, covar_correction_rhs)
+            if torch.is_tensor(test_test_covar):
+                return lazify(test_test_covar + test_train_covar @ covar_correction_rhs)
+            else:
+                return test_test_covar + MatmulLazyTensor(test_train_covar, covar_correction_rhs)
 
         precomputed_cache = self.covar_cache
         covar_inv_quad_form_root = self._exact_predictive_covar_inv_quad_form_root(precomputed_cache,
                                                                                    test_train_covar)
-        return test_test_covar + RootLazyTensor(covar_inv_quad_form_root).mul(-1)
+        if torch.is_tensor(test_test_covar):
+            return lazify(
+                torch.add(test_test_covar, -1, covar_inv_quad_form_root @ covar_inv_quad_form_root.transpose(-1, -2))
+            )
+        else:
+            return test_test_covar + MatmulLazyTensor(
+                covar_inv_quad_form_root, covar_inv_quad_form_root.transpose(-1, -2).mul(-1)
+            )
 
 
 @register_prediction_strategy(InterpolatedLazyTensor)

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -310,6 +310,16 @@ class lazily_evaluate_kernels(_feature_flag):
     _state = True
 
 
+class max_eager_kernel_size(_value_context):
+    """
+    If the joint train/test covariance matrix is less than this size, then we will avoid as
+    much lazy evaluation of the kernel as possible.
+    Default: 512
+    """
+
+    _global_value = 512
+
+
 class max_cg_iterations(_value_context):
     """
     The maximum number of conjugate gradient iterations to perform (when computing


### PR DESCRIPTION
This PR does a majority of kernel prediction operations not in lazy mode.
It lazily computes `[k* k**]` in batch, and then does most operations with torch.tensors.

This reduces the overhead with small predictions.