### PR TITLE
Custom __deepcopy__ for InducingPointKernel

### DIFF
--- a/gpytorch/kernels/inducing_point_kernel.py
+++ b/gpytorch/kernels/inducing_point_kernel.py
@@ -2,6 +2,7 @@
 
 import math
 import torch
+import copy
 from .kernel import Kernel
 from ..lazy import delazify, DiagLazyTensor, MatmulLazyTensor, RootLazyTensor, PsdSumLazyTensor
 from ..distributions import MultivariateNormal
@@ -96,3 +97,33 @@ class InducingPointKernel(Kernel):
 
     def num_outputs_per_input(self, x1, x2):
         return self.base_kernel.num_outputs_per_input(x1, x2)
+
+    def __deepcopy__(self, memo):
+        replace_inv_root = False
+        replace_kernel_mat = False
+
+        if hasattr(self, "_cached_kernel_inv_root"):
+            replace_inv_root = True
+            kernel_inv_root = self._cached_kernel_inv_root
+            self._cached_kernel_inv_root = None
+        if hasattr(self, "_cached_kernel_mat"):
+            replace_kernel_mat = True
+            kernel_mat = self._cached_kernel_mat
+            self._cached_kernel_mat = None
+
+        deepcopy_method = self.__deepcopy__
+        self.__deepcopy__ = None
+        cp = copy.deepcopy(self, memo)
+
+        self.__deepcopy__ = deepcopy_method
+        cp.__deepcopy__ = deepcopy_method
+
+        if replace_inv_root:
+            self._cached_kernel_inv_root = kernel_inv_root
+            cp._cached_kernel_inv_root = kernel_inv_root
+
+        if replace_kernel_mat:
+            self._cached_kernel_mat = kernel_mat
+            cp._cached_kernel_mat = kernel_mat
+
+        return cp


### PR DESCRIPTION
Since `_cached_kernel_mat` and `_cached_kernel_inv_root` require grad, we can't deepcopy them, which is a required op for creating fantasy models. Since these caches only exist for inference efficiency, (e.g., they are explicitly only used at test time when we won't want derivatives w.r.t kernel hypers), the original `InducingPointKernel` and the copy can just share these tensors.

Fixes #784