### PR TITLE
Add prior_mode context manager for Exact GP models

### DIFF
--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -231,7 +231,7 @@ class ExactGP(GP):
             return res
 
         # Prior mode
-        elif self.train_inputs is None or self.train_targets is None:
+        elif settings.prior_mode.on() or self.train_inputs is None or self.train_targets is None:
             full_inputs = args
             full_output = super(ExactGP, self).__call__(*full_inputs, **kwargs)
             if settings.debug().on():

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -435,6 +435,15 @@ class num_trace_samples(_value_context):
     _global_value = 10
 
 
+class prior_mode(_feature_flag):
+    """
+    If set to true, GP models will be evaluated in prior mode.
+    This allows evaluating any Exact GP model in prior mode, even it if has training data / targets.
+    """
+
+    _state = False
+
+
 class skip_logdet_forward(_feature_flag):
     """
     .. warning:

--- a/test/models/test_exact_gp.py
+++ b/test/models/test_exact_gp.py
@@ -140,6 +140,21 @@ class TestExactGP(_ModelTestCase, unittest.TestCase):
         self.assertTrue(output.lazy_covariance_matrix.size(-1) == batch_data.size(-2))
         self.assertTrue(output.lazy_covariance_matrix.size(-2) == batch_data.size(-2))
 
+    def test_prior_mode(self):
+        train_data = self.create_test_data()
+        likelihood, labels = self.create_likelihood_and_labels()
+        prior_model = self.create_model(None, None, likelihood)
+        model = self.create_model(train_data, labels, likelihood)
+        prior_model.eval()
+        model.eval()
+
+        test_data = self.create_test_data()
+        prior_out = prior_model(test_data)
+        with gpytorch.settings.prior_mode(True):
+            prior_out_cm = model(test_data)
+        self.assertTrue(torch.allclose(prior_out.mean, prior_out_cm.mean))
+        self.assertTrue(torch.allclose(prior_out.covariance_matrix, prior_out_cm.covariance_matrix))
+
 
 class TestInterpolatedExactGP(TestExactGP):
     def create_model(self, train_x, train_y, likelihood):


### PR DESCRIPTION
Implements #696.

Usage:

```
with gpytorch.settings.prior_mode(True):
     model(test_input)
```