### PR TITLE
Fix Interval class upper bound transform for bug #744

### DIFF
--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -94,7 +94,7 @@ class Interval(Module):
                     "GreaterThan or LessThan instead."
                 )
 
-        transformed_tensor = (self._transform(tensor) * self.upper_bound) + self.lower_bound
+        transformed_tensor = (self._transform(tensor) * (self.upper_bound - self.lower_bound)) + self.lower_bound
 
         return transformed_tensor
 

--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -115,7 +115,7 @@ class Interval(Module):
                     "GreaterThan or LessThan instead."
                 )
 
-        tensor = self._inv_transform((transformed_tensor - self.lower_bound) / self.upper_bound)
+        tensor = self._inv_transform((transformed_tensor - self.lower_bound) / (self.upper_bound - self.lower_bound))
 
         return tensor
 

--- a/test/constraints/test_constraints.py
+++ b/test/constraints/test_constraints.py
@@ -28,7 +28,7 @@ class TestInterval(unittest.TestCase, BaseTestCase):
         v = torch.tensor(-3.0)
 
         value = constraint.transform(v)
-        actual_value = (5.0 * sigmoid(v)) + 1.0
+        actual_value = ((5.0 - 1.0) * sigmoid(v)) + 1.0
 
         self.assertAllClose(value, actual_value)
 
@@ -48,8 +48,8 @@ class TestInterval(unittest.TestCase, BaseTestCase):
 
         value = constraint.transform(v)
         actual_value = v.clone()
-        actual_value[0] = 3.0 * sigmoid(v[0]) + 1.0
-        actual_value[1] = 4.0 * sigmoid(v[1]) + 2.0
+        actual_value[0] = (3.0 - 1.0) * sigmoid(v[0]) + 1.0
+        actual_value[1] = (4.0 - 2.0) * sigmoid(v[1]) + 2.0
 
         self.assertAllClose(value, actual_value)
 


### PR DESCRIPTION
Fix Interval class upper bound transform for bug #744. The new code multiplies the tensor by (upper_bound - lower_bound) before adding lower_bound, thus keeping the tensor between bounds.