### PR TITLE
Fix TypeError when calling `backward` on `gpytorch.functions.logdet`

### DIFF
--- a/gpytorch/functions/_inv_quad_log_det.py
+++ b/gpytorch/functions/_inv_quad_log_det.py
@@ -218,6 +218,6 @@ class InvQuadLogDet(Function):
         if ctx.inv_quad:
             res = [inv_quad_rhs_grad] + list(matrix_arg_grads)
         else:
-            res = matrix_arg_grads
+            res = list(matrix_arg_grads)
 
         return tuple([None] * 9 + res)


### PR DESCRIPTION
fixes #710.