### PR TITLE
Fix sigmoid deprecation

### DIFF
--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -2,7 +2,8 @@
 
 import math
 import torch
-from torch.nn.functional import softplus, sigmoid
+from torch.nn.functional import softplus
+from torch import sigmoid
 from ..utils.transforms import _get_inv_param_transform, inv_sigmoid, inv_softplus
 from torch.nn import Module
 from .. import settings

--- a/gpytorch/utils/transforms.py
+++ b/gpytorch/utils/transforms.py
@@ -25,5 +25,5 @@ def _get_inv_param_transform(param_transform, inv_param_transform=None):
 TRANSFORM_REGISTRY = {
     torch.exp: torch.log,
     torch.nn.functional.softplus: inv_softplus,
-    torch.nn.functional.sigmoid: inv_sigmoid,
+    torch.sigmoid: inv_sigmoid,
 }

--- a/test/constraints/test_constraints.py
+++ b/test/constraints/test_constraints.py
@@ -4,7 +4,8 @@ import torch
 import unittest
 import gpytorch
 
-from torch.nn.functional import softplus, sigmoid
+from torch.nn.functional import softplus
+from torch import sigmoid
 from gpytorch.test.base_test_case import BaseTestCase
 
 


### PR DESCRIPTION
- Importing sigmoid from ```torch``` instead of ```torch.nn.functional``` as the latter is deprecated
- Fixing a dtype error in ```PolynomialKernelGrad```