### PR TITLE
RBFKernelGrad fixes and improvements

### DIFF
--- a/gpytorch/kernels/rbf_kernel_grad.py
+++ b/gpytorch/kernels/rbf_kernel_grad.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from .rbf_kernel import RBFKernel
+from .rbf_kernel import RBFKernel, postprocess_rbf
 import torch
 from ..lazy.kronecker_product_lazy_tensor import KroneckerProductLazyTensor
 
@@ -67,8 +67,14 @@ class RBFKernelGrad(RBFKernel):
             outer = torch.transpose(outer, -1, -2).contiguous()
 
             # 1) Kernel block
-            diff = self.covar_dist(x1_, x2_, square_dist=True, **params)
-            K_11 = diff.div_(-2).exp_()
+            diff = self.covar_dist(
+                x1_,
+                x2_,
+                square_dist=True,
+                dist_postprocess_func=postprocess_rbf,
+                **params
+            )
+            K_11 = diff
             K[..., :n1, :n2] = K_11
 
             # 2) First gradient block

--- a/test/kernels/test_rbf_kernel_grad.py
+++ b/test/kernels/test_rbf_kernel_grad.py
@@ -3,9 +3,16 @@
 import torch
 import unittest
 from gpytorch.kernels import RBFKernelGrad
+from test.kernels._base_kernel_test_case import BaseKernelTestCase
 
 
-class TestRBFKernelGrad(unittest.TestCase):
+class TestRBFKernelGrad(unittest.TestCase, BaseKernelTestCase):
+    def create_kernel_no_ard(self, **kwargs):
+        return RBFKernelGrad(**kwargs)
+
+    def create_kernel_ard(self, num_dims, **kwargs):
+        return RBFKernelGrad(ard_num_dims=num_dims, **kwargs)
+
     def test_kernel(self, cuda=False):
         a = torch.tensor([[[1, 2], [2, 4]]], dtype=torch.float)
         b = torch.tensor([[[1, 3], [0, 4]]], dtype=torch.float)


### PR DESCRIPTION
- RBFKernelGrad now uses JIT for kernel postprocessing
- RBFKernelGrad now supports multibatch
- Use base kernel test cases for RBFKernelGrad
- Fix an issue where RBFKernelGrad was modifying `self.lengthscale` in-place.