### PR TITLE
Add skip_posterior_variances support to VariationalStrategy

### DIFF
--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -144,8 +144,11 @@ class VariationalStrategy(Module):
                 if not hasattr(self, "_mean_cache"):
                     self._mean_cache = induc_induc_covar.inv_matmul(mean_diff).detach()
 
-                mean_cache = self._mean_cache
-                predictive_mean = torch.add(test_mean, induc_data_covar.transpose(-2, -1).matmul(mean_cache))
+                predictive_mean = torch.add(
+                    test_mean,
+                    induc_data_covar.transpose(-2, -1).matmul(self._mean_cache).squeeze(-1)
+                )
+
                 predictive_covar = ZeroLazyTensor(test_mean.size(-1), test_mean.size(-1))
 
                 return MultivariateNormal(predictive_mean, predictive_covar)

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -142,7 +142,7 @@ class VariationalStrategy(Module):
             # If we are making predictions and don't need variances, we can do things very quickly.
             if not self.training and settings.skip_posterior_variances.on():
                 if not hasattr(self, "_mean_cache"):
-                    self._mean_cache = induc_induc_covar.inv_matmul(mean_diff)
+                    self._mean_cache = induc_induc_covar.inv_matmul(mean_diff).detach()
 
                 mean_cache = self._mean_cache
                 predictive_mean = torch.add(test_mean, induc_data_covar.transpose(-2, -1).matmul(mean_cache))


### PR DESCRIPTION
When running variational model predictions with `skip_posterior_variances` on, we now compute and cache `K_{uu}^{-1}m` instead of `K_{uu}^{-1}K_{ux}` because we don't need the latter term at all. This is around 60 times faster.