### PR TITLE
use padding and matmul to compute pairwise distance

### DIFF
--- a/test/functions/test_matern_covariance.py
+++ b/test/functions/test_matern_covariance.py
@@ -8,7 +8,7 @@ import gpytorch
 
 def dist_func(x1, x2):
     dist_module = gpytorch.kernels.kernel.Distance()
-    return dist_module._jit_dist_x1_neq_x2(x1, x2, postprocess=torch.tensor(False), false_tensor=torch.tensor(False))
+    return dist_module._dist(x1, x2, postprocess=torch.tensor(False))
 
 
 class TestMaternCovariance(unittest.TestCase):

--- a/test/functions/test_rbf_covariance.py
+++ b/test/functions/test_rbf_covariance.py
@@ -7,7 +7,7 @@ import gpytorch
 
 def sq_dist_func(x1, x2):
     dist_module = gpytorch.kernels.kernel.Distance()
-    return dist_module._jit_sq_dist_x1_neq_x2(x1, x2, postprocess=torch.tensor(False))
+    return dist_module._sq_dist(x1, x2, postprocess=torch.tensor(False))
 
 
 class TestRBFCovariance(unittest.TestCase):


### PR DESCRIPTION
Use only ones padding and matmul to compute pairwise distances. Also clean up all the different case considerations. 

This is about 3x faster on large tensors. `torch.cdist` is still fastest on small tensors. We should check speed again once this PR https://github.com/pytorch/pytorch/pull/20605 lands. 