### PR TITLE
Throw error when initializing parameter value to something out of bounds

### DIFF
--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -44,7 +44,13 @@ class Interval(Module):
         return self._transform is not None
 
     def check(self, tensor):
-        return torch.all(tensor <= self.upper_bound) and torch.all(tensor >= self.lower_bound)
+        return bool(torch.all(tensor <= self.upper_bound) and torch.all(tensor >= self.lower_bound))
+
+    def check_raw(self, tensor):
+        return bool(
+            torch.all((self.transform(tensor) <= self.upper_bound))
+            and torch.all(self.transform(tensor) >= self.lower_bound)
+        )
 
     def intersect(self, other):
         """

--- a/test/kernels/_base_kernel_test_case.py
+++ b/test/kernels/_base_kernel_test_case.py
@@ -20,7 +20,7 @@ class BaseKernelTestCase(object):
         kernel_basic = self.create_kernel_no_ard()
         covar_mat_actual = kernel_basic(x[:, [0, 2, 4, 6]]).evaluate_kernel().evaluate()
 
-        self.assertLess(torch.norm(covar_mat - covar_mat_actual), 1e-4)
+        self.assertLess(torch.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(), 1e-4)
 
     def test_active_dims_range(self):
         active_dims = list(range(3, 9))
@@ -30,7 +30,7 @@ class BaseKernelTestCase(object):
         kernel_basic = self.create_kernel_no_ard()
         covar_mat_actual = kernel_basic(x[:, active_dims]).evaluate_kernel().evaluate()
 
-        self.assertLess(torch.norm(covar_mat - covar_mat_actual), 1e-4)
+        self.assertLess(torch.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(), 1e-4)
 
     def test_no_batch_kernel_single_batch_x_no_ard(self):
         kernel = self.create_kernel_no_ard()
@@ -41,7 +41,7 @@ class BaseKernelTestCase(object):
         actual_mat_2 = kernel(x[1]).evaluate_kernel().evaluate()
         actual_covar_mat = torch.cat([actual_mat_1.unsqueeze(0), actual_mat_2.unsqueeze(0)])
 
-        self.assertLess(torch.norm(batch_covar_mat - actual_covar_mat), 1e-4)
+        self.assertLess(torch.norm(batch_covar_mat - actual_covar_mat) / actual_covar_mat.norm(), 1e-4)
 
     def test_single_batch_kernel_single_batch_x_no_ard(self):
         kernel = self.create_kernel_no_ard(batch_shape=torch.Size([]))
@@ -52,7 +52,7 @@ class BaseKernelTestCase(object):
         actual_mat_2 = kernel(x[1]).evaluate_kernel().evaluate()
         actual_covar_mat = torch.cat([actual_mat_1.unsqueeze(0), actual_mat_2.unsqueeze(0)])
 
-        self.assertLess(torch.norm(batch_covar_mat - actual_covar_mat), 1e-4)
+        self.assertLess(torch.norm(batch_covar_mat - actual_covar_mat) / actual_covar_mat.norm(), 1e-4)
 
     def test_no_batch_kernel_double_batch_x_no_ard(self):
         kernel = self.create_kernel_no_ard(batch_shape=torch.Size([]))
@@ -68,7 +68,7 @@ class BaseKernelTestCase(object):
 
         actual_covar_mat = torch.cat([ac.unsqueeze(0) for ac in ij_actual_covars])
 
-        self.assertLess(torch.norm(batch_covar_mat - actual_covar_mat), 1e-4)
+        self.assertLess(torch.norm(batch_covar_mat - actual_covar_mat) / actual_covar_mat.norm(), 1e-4)
 
     def test_no_batch_kernel_double_batch_x_ard(self):
         try:
@@ -88,7 +88,7 @@ class BaseKernelTestCase(object):
 
         actual_covar_mat = torch.cat([ac.unsqueeze(0) for ac in ij_actual_covars])
 
-        self.assertLess(torch.norm(batch_covar_mat - actual_covar_mat), 1e-4)
+        self.assertLess(torch.norm(batch_covar_mat - actual_covar_mat) / actual_covar_mat.norm(), 1e-4)
 
     def test_smoke_double_batch_kernel_double_batch_x_no_ard(self):
         kernel = self.create_kernel_no_ard(batch_shape=torch.Size([3, 2]))


### PR DESCRIPTION
Right now, initializing a parameter to a value that is out of its constraint bounds silently initializes it to NaN. For example:
```python
likelihood = GaussianLikelihood(noise_constraint=GreaterThan(1e-4))  # This is the default
likelihood.noise = 1e-5  # Out of bounds! Noise value is now nan with no error.
```

We now throw an error with a suggestion for what to do in the likelihood case specifically, because that's the only default constraint we have that this would realistically happen for (since all other default constraints are simply `Positive()`.

Fixes #620 