### PR TITLE
Add pip-wheel-metadata/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ parts/
 sdist/
 var/
 wheels/
+pip-wheel-metadata/
 *.egg-info/
 .installed.cfg
 *.egg


### PR DESCRIPTION
Avoids having the folder generated when doing `pip install -e .` be tracked.