### PR TITLE
Remove deprecated beta_features.fast_pred_*

### DIFF
--- a/gpytorch/__init__.py
+++ b/gpytorch/__init__.py
@@ -37,9 +37,6 @@ from .lazy import lazify, delazify
 
 __version__ = "0.2.1"
 
-# Old deprecated stuff
-fast_pred_var = beta_features._moved_beta_feature(settings.fast_pred_var, "gpytorch.settings.fast_pred_var")
-
 __all__ = [
     # Submodules
     "distributions",
@@ -77,7 +74,6 @@ __all__ = [
     # Other
     "__version__",
     # Deprecated
-    "fast_pred_var",
     "inv_quad_log_det",
     "log_det",
 ]

--- a/gpytorch/beta_features.py
+++ b/gpytorch/beta_features.py
@@ -2,8 +2,6 @@
 
 import warnings
 from .settings import _feature_flag, _value_context
-from .settings import fast_pred_var as _fast_pred_var
-from .settings import fast_pred_samples as _fast_pred_samples
 
 
 class _moved_beta_feature(object):
@@ -20,10 +18,6 @@ class _moved_beta_feature(object):
 
     def __getattr__(self, name):
         return getattr(self.new_cls, name)
-
-
-fast_pred_var = _moved_beta_feature(_fast_pred_var)
-fast_pred_samples = _moved_beta_feature(_fast_pred_samples)
 
 
 class checkpoint_kernel(_value_context):
@@ -61,4 +55,4 @@ class default_preconditioner(_feature_flag):
     pass
 
 
-__all__ = ["fast_pred_var", "fast_pred_samples", "diagonal_correction", "default_preconditioner"]
+__all__ = ["checkpoint_kernel", "diagonal_correction", "default_preconditioner"]


### PR DESCRIPTION
This is an old deprecation warning that should be removed for 0.3.0.

Closes #524