### PR TITLE
Replacing SMW solve in pivoted Cholesky with a more stable QR version

### DIFF
--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -34,11 +34,7 @@ class AddedDiagLazyTensor(SumLazyTensor):
             raise RuntimeError("One of the LazyTensors input to AddedDiagLazyTensor must be a DiagLazyTensor!")
 
     def _matmul(self, rhs):
-        return torch.addcmul(
-            self._lazy_tensor._matmul(rhs),
-            self._diag_tensor._diag.unsqueeze(-1),
-            rhs
-        )
+        return torch.addcmul(self._lazy_tensor._matmul(rhs), self._diag_tensor._diag.unsqueeze(-1), rhs)
 
     def add_diag(self, added_diag):
         return AddedDiagLazyTensor(self._lazy_tensor, self._diag_tensor.add_diag(added_diag))
@@ -73,27 +69,34 @@ class AddedDiagLazyTensor(SumLazyTensor):
                 eye = torch.eye(k, dtype=self._piv_chol_self.dtype, device=self._piv_chol_self.device)
 
                 if constant_diag:
+                    # We can factor out the noise for for both QR and solves.
                     noise_constant = self._noise[0].squeeze()
-                    self._q_cache, self._r_cache = torch.qr(torch.cat((self._piv_chol_self, noise_constant.sqrt() * eye)))
+                    self._q_cache, self._r_cache = torch.qr(
+                        torch.cat((self._piv_chol_self, noise_constant.sqrt() * eye))
+                    )
                     self._q_cache = self._q_cache[:n, :]
 
+                    # Use the matrix determinant lemma for the logdet, using the fact that R'R = L_k'L_k + s*I
                     logdet = self._r_cache.diagonal(dim1=-1, dim2=-2).abs().log().sum(-1).mul(2)
                     logdet = logdet + (n - k) * noise_constant.log()
                     self._precond_logdet_cache = logdet.view(*batch_shape) if len(batch_shape) else logdet.squeeze()
 
                     def precondition_closure(rhs: torch.Tensor):
                         return (1 / noise_constant) * (rhs - self._q_cache.matmul(self._q_cache.t().matmul(rhs)))
+
                 else:
+                    # With non-constant diagonals, we cant factor out the noise as easily
                     self._q_cache, self._r_cache = torch.qr(torch.cat((self._piv_chol_self / self._noise.sqrt(), eye)))
                     self._q_cache = self._q_cache[:n, :] / self._noise.sqrt()
 
-                    # Use the matrix determinant lemma for the logdet
-                    logdet = self._r_cache.diagonal(dim1=-1, dim2=-2).abs().log().sum(-1).mul(2) - \
-                        (1.0 / self._noise).log().sum([-1, -2])
+                    logdet = self._r_cache.diagonal(dim1=-1, dim2=-2).abs().log().sum(-1).mul(2) - (
+                        1.0 / self._noise
+                    ).log().sum([-1, -2])
                     self._precond_logdet_cache = logdet.view(*batch_shape) if len(batch_shape) else logdet.squeeze()
 
                     def precondition_closure(rhs: torch.Tensor):
                         return (rhs / self._noise) - self._q_cache.matmul(self._q_cache.t().matmul(rhs))
+
             else:
                 self._woodbury_cache, self._inv_scale, self._precond_logdet_cache = woodbury.woodbury_factor(
                     self._piv_chol_self, self._piv_chol_self, self._diag_tensor.diag(), logdet=True
@@ -104,8 +107,11 @@ class AddedDiagLazyTensor(SumLazyTensor):
                 # preconditioner
                 def precondition_closure(tensor):
                     res = woodbury.woodbury_solve(
-                        tensor, self._scaled_inv_diag_piv_chol_self, self._woodbury_cache,
-                        self._scaled_inv_diag, self._inv_scale
+                        tensor,
+                        self._scaled_inv_diag_piv_chol_self,
+                        self._woodbury_cache,
+                        self._scaled_inv_diag,
+                        self._inv_scale,
                     )
                     return res
 

--- a/test/utils/test_pivoted_cholesky.py
+++ b/test/utils/test_pivoted_cholesky.py
@@ -50,13 +50,13 @@ class TestPivotedCholesky(unittest.TestCase):
 
         self.assertTrue(approx_equal(approx_solve, real_solve, 2e-4))
 
-    def test_solve_qr_float64(self):
-        size = 100
-        X = torch.rand((size, 3)).to(dtype=torch.float64)
-        y = torch.sin(torch.sum(X, 1)).unsqueeze(-1).to(dtype=torch.float64)
+    def test_solve_qr(self, dtype=torch.float64, tol=1e-8):
+        size = 50
+        X = torch.rand((size, 2)).to(dtype=dtype)
+        y = torch.sin(torch.sum(X, 1)).unsqueeze(-1).to(dtype=dtype)
 
-        noise = torch.DoubleTensor(size,).uniform_(math.log(1e-6), math.log(1e-2)).exp_()
-        lazy_tsr = RBFKernel().to(dtype=torch.float64)(X).evaluate_kernel().add_diag(noise)
+        noise = torch.DoubleTensor(size,).uniform_(math.log(1e-3), math.log(1e-1)).exp_().to(dtype=dtype)
+        lazy_tsr = RBFKernel().to(dtype=dtype)(X).evaluate_kernel().add_diag(noise)
         precondition_qr, logdet_qr = lazy_tsr._preconditioner()
 
         F = lazy_tsr._piv_chol_self
@@ -64,10 +64,13 @@ class TestPivotedCholesky(unittest.TestCase):
 
         x_exact = torch.gesv(y, M)[0]
         x_qr = precondition_qr(y)
-        self.assertTrue(approx_equal(x_exact, x_qr, 1e-6))
+        self.assertTrue(approx_equal(x_exact, x_qr, tol))
 
         logdet = 2 * torch.cholesky(M).diag().log().sum(-1)
-        self.assertTrue(approx_equal(logdet, logdet_qr, 1e-6))
+        self.assertTrue(approx_equal(logdet, logdet_qr, tol))
+
+    def test_solve_qr_float32(self):
+        self.test_solve_qr(dtype=torch.float32, tol=1e-3)
 
 
 class TestPivotedCholeskyBatch(unittest.TestCase):

--- a/test/utils/test_pivoted_cholesky.py
+++ b/test/utils/test_pivoted_cholesky.py
@@ -64,13 +64,37 @@ class TestPivotedCholesky(unittest.TestCase):
 
         x_exact = torch.gesv(y, M)[0]
         x_qr = precondition_qr(y)
+
+        self.assertTrue(approx_equal(x_exact, x_qr, tol))
+
+        logdet = 2 * torch.cholesky(M).diag().log().sum(-1)
+        self.assertTrue(approx_equal(logdet, logdet_qr, tol))
+
+    def test_solve_qr_constant_noise(self, dtype=torch.float64, tol=1e-8):
+        size = 50
+        X = torch.rand((size, 2)).to(dtype=dtype)
+        y = torch.sin(torch.sum(X, 1)).unsqueeze(-1).to(dtype=dtype)
+
+        noise = 1e-2 * torch.ones(size, dtype=dtype)
+        lazy_tsr = RBFKernel().to(dtype=dtype)(X).evaluate_kernel().add_diag(noise)
+        precondition_qr, logdet_qr = lazy_tsr._preconditioner()
+
+        F = lazy_tsr._piv_chol_self
+        M = noise.diag() + F.matmul(F.t())
+
+        x_exact = torch.gesv(y, M)[0]
+        x_qr = precondition_qr(y)
+
         self.assertTrue(approx_equal(x_exact, x_qr, tol))
 
         logdet = 2 * torch.cholesky(M).diag().log().sum(-1)
         self.assertTrue(approx_equal(logdet, logdet_qr, tol))
 
     def test_solve_qr_float32(self):
-        self.test_solve_qr(dtype=torch.float32, tol=1e-3)
+        self.test_solve_qr(dtype=torch.float32, tol=1e-2)
+
+    def test_solve_qr_constant_noise_float32(self):
+        self.test_solve_qr_constant_noise(dtype=torch.float32, tol=1e-3)
 
 
 class TestPivotedCholeskyBatch(unittest.TestCase):


### PR DESCRIPTION
- Applying the pivoted Cholesky preconditioner is much more accurate via the QR factorization
- `torch.qr` doesn't support batch, so SMW is still used in the batch setting