### PR TITLE
Add gpytorch.cat function

### DIFF
--- a/gpytorch/__init__.py
+++ b/gpytorch/__init__.py
@@ -32,7 +32,7 @@ from .functions import (
     log_det,
 )
 from .mlls import ExactMarginalLogLikelihood, VariationalMarginalLogLikelihood
-from .lazy import lazify, delazify
+from .lazy import lazify, delazify, cat
 
 
 __version__ = "0.3.1"
@@ -56,6 +56,7 @@ __all__ = [
     # Functions
     "add_diag",
     "add_jitter",
+    "cat",
     "delazify",
     "dsmm",
     "inv_matmul",

--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -6,7 +6,7 @@ from .batch_repeat_lazy_tensor import BatchRepeatLazyTensor
 from .block_lazy_tensor import BlockLazyTensor
 from .block_diag_lazy_tensor import BlockDiagLazyTensor
 from .cached_cg_lazy_tensor import CachedCGLazyTensor
-from .cat_lazy_tensor import CatLazyTensor
+from .cat_lazy_tensor import cat, CatLazyTensor
 from .chol_lazy_tensor import CholLazyTensor
 from .constant_mul_lazy_tensor import ConstantMulLazyTensor
 from .diag_lazy_tensor import DiagLazyTensor
@@ -27,6 +27,7 @@ from .zero_lazy_tensor import ZeroLazyTensor
 __all__ = [
     "delazify",
     "lazify",
+    "cat",
     "LazyTensor",
     "LazyEvaluatedKernelTensor",
     "AddedDiagLazyTensor",

--- a/gpytorch/lazy/cat_lazy_tensor.py
+++ b/gpytorch/lazy/cat_lazy_tensor.py
@@ -2,8 +2,17 @@
 
 import torch
 from .lazy_tensor import LazyTensor
+from .non_lazy_tensor import lazify
 from ..utils.broadcasting import _mul_broadcast_shape, _matmul_broadcast_shape
 from ..utils.getitem import _noop_index
+
+
+def cat(inputs, dim=0):
+    if all(torch.is_tensor(i) for i in inputs):
+        return torch.cat(inputs, dim=dim)
+
+    inputs = [lazify(i) for i in inputs]
+    return CatLazyTensor(*inputs, dim=dim)
 
 
 class CatLazyTensor(LazyTensor):

--- a/gpytorch/lazy/cat_lazy_tensor.py
+++ b/gpytorch/lazy/cat_lazy_tensor.py
@@ -7,12 +7,18 @@ from ..utils.broadcasting import _mul_broadcast_shape, _matmul_broadcast_shape
 from ..utils.getitem import _noop_index
 
 
-def cat(inputs, dim=0):
+def cat(inputs, dim=0, output_device=None):
     if all(torch.is_tensor(i) for i in inputs):
         return torch.cat(inputs, dim=dim)
 
     inputs = [lazify(i) for i in inputs]
-    return CatLazyTensor(*inputs, dim=dim)
+
+    if output_device is None and all(i.device == inputs[0].device for i in inputs):
+        output_device = inputs[0].device
+    elif output_device is None:
+        raise RuntimeError("Trying to concat lazy tensors on different devices without specifying an output device.")
+
+    return CatLazyTensor(*inputs, dim=dim, output_device=output_device)
 
 
 class CatLazyTensor(LazyTensor):

--- a/gpytorch/lazy/cat_lazy_tensor.py
+++ b/gpytorch/lazy/cat_lazy_tensor.py
@@ -2,7 +2,8 @@
 
 import torch
 from .lazy_tensor import LazyTensor
-from .non_lazy_tensor import lazify
+from .non_lazy_tensor import lazify, NonLazyTensor
+from . import delazify
 from ..utils.broadcasting import _mul_broadcast_shape, _matmul_broadcast_shape
 from ..utils.getitem import _noop_index
 
@@ -12,6 +13,10 @@ def cat(inputs, dim=0, output_device=None):
         return torch.cat(inputs, dim=dim)
 
     inputs = [lazify(i) for i in inputs]
+
+    if all(isinstance(i, NonLazyTensor) for i in inputs):
+        # Dont form a CatLazyTensor if all tensors are NonLazyTensor
+        return lazify(torch.cat([delazify(i) for i in inputs]))
 
     if output_device is None and all(i.device == inputs[0].device for i in inputs):
         output_device = inputs[0].device


### PR DESCRIPTION
Adds a `gpytorch.cat` function that functions as `torch.cat` but is agnostic to whether the input list contains tensors or lazy tensors or a mix.
- When the list is all tensors, functions as `torch.cat`
- When the list is not all tensors, calls `lazify` on everything then constructs a `CatLazyTensor`.

Extremely useful for the next PR I am about to put up.