### PR TITLE
Make noise an attribute in FixedGaussianNoise

### DIFF
--- a/gpytorch/likelihoods/noise_models.py
+++ b/gpytorch/likelihoods/noise_models.py
@@ -153,7 +153,7 @@ class HeteroskedasticNoise(Noise):
 class FixedGaussianNoise(Module):
     def __init__(self, noise: Tensor) -> None:
         super().__init__()
-        self.register_buffer("noise", noise)
+        self.noise = noise
 
     def forward(
         self,
@@ -172,3 +172,7 @@ class FixedGaussianNoise(Module):
             return DiagLazyTensor(self.noise)
         else:
             return ZeroLazyTensor()
+
+    def _apply(self, fn):
+        self.noise = fn(self.noise)
+        return super(FixedGaussianNoise, self)._apply(fn)

--- a/test/examples/test_kissgp_white_noise_regression.py
+++ b/test/examples/test_kissgp_white_noise_regression.py
@@ -131,7 +131,7 @@ class TestKISSGPWhiteNoiseRegression(unittest.TestCase):
 
             # Now bump up the likelihood to something huge
             # This will make it easy to calculate the variance
-            likelihood.initialize(noise=3.)
+            likelihood.noise = torch.ones(100) * 3.0
             test_function_predictions = likelihood(gp_model(train_x))
 
             noise = likelihood.noise


### PR DESCRIPTION
The current issue is the load_state_dict functionality does not work in the case when loading the state_dict from model A with `n` training points into model B with `m` training points where `m!=n` both use a likelihood with a FixedGaussianNoiseModel. This approach follows the pattern used by `ExactGP` to extend the `_apply` function to apply to `noise` as an attribute.