### PR TITLE
Fix handling of preconditioned logdet calculation

### DIFF
--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -4,6 +4,9 @@ import torch
 import warnings
 from .sum_lazy_tensor import SumLazyTensor
 from .diag_lazy_tensor import DiagLazyTensor
+from .psd_sum_lazy_tensor import PsdSumLazyTensor
+from .root_lazy_tensor import RootLazyTensor
+
 from ..utils import broadcasting, pivoted_cholesky, woodbury
 from .. import settings
 
@@ -115,6 +118,8 @@ class AddedDiagLazyTensor(SumLazyTensor):
                     )
                     return res
 
+            self.preconditioner_lt = PsdSumLazyTensor(RootLazyTensor(self._piv_chol_self), self._diag_tensor)
+
             self.precondition_closure = precondition_closure
 
-        return self.precondition_closure, self._precond_logdet_cache
+        return self.precondition_closure, self.preconditioner_lt, self._precond_logdet_cache

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -423,7 +423,7 @@ class LazyTensor(ABC):
         Returns:
             function: a function on x which performs P^{-1}(x)
         """
-        base_precond, _ = self._preconditioner()
+        base_precond, _, _ = self._preconditioner()
 
         if base_precond is not None:
             return base_precond
@@ -500,7 +500,7 @@ class LazyTensor(ABC):
             function: a function on x which performs P^{-1}(x)
             scalar: the log determinant of P
         """
-        return None, None
+        return None, None, None
 
     def _probe_vectors_and_norms(self):
         return None, None

--- a/test/functions/test_root_decomposition.py
+++ b/test/functions/test_root_decomposition.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
-from .._base_test_case import BaseTestCase
+from test._base_test_case import BaseTestCase
 
 import torch
 from gpytorch.lazy import NonLazyTensor

--- a/test/utils/test_pivoted_cholesky.py
+++ b/test/utils/test_pivoted_cholesky.py
@@ -57,7 +57,7 @@ class TestPivotedCholesky(unittest.TestCase):
 
         noise = torch.DoubleTensor(size,).uniform_(math.log(1e-3), math.log(1e-1)).exp_().to(dtype=dtype)
         lazy_tsr = RBFKernel().to(dtype=dtype)(X).evaluate_kernel().add_diag(noise)
-        precondition_qr, logdet_qr = lazy_tsr._preconditioner()
+        precondition_qr, _, logdet_qr = lazy_tsr._preconditioner()
 
         F = lazy_tsr._piv_chol_self
         M = noise.diag() + F.matmul(F.t())
@@ -77,7 +77,7 @@ class TestPivotedCholesky(unittest.TestCase):
 
         noise = 1e-2 * torch.ones(size, dtype=dtype)
         lazy_tsr = RBFKernel().to(dtype=dtype)(X).evaluate_kernel().add_diag(noise)
-        precondition_qr, logdet_qr = lazy_tsr._preconditioner()
+        precondition_qr, _, logdet_qr = lazy_tsr._preconditioner()
 
         F = lazy_tsr._piv_chol_self
         M = noise.diag() + F.matmul(F.t())


### PR DESCRIPTION
This PR fixes an issue where we weren't correctly accounting for the existence of a preconditioner when setting up probe vectors for the log determinant.

This somewhat affects the forward pass calculation of the marginal likelihood, but not the backward pass.