### PR TITLE
preserve the original model's likelihood in get_fantasy_strategy

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -119,8 +119,8 @@ class DefaultPredictionStrategy(object):
         fant_fant_covar = full_covar[..., num_train:, num_train:]
         fant_mean = full_mean[..., num_train:]
         mvn = self.train_prior_dist.__class__(fant_mean, fant_fant_covar)
-        self.likelihood = self.likelihood.get_fantasy_likelihood(**kwargs)
-        mvn_obs = self.likelihood(mvn, inputs, **kwargs)
+        fant_likelihood = self.likelihood.get_fantasy_likelihood(**kwargs)
+        mvn_obs = fant_likelihood(mvn, inputs, **kwargs)
 
         fant_fant_covar = mvn_obs.covariance_matrix
         fant_train_covar = delazify(full_covar[..., num_train:, :num_train])
@@ -232,7 +232,7 @@ class DefaultPredictionStrategy(object):
             train_inputs=full_inputs,
             train_prior_dist=self.train_prior_dist.__class__(full_mean, full_covar),
             train_labels=full_targets,
-            likelihood=self.likelihood,
+            likelihood=fant_likelihood,
             root=new_root,
             inv_root=new_covar_cache,
         )


### PR DESCRIPTION
Previously, `get_fantasy_strategy` would overwrite `model.prediction_strategy.likelihood`. This is change preserves the original `prediction_strategy.likelihood`.

Before change:
[test_get_fantasy_model_without_fant_likelihood.ipynb.txt](https://github.com/cornellius-gp/gpytorch/files/3217576/test_get_fantasy_model_without_fant_likelihood.ipynb.txt)

After change:
[test_get_fantasy_fantasies_with_fant_likelihood.ipynb.txt](https://github.com/cornellius-gp/gpytorch/files/3217577/test_get_fantasy_fantasies_with_fant_likelihood.ipynb.txt)

