### PR TITLE
Fix setters for non-tensor initialization values

### DIFF
--- a/gpytorch/kernels/cosine_kernel.py
+++ b/gpytorch/kernels/cosine_kernel.py
@@ -82,7 +82,7 @@ class CosineKernel(Kernel):
 
     def _set_period_length(self, value):
         if not torch.is_tensor(value):
-            value = torch.tensor(value)
+            value = torch.as_tensor(value).to(self.raw_period_length)
 
         self.initialize(raw_period_length=self.raw_period_length_constraint.inverse_transform(value))
 

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -272,7 +272,7 @@ class Kernel(Module):
             raise RuntimeError("Kernel has no lengthscale.")
 
         if not torch.is_tensor(value):
-            value = torch.tensor(value)
+            value = torch.as_tensor(value).to(self.raw_lengthscale)
 
         self.initialize(raw_lengthscale=self.raw_lengthscale_constraint.inverse_transform(value))
 

--- a/gpytorch/kernels/linear_kernel.py
+++ b/gpytorch/kernels/linear_kernel.py
@@ -91,7 +91,7 @@ class LinearKernel(Kernel):
 
     def _set_variance(self, value):
         if not torch.is_tensor(value):
-            value = torch.tensor(value)
+            value = torch.as_tensor(value).to(self.raw_variance)
         self.initialize(raw_variance=self.raw_variance_constraint.inverse_transform(value))
 
     def forward(self, x1, x2, diag=False, batch_dims=None, **params):

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -99,7 +99,7 @@ class PeriodicKernel(Kernel):
 
     def _set_period_length(self, value):
         if not torch.is_tensor(value):
-            value = torch.tensor(value)
+            value = torch.as_tensor(value).to(self.raw_period_length)
         self.initialize(raw_period_length=self.raw_period_length_constraint.inverse_transform(value))
 
     def forward(self, x1, x2, **params):

--- a/gpytorch/kernels/scale_kernel.py
+++ b/gpytorch/kernels/scale_kernel.py
@@ -75,7 +75,7 @@ class ScaleKernel(Kernel):
 
     def _set_outputscale(self, value):
         if not torch.is_tensor(value):
-            value = torch.tensor(value)
+            value = torch.as_tensor(value).to(self.raw_outputscale)
         self.initialize(raw_outputscale=self.raw_outputscale_constraint.inverse_transform(value))
 
     def forward(self, x1, x2, batch_dims=None, diag=False, **params):

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -115,7 +115,7 @@ class SpectralMixtureKernel(Kernel):
 
     def _set_mixture_scales(self, value):
         if not torch.is_tensor(value):
-            value = torch.tensor(value)
+            value = torch.as_tensor(value).to(self.raw_mixture_scales)
         self.initialize(raw_mixture_scales=self.raw_mixture_scales_constraint.inverse_transform(value))
 
     @property
@@ -128,7 +128,7 @@ class SpectralMixtureKernel(Kernel):
 
     def _set_mixture_means(self, value):
         if not torch.is_tensor(value):
-            value = torch.tensor(value)
+            value = torch.as_tensor(value).to(self.raw_mixture_means)
         self.initialize(raw_mixture_means=self.raw_mixture_means_constraint.inverse_transform(value))
 
     @property
@@ -141,7 +141,7 @@ class SpectralMixtureKernel(Kernel):
 
     def _set_mixture_weights(self, value):
         if not torch.is_tensor(value):
-            value = torch.tensor(value)
+            value = torch.as_tensor(value).to(self.raw_mixture_weights)
         self.initialize(raw_mixture_weights=self.raw_mixture_weights_constraint.inverse_transform(value))
 
     def initialize_from_data(self, train_x, train_y, **kwargs):

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -183,7 +183,7 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
 
     def _set_noise(self, value):
         if not torch.is_tensor(value):
-            value = torch.tensor(value)
+            value = torch.as_tensor(value).to(self.raw_noise)
         self.initialize(raw_noise=self.raw_noise_constraint.inverse_transform(value))
 
     def _shaped_noise_covar(self, base_shape, *params):

--- a/gpytorch/likelihoods/noise_models.py
+++ b/gpytorch/likelihoods/noise_models.py
@@ -39,7 +39,7 @@ class _HomoskedasticNoiseBase(Noise):
 
     def _set_noise(self, value: Tensor) -> None:
         if not torch.is_tensor(value):
-            value = torch.tensor(value)
+            value = torch.as_tensor(value).to(self.raw_noise)
         self.initialize(raw_noise=self.raw_noise_constraint.inverse_transform(value))
 
     def forward(self, *params: Any, shape: Optional[torch.Size] = None) -> DiagLazyTensor:


### PR DESCRIPTION
Previously, if a model was on cuda or using double, these setters would error out when trying to set a value using a python float. This fixes the issue by moving the constructed tensor to the right device/dtype.