### PR TITLE
Fast fantasies in batch (batch evaluation, not batch model) mode.

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -84,6 +84,9 @@ class DefaultPredictionStrategy(object):
         """
         # Here the precomputed cache represents S,
         # where S S^T = (K_XX + sigma^2 I)^-1
+        if not torch.is_tensor(precomputed_cache):
+            # can't call tensor matmul on a lazy, so we'll flip things around
+            return precomputed_cache.transpose(-1, -2).matmul(test_train_covar.transpose(-1, -2)).transpose(-1, -2)
         return test_train_covar.matmul(precomputed_cache)
 
     def get_fantasy_strategy(self, inputs, targets, full_inputs, full_targets, full_output, **kwargs):

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -84,9 +84,6 @@ class DefaultPredictionStrategy(object):
         """
         # Here the precomputed cache represents S,
         # where S S^T = (K_XX + sigma^2 I)^-1
-        if not torch.is_tensor(precomputed_cache):
-            # can't call tensor matmul on a lazy, so we'll flip things around
-            return precomputed_cache.transpose(-1, -2).matmul(test_train_covar.transpose(-1, -2)).transpose(-1, -2)
         return test_train_covar.matmul(precomputed_cache)
 
     def get_fantasy_strategy(self, inputs, targets, full_inputs, full_targets, full_output, **kwargs):
@@ -219,7 +216,7 @@ class DefaultPredictionStrategy(object):
             full_mean = full_mean.expand(fant_batch_shape + full_mean.shape)
             full_covar = BatchRepeatLazyTensor(full_covar, repeat_shape)
             new_root = BatchRepeatLazyTensor(NonLazyTensor(new_root), repeat_shape)
-            new_covar_cache = BatchRepeatLazyTensor(NonLazyTensor(new_covar_cache), repeat_shape)
+            # no need to repeat the covar cache, broadcasting will do the right thing
 
         # Create new DefaultPredictionStrategy object
         fant_strat = self.__class__(

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -207,14 +207,16 @@ class DefaultPredictionStrategy(object):
             new_covar_cache = cholesky_solve(new_root.transpose(-2, -1), torch.cholesky(cap_mat))
             new_covar_cache = new_covar_cache.transpose(-2, -1)
 
-        # Expand inputs accordingly if necessary
+        # Expand inputs accordingly if necessary (for fantasies at the same points)
         if full_inputs[0].dim() <= full_targets.dim():
-            batch_shape = full_targets.shape[:-1]
-            full_inputs = [fi.expand(batch_shape + fi.shape) for fi in full_inputs]
-            full_mean = full_mean.expand(batch_shape + full_mean.shape)
-            full_covar = BatchRepeatLazyTensor(full_covar, batch_shape)
-            new_root = BatchRepeatLazyTensor(NonLazyTensor(new_root), batch_shape)
-            new_covar_cache = BatchRepeatLazyTensor(NonLazyTensor(new_covar_cache), batch_shape)
+            fant_batch_shape = full_targets.shape[:1]
+            n_batch = len(full_mean.shape[:-1])
+            repeat_shape = fant_batch_shape + torch.Size([1] * n_batch)
+            full_inputs = [fi.expand(fant_batch_shape + fi.shape) for fi in full_inputs]
+            full_mean = full_mean.expand(fant_batch_shape + full_mean.shape)
+            full_covar = BatchRepeatLazyTensor(full_covar, repeat_shape)
+            new_root = BatchRepeatLazyTensor(NonLazyTensor(new_root), repeat_shape)
+            new_covar_cache = BatchRepeatLazyTensor(NonLazyTensor(new_covar_cache), repeat_shape)
 
         # Create new DefaultPredictionStrategy object
         fant_strat = self.__class__(


### PR DESCRIPTION
Updates #687 to work with batched inputs. 

`inputs` can now be `b1 x ... x bk x m x d` or `f x b1 x ... x bk x m x d`, and `targets` are `b1 x ... x bk x m` or `f x b1 x ... x bk x m`.

If the `f` dimension is present in the targets but not the inputs, this will assume all fantasies are evaluated at the same inputs (in the respective batch), and computation happens more (time, memory) efficiently by only doing the update once.

Test:
[test_same_input_fantasies_batched.ipynb.txt](https://github.com/cornellius-gp/gpytorch/files/3164081/test_same_input_fantasies_batched.ipynb.txt)
