### PR TITLE
[RFC] Fantasizing repeatedly at the same input points

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -120,7 +120,6 @@ class DefaultPredictionStrategy(object):
         mvn_obs = self.likelihood(mvn, inputs, **kwargs)
 
         fant_fant_covar = mvn_obs.covariance_matrix
-        # TODO: Don't have this be explicit across batches
         fant_train_covar = delazify(full_covar[..., num_train:, :num_train])
 
         self.fantasy_inputs = inputs
@@ -208,7 +207,7 @@ class DefaultPredictionStrategy(object):
             new_covar_cache = cholesky_solve(new_root.transpose(-2, -1), torch.cholesky(cap_mat))
             new_covar_cache = new_covar_cache.transpose(-2, -1)
 
-        # TODO: Expand inputs accordingly if necessary
+        # Expand inputs accordingly if necessary
         if full_inputs[0].dim() <= full_targets.dim():
             batch_shape = full_targets.shape[:-1]
             full_inputs = [fi.expand(batch_shape + fi.shape) for fi in full_inputs]

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -5,7 +5,7 @@ import torch
 from .. import settings
 from ..lazy import (
     InterpolatedLazyTensor, MatmulLazyTensor, RootLazyTensor, SumLazyTensor, ZeroLazyTensor,
-    lazify, delazify, LazyEvaluatedKernelTensor
+    lazify, delazify, LazyEvaluatedKernelTensor, NonLazyTensor, BatchRepeatLazyTensor
 )
 from ..utils.interpolation import left_interp, left_t_interp
 from ..utils.memoize import cached, add_to_cache
@@ -99,6 +99,7 @@ class DefaultPredictionStrategy(object):
             - :attr:`full_inputs` (Tensor `n+m x d` or `b x n+m x d`): Training data concatenated with fantasy inputs
             - :attr:`full_targets` (Tensor `n+m` or `b x n+m`): Training labels concatenated with fantasy labels.
             - :attr:`full_output` (:class:`gpytorch.distributions.MultivariateNormal`): Prior called on full_inputs
+
         Returns:
             - :class:`DefaultPredictionStrategy`
                 A `DefaultPredictionStrategy` model with `n + m` training examples, where the `m` fantasy examples have
@@ -119,6 +120,7 @@ class DefaultPredictionStrategy(object):
         mvn_obs = self.likelihood(mvn, inputs, **kwargs)
 
         fant_fant_covar = mvn_obs.covariance_matrix
+        # TODO: Don't have this be explicit across batches
         fant_train_covar = delazify(full_covar[..., num_train:, :num_train])
 
         self.fantasy_inputs = inputs
@@ -206,6 +208,15 @@ class DefaultPredictionStrategy(object):
             new_covar_cache = cholesky_solve(new_root.transpose(-2, -1), torch.cholesky(cap_mat))
             new_covar_cache = new_covar_cache.transpose(-2, -1)
 
+        # TODO: Expand inputs accordingly if necessary
+        if full_inputs[0].dim() <= full_targets.dim():
+            batch_shape = full_targets.shape[:-1]
+            full_inputs = [fi.expand(batch_shape + fi.shape) for fi in full_inputs]
+            full_mean = full_mean.expand(batch_shape + full_mean.shape)
+            full_covar = BatchRepeatLazyTensor(full_covar, batch_shape)
+            new_root = BatchRepeatLazyTensor(NonLazyTensor(new_root), batch_shape)
+            new_covar_cache = BatchRepeatLazyTensor(NonLazyTensor(new_covar_cache), batch_shape)
+
         # Create new DefaultPredictionStrategy object
         fant_strat = self.__class__(
             train_inputs=full_inputs,
@@ -215,7 +226,7 @@ class DefaultPredictionStrategy(object):
             root=new_root,
             inv_root=new_covar_cache,
         )
-        setattr(fant_strat, "_memoize_cache", {"mean_cache": fant_mean_cache, "covar_cache": new_covar_cache})
+        fant_strat._memoize_cache = {"mean_cache": fant_mean_cache, "covar_cache": new_covar_cache}
 
         return fant_strat
 


### PR DESCRIPTION
If `get_fantasize_model` is called with a `m x d` input tensor and a `b x m` target tensor, this change makes sure to not automatically expand the input and compute the fantasy updates for each batch (they are the same). Instead, the fantasy update is done only once, and the resulting updated covariance caches are copied (using a `BatchRepeatLazyTensor`).

This is an early draft and requires additional tests.

Addresses #667

To test, see attached notebook:
[test_same_input_fantasies.ipynb.txt](https://github.com/cornellius-gp/gpytorch/files/3159647/test_same_input_fantasies.ipynb.txt)
