### PR TITLE
Changed to  lengthscale squared in RBF kernel equation

### DIFF
--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -17,7 +17,7 @@ class RBFKernel(Kernel):
 
        \begin{equation*}
           k_{\text{RBF}}(\mathbf{x_1}, \mathbf{x_2}) = \exp \left( -\frac{1}{2}
-          (\mathbf{x_1} - \mathbf{x_2})^\top \Theta^{-1} (\mathbf{x_1} - \mathbf{x_2}) \right)
+          (\mathbf{x_1} - \mathbf{x_2})^\top \Theta^{-2} (\mathbf{x_1} - \mathbf{x_2}) \right)
        \end{equation*}
 
     where :math:`\Theta` is a :attr:`lengthscale` parameter.


### PR DESCRIPTION
This attempts to clarify https://github.com/cornellius-gp/gpytorch/issues/752