### PR TITLE
Implement KeOps Integration

### DIFF
--- a/examples/14_KeOps_Integration/KeOps_GP_Regression.ipynb
+++ b/examples/14_KeOps_Integration/KeOps_GP_Regression.ipynb
@@ -1,0 +1,362 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GPyTorch Regression With KeOps\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "`KeOps` (https://github.com/getkeops/keops) is a recently released software package for fast kernel operations that integrates wih PyTorch. We can use the ability of `KeOps` to perform efficient kernel matrix multiplies on the GPU to integrate with the rest of GPyTorch.\n",
+    "\n",
+    "In this tutorial, we'll demonstrate how to integrate the kernel matmuls of `KeOps` with all of the bells of whistles of GPyTorch, including things like our preconditioning for conjugate gradients."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %set_env CUDA_VISIBLE_DEVICES=1\n",
+    "import math\n",
+    "import torch\n",
+    "import gpytorch\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "%matplotlib inline\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Downloading Data\n",
+    "We will be using the Protein UCI dataset which contains a total of 40000+ data points. The next cell will download this dataset from a Google drive and load it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib.request\n",
+    "from scipy.io import loadmat\n",
+    "dataset = 'protein'\n",
+    "if not os.path.isfile(f'{dataset}.mat'):\n",
+    "    print(f'Downloading \\'{dataset}\\' UCI dataset...')\n",
+    "    urllib.request.urlretrieve('https://drive.google.com/uc?export=download&id=1nRb8e7qooozXkNghC5eQS0JeywSXGX2S',\n",
+    "                               f'{dataset}.mat')\n",
+    "    \n",
+    "data = torch.Tensor(loadmat(f'{dataset}.mat')['data'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "N = data.shape[0]\n",
+    "# make train/val/test\n",
+    "n_train = int(0.8 * N)\n",
+    "train_x, train_y = data[:n_train, :-1], data[:n_train, -1]\n",
+    "test_x, test_y = data[n_train:, :-1], data[n_train:, -1]\n",
+    "\n",
+    "# normalize features\n",
+    "mean = train_x.mean(dim=-2, keepdim=True)\n",
+    "std = train_x.std(dim=-2, keepdim=True) + 1e-6 # prevent dividing by 0\n",
+    "train_x = (train_x - mean) / std\n",
+    "test_x = (test_x - mean) / std\n",
+    "\n",
+    "# normalize labels\n",
+    "mean, std = train_y.mean(),train_y.std()\n",
+    "train_y = (train_y - mean) / std\n",
+    "test_y = (test_y - mean) / std\n",
+    "\n",
+    "# make continguous\n",
+    "train_x, train_y = train_x.contiguous(), train_y.contiguous()\n",
+    "test_x, test_y = test_x.contiguous(), test_y.contiguous()\n",
+    "\n",
+    "output_device = torch.device('cuda:0')\n",
+    "\n",
+    "train_x, train_y = train_x.to(output_device), train_y.to(output_device)\n",
+    "test_x, test_y = test_x.to(output_device), test_y.to(output_device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting up the model\n",
+    "\n",
+    "Using KeOps with one of our pre built kernels is as straightforward as swapping the kernel out. For example, in the cell below, we copy the simple GP from our basic tutorial notebook, and swap out `gpytorch.kernels.MaternKernel` for `gpytorch.kernels.keops.MaternKernel`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We will use the simplest form of GP model, exact inference\n",
+    "class ExactGPModel(gpytorch.models.ExactGP):\n",
+    "    def __init__(self, train_x, train_y, likelihood):\n",
+    "        super(ExactGPModel, self).__init__(train_x, train_y, likelihood)\n",
+    "        self.mean_module = gpytorch.means.ConstantMean()\n",
+    "\n",
+    "        self.covar_module = gpytorch.kernels.ScaleKernel(gpytorch.kernels.keops.MaternKernel(nu=2.5))\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        mean_x = self.mean_module(x)\n",
+    "        covar_x = self.covar_module(x)\n",
+    "        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)\n",
+    "\n",
+    "# initialize likelihood and model\n",
+    "likelihood = gpytorch.likelihoods.GaussianLikelihood().cuda()\n",
+    "model = ExactGPModel(train_x, train_y, likelihood).cuda()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iter 1/50 - Loss: 0.589   lengthscale: 3.033   noise: 0.089\n",
+      "0.5267367362976074\n",
+      "Iter 2/50 - Loss: 0.598   lengthscale: 3.129   noise: 0.081\n",
+      "0.5038349628448486\n",
+      "Iter 3/50 - Loss: 0.571   lengthscale: 3.220   noise: 0.082\n",
+      "0.4416794776916504\n",
+      "Iter 4/50 - Loss: 0.559   lengthscale: 3.305   noise: 0.084\n",
+      "0.4224965572357178\n",
+      "Iter 5/50 - Loss: 0.546   lengthscale: 3.386   noise: 0.088\n",
+      "0.41598010063171387\n",
+      "Iter 6/50 - Loss: 0.536   lengthscale: 3.461   noise: 0.092\n",
+      "0.4090542793273926\n",
+      "Iter 7/50 - Loss: 0.516   lengthscale: 3.533   noise: 0.096\n",
+      "0.3613882064819336\n",
+      "Iter 8/50 - Loss: 0.509   lengthscale: 3.601   noise: 0.096\n",
+      "0.3575630187988281\n",
+      "Iter 9/50 - Loss: 0.508   lengthscale: 3.664   noise: 0.094\n",
+      "0.3791520595550537\n",
+      "Iter 10/50 - Loss: 0.522   lengthscale: 3.719   noise: 0.091\n",
+      "0.38656091690063477\n",
+      "Iter 11/50 - Loss: 0.508   lengthscale: 3.766   noise: 0.088\n",
+      "0.39499783515930176\n",
+      "Iter 12/50 - Loss: 0.518   lengthscale: 3.796   noise: 0.085\n",
+      "0.40425920486450195\n",
+      "Iter 13/50 - Loss: 0.525   lengthscale: 3.812   noise: 0.084\n",
+      "0.4158463478088379\n",
+      "Iter 14/50 - Loss: 0.521   lengthscale: 3.815   noise: 0.083\n",
+      "0.4932892322540283\n",
+      "Iter 15/50 - Loss: 0.543   lengthscale: 3.807   noise: 0.083\n",
+      "0.4583451747894287\n",
+      "Iter 16/50 - Loss: 0.548   lengthscale: 3.796   noise: 0.085\n",
+      "0.46480274200439453\n",
+      "Iter 17/50 - Loss: 0.540   lengthscale: 3.785   noise: 0.087\n",
+      "0.51192307472229\n",
+      "Iter 18/50 - Loss: 0.546   lengthscale: 3.776   noise: 0.090\n",
+      "0.4682350158691406\n",
+      "Iter 19/50 - Loss: 0.556   lengthscale: 3.772   noise: 0.092\n",
+      "0.46701955795288086\n",
+      "Iter 20/50 - Loss: 0.542   lengthscale: 3.779   noise: 0.094\n",
+      "0.43764376640319824\n",
+      "Iter 21/50 - Loss: 0.551   lengthscale: 3.794   noise: 0.095\n",
+      "0.4625883102416992\n",
+      "Iter 22/50 - Loss: 0.532   lengthscale: 3.820   noise: 0.094\n",
+      "0.4164125919342041\n",
+      "Iter 23/50 - Loss: 0.557   lengthscale: 3.851   noise: 0.092\n",
+      "0.4912734031677246\n",
+      "Iter 24/50 - Loss: 0.555   lengthscale: 3.887   noise: 0.089\n",
+      "0.5559864044189453\n",
+      "Iter 25/50 - Loss: 0.559   lengthscale: 3.927   noise: 0.087\n",
+      "0.5327601432800293\n",
+      "Iter 26/50 - Loss: 0.543   lengthscale: 3.966   noise: 0.085\n",
+      "0.5146927833557129\n",
+      "Iter 27/50 - Loss: 0.537   lengthscale: 4.000   noise: 0.084\n",
+      "0.43804359436035156\n",
+      "Iter 28/50 - Loss: 0.536   lengthscale: 4.029   noise: 0.082\n",
+      "0.4342367649078369\n",
+      "Iter 29/50 - Loss: 0.554   lengthscale: 4.051   noise: 0.081\n",
+      "0.4643881320953369\n",
+      "Iter 30/50 - Loss: 0.548   lengthscale: 4.067   noise: 0.081\n",
+      "0.44389867782592773\n",
+      "Iter 31/50 - Loss: 0.530   lengthscale: 4.076   noise: 0.082\n",
+      "0.40947985649108887\n",
+      "Iter 32/50 - Loss: 0.564   lengthscale: 4.076   noise: 0.081\n",
+      "0.5228478908538818\n",
+      "Iter 33/50 - Loss: 0.559   lengthscale: 4.074   noise: 0.082\n",
+      "0.5151913166046143\n",
+      "Iter 34/50 - Loss: 0.569   lengthscale: 4.072   noise: 0.084\n",
+      "0.5408072471618652\n",
+      "Iter 35/50 - Loss: 0.541   lengthscale: 4.075   noise: 0.087\n",
+      "0.4760885238647461\n",
+      "Iter 36/50 - Loss: 0.548   lengthscale: 4.079   noise: 0.088\n",
+      "0.46231985092163086\n",
+      "Iter 37/50 - Loss: 0.523   lengthscale: 4.088   noise: 0.089\n",
+      "0.4274454116821289\n",
+      "Iter 38/50 - Loss: 0.557   lengthscale: 4.101   noise: 0.087\n",
+      "0.4952268600463867\n",
+      "Iter 39/50 - Loss: 0.521   lengthscale: 4.118   noise: 0.086\n",
+      "0.41435694694519043\n",
+      "Iter 40/50 - Loss: 0.559   lengthscale: 4.132   noise: 0.082\n",
+      "0.4613039493560791\n",
+      "Iter 41/50 - Loss: 0.498   lengthscale: 4.144   noise: 0.080\n",
+      "0.37143421173095703\n",
+      "Iter 42/50 - Loss: 0.574   lengthscale: 4.157   noise: 0.075\n",
+      "0.4642205238342285\n",
+      "Iter 43/50 - Loss: 0.603   lengthscale: 4.161   noise: 0.073\n",
+      "0.5190582275390625\n",
+      "Iter 44/50 - Loss: 0.609   lengthscale: 4.157   noise: 0.072\n",
+      "0.5418822765350342\n",
+      "Iter 45/50 - Loss: 0.598   lengthscale: 4.147   noise: 0.073\n",
+      "0.5297873020172119\n",
+      "Iter 46/50 - Loss: 0.609   lengthscale: 4.133   noise: 0.075\n",
+      "0.5633969306945801\n",
+      "Iter 47/50 - Loss: 0.555   lengthscale: 4.123   noise: 0.079\n",
+      "0.4395630359649658\n",
+      "Iter 48/50 - Loss: 0.596   lengthscale: 4.112   noise: 0.082\n",
+      "0.5334904193878174\n",
+      "Iter 49/50 - Loss: 0.577   lengthscale: 4.112   noise: 0.085\n",
+      "0.4734311103820801\n",
+      "Iter 50/50 - Loss: 0.587   lengthscale: 4.122   noise: 0.087\n",
+      "0.5158843994140625\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Find optimal model hyperparameters\n",
+    "model.train()\n",
+    "likelihood.train()\n",
+    "\n",
+    "# Use the adam optimizer\n",
+    "optimizer = torch.optim.Adam([\n",
+    "    {'params': model.parameters()},  # Includes GaussianLikelihood parameters\n",
+    "], lr=0.1)\n",
+    "\n",
+    "# \"Loss\" for GPs - the marginal log likelihood\n",
+    "mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, model)\n",
+    "\n",
+    "import time\n",
+    "training_iter = 50\n",
+    "for i in range(training_iter):\n",
+    "    start_time = time.time()\n",
+    "    # Zero gradients from previous iteration\n",
+    "    optimizer.zero_grad()\n",
+    "    # Output from model\n",
+    "    output = model(train_x)\n",
+    "    # Calc loss and backprop gradients\n",
+    "    loss = -mll(output, train_y)\n",
+    "    loss.backward()\n",
+    "    print('Iter %d/%d - Loss: %.3f   lengthscale: %.3f   noise: %.3f' % (\n",
+    "        i + 1, training_iter, loss.item(),\n",
+    "        model.covar_module.base_kernel.lengthscale.item(),\n",
+    "        model.likelihood.noise.item()\n",
+    "    ))\n",
+    "    optimizer.step()\n",
+    "    print(time.time() - start_time)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling libKeOpstorchd7ba409487 in /home/jake.gardner/.cache/pykeops-1.1.1//build-libKeOpstorchd7ba409487:\n",
+      "       formula: Sum_Reduction(((((Var(0,1,2) * Sqrt(Sum(Square((Var(1,18,0) - Var(2,18,1)))))) + (IntCst(1) + (Var(3,1,2) * Square(Sqrt(Sum(Square((Var(1,18,0) - Var(2,18,1))))))))) * Exp((Var(4,1,2) * Sqrt(Sum(Square((Var(1,18,0) - Var(2,18,1)))))))) * Var(5,3320,1)),0)\n",
+      "       aliases: Var(0,1,2); Var(1,18,0); Var(2,18,1); Var(3,1,2); Var(4,1,2); Var(5,3320,1); \n",
+      "       dtype  : float32\n",
+      "... Done.\n",
+      "Compiling libKeOpstorch7385e76d34 in /home/jake.gardner/.cache/pykeops-1.1.1//build-libKeOpstorch7385e76d34:\n",
+      "       formula: Sum_Reduction(((((Var(0,1,2) * Sqrt(Sum(Square((Var(1,18,0) - Var(2,18,1)))))) + (IntCst(1) + (Var(3,1,2) * Square(Sqrt(Sum(Square((Var(1,18,0) - Var(2,18,1))))))))) * Exp((Var(4,1,2) * Sqrt(Sum(Square((Var(1,18,0) - Var(2,18,1)))))))) * Var(5,1,1)),0)\n",
+      "       aliases: Var(0,1,2); Var(1,18,0); Var(2,18,1); Var(3,1,2); Var(4,1,2); Var(5,1,1); \n",
+      "       dtype  : float32\n",
+      "... Done.\n",
+      "Compiling libKeOpstorch97105370ea in /home/jake.gardner/.cache/pykeops-1.1.1//build-libKeOpstorch97105370ea:\n",
+      "       formula: Sum_Reduction(((((Var(0,1,2) * Sqrt(Sum(Square((Var(1,18,0) - Var(2,18,1)))))) + (IntCst(1) + (Var(3,1,2) * Square(Sqrt(Sum(Square((Var(1,18,0) - Var(2,18,1))))))))) * Exp((Var(4,1,2) * Sqrt(Sum(Square((Var(1,18,0) - Var(2,18,1)))))))) * Var(5,100,1)),0)\n",
+      "       aliases: Var(0,1,2); Var(1,18,0); Var(2,18,1); Var(3,1,2); Var(4,1,2); Var(5,100,1); \n",
+      "       dtype  : float32\n",
+      "... Done.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get into evaluation (predictive posterior) mode\n",
+    "model.eval()\n",
+    "likelihood.eval()\n",
+    "\n",
+    "# Test points are regularly spaced along [0,1]\n",
+    "# Make predictions by feeding model through likelihood\n",
+    "with torch.no_grad(), gpytorch.settings.fast_pred_var():\n",
+    "    observed_pred = likelihood(model(test_x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compute RMSE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(0.3651, device='cuda:0')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.sqrt(torch.mean(torch.pow(observed_pred.mean - test_y, 2)))"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/examples/14_KeOps_Integration/KeOps_GP_Regression.ipynb
+++ b/examples/14_KeOps_Integration/KeOps_GP_Regression.ipynb
@@ -10,16 +10,26 @@
     "\n",
     "`KeOps` (https://github.com/getkeops/keops) is a recently released software package for fast kernel operations that integrates wih PyTorch. We can use the ability of `KeOps` to perform efficient kernel matrix multiplies on the GPU to integrate with the rest of GPyTorch.\n",
     "\n",
-    "In this tutorial, we'll demonstrate how to integrate the kernel matmuls of `KeOps` with all of the bells of whistles of GPyTorch, including things like our preconditioning for conjugate gradients."
+    "In this tutorial, we'll demonstrate how to integrate the kernel matmuls of `KeOps` with all of the bells of whistles of GPyTorch, including things like our preconditioning for conjugate gradients.\n",
+    "\n",
+    "In this notebook, we will train an exact GP on `3droad`, which has hundreds of thousands of data points. Together, the highly optimized matmuls of `KeOps` combined with algorithmic speed improvements like preconditioning allow us to train on a dataset like this in a matter of minutes using only a single GPU."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
-    "# %set_env CUDA_VISIBLE_DEVICES=1\n",
     "import math\n",
     "import torch\n",
     "import gpytorch\n",
@@ -35,30 +45,38 @@
    "metadata": {},
    "source": [
     "## Downloading Data\n",
-    "We will be using the Protein UCI dataset which contains a total of 40000+ data points. The next cell will download this dataset from a Google drive and load it."
+    "We will be using the 3droad UCI dataset which contains a total of 278,319 data points. The next cell will download this dataset from a Google drive and load it."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading '3droad' UCI dataset...\n"
+     ]
+    }
+   ],
    "source": [
-    "import os\n",
     "import urllib.request\n",
+    "import os.path\n",
     "from scipy.io import loadmat\n",
-    "dataset = 'protein'\n",
-    "if not os.path.isfile(f'{dataset}.mat'):\n",
-    "    print(f'Downloading \\'{dataset}\\' UCI dataset...')\n",
-    "    urllib.request.urlretrieve('https://drive.google.com/uc?export=download&id=1nRb8e7qooozXkNghC5eQS0JeywSXGX2S',\n",
-    "                               f'{dataset}.mat')\n",
+    "from math import floor\n",
+    "\n",
+    "if not os.path.isfile('3droad.mat'):\n",
+    "    print('Downloading \\'3droad\\' UCI dataset...')\n",
+    "    urllib.request.urlretrieve('https://www.dropbox.com/s/f6ow1i59oqx05pl/3droad.mat?dl=1', '3droad.mat')\n",
     "    \n",
-    "data = torch.Tensor(loadmat(f'{dataset}.mat')['data'])"
+    "data = torch.Tensor(loadmat('3droad.mat')['data'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,118 +144,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Iter 1/50 - Loss: 0.589   lengthscale: 3.033   noise: 0.089\n",
-      "0.5267367362976074\n",
-      "Iter 2/50 - Loss: 0.598   lengthscale: 3.129   noise: 0.081\n",
-      "0.5038349628448486\n",
-      "Iter 3/50 - Loss: 0.571   lengthscale: 3.220   noise: 0.082\n",
-      "0.4416794776916504\n",
-      "Iter 4/50 - Loss: 0.559   lengthscale: 3.305   noise: 0.084\n",
-      "0.4224965572357178\n",
-      "Iter 5/50 - Loss: 0.546   lengthscale: 3.386   noise: 0.088\n",
-      "0.41598010063171387\n",
-      "Iter 6/50 - Loss: 0.536   lengthscale: 3.461   noise: 0.092\n",
-      "0.4090542793273926\n",
-      "Iter 7/50 - Loss: 0.516   lengthscale: 3.533   noise: 0.096\n",
-      "0.3613882064819336\n",
-      "Iter 8/50 - Loss: 0.509   lengthscale: 3.601   noise: 0.096\n",
-      "0.3575630187988281\n",
-      "Iter 9/50 - Loss: 0.508   lengthscale: 3.664   noise: 0.094\n",
-      "0.3791520595550537\n",
-      "Iter 10/50 - Loss: 0.522   lengthscale: 3.719   noise: 0.091\n",
-      "0.38656091690063477\n",
-      "Iter 11/50 - Loss: 0.508   lengthscale: 3.766   noise: 0.088\n",
-      "0.39499783515930176\n",
-      "Iter 12/50 - Loss: 0.518   lengthscale: 3.796   noise: 0.085\n",
-      "0.40425920486450195\n",
-      "Iter 13/50 - Loss: 0.525   lengthscale: 3.812   noise: 0.084\n",
-      "0.4158463478088379\n",
-      "Iter 14/50 - Loss: 0.521   lengthscale: 3.815   noise: 0.083\n",
-      "0.4932892322540283\n",
-      "Iter 15/50 - Loss: 0.543   lengthscale: 3.807   noise: 0.083\n",
-      "0.4583451747894287\n",
-      "Iter 16/50 - Loss: 0.548   lengthscale: 3.796   noise: 0.085\n",
-      "0.46480274200439453\n",
-      "Iter 17/50 - Loss: 0.540   lengthscale: 3.785   noise: 0.087\n",
-      "0.51192307472229\n",
-      "Iter 18/50 - Loss: 0.546   lengthscale: 3.776   noise: 0.090\n",
-      "0.4682350158691406\n",
-      "Iter 19/50 - Loss: 0.556   lengthscale: 3.772   noise: 0.092\n",
-      "0.46701955795288086\n",
-      "Iter 20/50 - Loss: 0.542   lengthscale: 3.779   noise: 0.094\n",
-      "0.43764376640319824\n",
-      "Iter 21/50 - Loss: 0.551   lengthscale: 3.794   noise: 0.095\n",
-      "0.4625883102416992\n",
-      "Iter 22/50 - Loss: 0.532   lengthscale: 3.820   noise: 0.094\n",
-      "0.4164125919342041\n",
-      "Iter 23/50 - Loss: 0.557   lengthscale: 3.851   noise: 0.092\n",
-      "0.4912734031677246\n",
-      "Iter 24/50 - Loss: 0.555   lengthscale: 3.887   noise: 0.089\n",
-      "0.5559864044189453\n",
-      "Iter 25/50 - Loss: 0.559   lengthscale: 3.927   noise: 0.087\n",
-      "0.5327601432800293\n",
-      "Iter 26/50 - Loss: 0.543   lengthscale: 3.966   noise: 0.085\n",
-      "0.5146927833557129\n",
-      "Iter 27/50 - Loss: 0.537   lengthscale: 4.000   noise: 0.084\n",
-      "0.43804359436035156\n",
-      "Iter 28/50 - Loss: 0.536   lengthscale: 4.029   noise: 0.082\n",
-      "0.4342367649078369\n",
-      "Iter 29/50 - Loss: 0.554   lengthscale: 4.051   noise: 0.081\n",
-      "0.4643881320953369\n",
-      "Iter 30/50 - Loss: 0.548   lengthscale: 4.067   noise: 0.081\n",
-      "0.44389867782592773\n",
-      "Iter 31/50 - Loss: 0.530   lengthscale: 4.076   noise: 0.082\n",
-      "0.40947985649108887\n",
-      "Iter 32/50 - Loss: 0.564   lengthscale: 4.076   noise: 0.081\n",
-      "0.5228478908538818\n",
-      "Iter 33/50 - Loss: 0.559   lengthscale: 4.074   noise: 0.082\n",
-      "0.5151913166046143\n",
-      "Iter 34/50 - Loss: 0.569   lengthscale: 4.072   noise: 0.084\n",
-      "0.5408072471618652\n",
-      "Iter 35/50 - Loss: 0.541   lengthscale: 4.075   noise: 0.087\n",
-      "0.4760885238647461\n",
-      "Iter 36/50 - Loss: 0.548   lengthscale: 4.079   noise: 0.088\n",
-      "0.46231985092163086\n",
-      "Iter 37/50 - Loss: 0.523   lengthscale: 4.088   noise: 0.089\n",
-      "0.4274454116821289\n",
-      "Iter 38/50 - Loss: 0.557   lengthscale: 4.101   noise: 0.087\n",
-      "0.4952268600463867\n",
-      "Iter 39/50 - Loss: 0.521   lengthscale: 4.118   noise: 0.086\n",
-      "0.41435694694519043\n",
-      "Iter 40/50 - Loss: 0.559   lengthscale: 4.132   noise: 0.082\n",
-      "0.4613039493560791\n",
-      "Iter 41/50 - Loss: 0.498   lengthscale: 4.144   noise: 0.080\n",
-      "0.37143421173095703\n",
-      "Iter 42/50 - Loss: 0.574   lengthscale: 4.157   noise: 0.075\n",
-      "0.4642205238342285\n",
-      "Iter 43/50 - Loss: 0.603   lengthscale: 4.161   noise: 0.073\n",
-      "0.5190582275390625\n",
-      "Iter 44/50 - Loss: 0.609   lengthscale: 4.157   noise: 0.072\n",
-      "0.5418822765350342\n",
-      "Iter 45/50 - Loss: 0.598   lengthscale: 4.147   noise: 0.073\n",
-      "0.5297873020172119\n",
-      "Iter 46/50 - Loss: 0.609   lengthscale: 4.133   noise: 0.075\n",
-      "0.5633969306945801\n",
-      "Iter 47/50 - Loss: 0.555   lengthscale: 4.123   noise: 0.079\n",
-      "0.4395630359649658\n",
-      "Iter 48/50 - Loss: 0.596   lengthscale: 4.112   noise: 0.082\n",
-      "0.5334904193878174\n",
-      "Iter 49/50 - Loss: 0.577   lengthscale: 4.112   noise: 0.085\n",
-      "0.4734311103820801\n",
-      "Iter 50/50 - Loss: 0.587   lengthscale: 4.122   noise: 0.087\n",
-      "0.5158843994140625\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Find optimal model hyperparameters\n",
     "model.train()\n",
@@ -324,7 +235,7 @@
     {
      "data": {
       "text/plain": [
-       "tensor(0.3651, device='cuda:0')"
+       "tensor(0.1068, device='cuda:0')"
       ]
      },
      "execution_count": 15,

--- a/examples/14_KeOps_Integration/README.md
+++ b/examples/14_KeOps_Integration/README.md
@@ -1,0 +1,5 @@
+KeOps (https://github.com/getkeops/keops) is a recently released software package for fast kernel operations that integrates wih PyTorch. We can use the ability of KeOps to perform efficient kernel matrix multiplies on the GPU to integrate with the rest of GPyTorch.
+
+In this folder, we'll demonstrate how to integrate the kernel matmuls of KeOps with all of the bells of whistles of GPyTorch, including things like our preconditioning for conjugate gradients.
+
+In our example notebook, we will train an exact GP on `3droad`, which has hundreds of thousands of data points. Together, the highly optimized matmuls of KeOps combined with algorithmic speed improvements like preconditioning allow us to train on a dataset like this in a matter of minutes using only a single GPU.

--- a/examples/14_KeOps_Integration/index.rst
+++ b/examples/14_KeOps_Integration/index.rst
@@ -1,0 +1,8 @@
+.. mdinclude:: README.md
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :hidden:
+
+   KeOps_GP_Regression.ipynb

--- a/gpytorch/kernels/__init__.py
+++ b/gpytorch/kernels/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+from . import keops
 from .additive_structure_kernel import AdditiveStructureKernel
 from .cylindrical_kernel import CylindricalKernel
 from .cosine_kernel import CosineKernel
@@ -25,6 +25,7 @@ from .white_noise_kernel import WhiteNoiseKernel
 
 
 __all__ = [
+    "keops",
     "Kernel",
     "AdditiveKernel",
     "AdditiveStructureKernel",

--- a/gpytorch/kernels/keops/__init__.py
+++ b/gpytorch/kernels/keops/__init__.py
@@ -1,0 +1,7 @@
+from .matern_kernel import MaternKernel
+from .rbf_kernel import RBFKernel
+
+__all__ = [
+    "MaternKernel",
+    "RBFKernel",
+]

--- a/gpytorch/kernels/keops/keops_kernel.py
+++ b/gpytorch/kernels/keops/keops_kernel.py
@@ -1,0 +1,13 @@
+import torch
+from pykeops.torch import LazyTensor as KEOLazyTensor
+from ..kernel import Kernel
+from abc import abstractmethod
+
+
+class KeOpsKernel(Kernel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @abstractmethod
+    def covar_func(self, x1: torch.Tensor, x2: torch.Tensor) -> KEOLazyTensor:
+        raise NotImplementedError("KeOpsKernels must define a covar_func method")

--- a/gpytorch/kernels/keops/keops_kernel.py
+++ b/gpytorch/kernels/keops/keops_kernel.py
@@ -1,13 +1,19 @@
 import torch
-from pykeops.torch import LazyTensor as KEOLazyTensor
 from ..kernel import Kernel
 from abc import abstractmethod
 
+try:
+    from pykeops.torch import LazyTensor as KEOLazyTensor
 
-class KeOpsKernel(Kernel):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    class KeOpsKernel(Kernel):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
 
-    @abstractmethod
-    def covar_func(self, x1: torch.Tensor, x2: torch.Tensor) -> KEOLazyTensor:
-        raise NotImplementedError("KeOpsKernels must define a covar_func method")
+        @abstractmethod
+        def covar_func(self, x1: torch.Tensor, x2: torch.Tensor) -> KEOLazyTensor:
+            raise NotImplementedError("KeOpsKernels must define a covar_func method")
+
+except ImportError:
+    class KeOpsKernel(Kernel):
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("You must have KeOps installed to use a KeOpsKernel")

--- a/gpytorch/kernels/keops/matern_kernel.py
+++ b/gpytorch/kernels/keops/matern_kernel.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import torch
+import math
+from pykeops.torch import LazyTensor as KEOLazyTensor
+from ..kernel import Kernel
+from gpytorch.lazy import KeOpsLazyTensor
+
+
+class MaternKernel(Kernel):
+    def __init__(self, nu=2.5, **kwargs):
+        if nu not in {0.5, 1.5, 2.5}:
+            raise RuntimeError("nu expected to be 0.5, 1.5, or 2.5")
+        super(MaternKernel, self).__init__(has_lengthscale=True, **kwargs)
+        self.nu = nu
+
+    def covar_func(self, x1, x2, diag=False):
+        # TODO: x1 / x2 size checks are a work around for a very minor bug in KeOps.
+        # This bug is fixed on KeOps master, and we'll remove that part of the check
+        # when they cut a new release.
+        if diag or x1.size(-2) == 1 or x2.size(-2) == 1:
+            distance = self.covar_dist(x1, x2, diag=diag)
+            exp_component = torch.exp(-math.sqrt(self.nu * 2) * distance)
+
+            if self.nu == 0.5:
+                constant_component = 1
+            elif self.nu == 1.5:
+                constant_component = (math.sqrt(3) * distance).add(1)
+            elif self.nu == 2.5:
+                constant_component = (math.sqrt(5) * distance).add(1).add(5.0 / 3.0 * distance ** 2)
+            return constant_component * exp_component
+        else:
+            with torch.autograd.enable_grad():
+                x1_ = KEOLazyTensor(x1[:, None, :])
+                x2_ = KEOLazyTensor(x2[None, :, :])
+
+                distance = ((x1_ - x2_) ** 2).sum(-1).sqrt()
+                exp_component = (-math.sqrt(self.nu * 2) * distance).exp()
+
+                if self.nu == 0.5:
+                    constant_component = 1
+                elif self.nu == 1.5:
+                    constant_component = (math.sqrt(3) * distance) + 1
+                elif self.nu == 2.5:
+                    constant_component = (math.sqrt(5) * distance) + (1 + 5.0 / 3.0 * distance ** 2)
+
+                return constant_component * exp_component
+
+    def forward(self, x1, x2, diag=False, **params):
+        mean = x1.contiguous().view(-1, x1.size(-1)).mean(0)[(None,) * (x1.dim() - 1)]
+
+        x1_ = (x1 - mean).div(self.lengthscale)
+        x2_ = (x2 - mean).div(self.lengthscale)
+
+        if diag:
+            return self.covar_func(x1_, x2_, diag=True)
+
+        covar_func = lambda x1, x2, diag=False: self.covar_func(x1, x2, diag)
+        return KeOpsLazyTensor(x1_, x2_, covar_func)

--- a/gpytorch/kernels/keops/matern_kernel.py
+++ b/gpytorch/kernels/keops/matern_kernel.py
@@ -38,8 +38,8 @@ try:
                 return constant_component * exp_component
             else:
                 with torch.autograd.enable_grad():
-                    x1_ = KEOLazyTensor(x1[:, None, :])
-                    x2_ = KEOLazyTensor(x2[None, :, :])
+                    x1_ = KEOLazyTensor(x1[..., :, None, :])
+                    x2_ = KEOLazyTensor(x2[..., None, :, :])
 
                     distance = ((x1_ - x2_) ** 2).sum(-1).sqrt()
                     exp_component = (-math.sqrt(self.nu * 2) * distance).exp()

--- a/gpytorch/kernels/keops/matern_kernel.py
+++ b/gpytorch/kernels/keops/matern_kernel.py
@@ -8,6 +8,13 @@ try:
     from pykeops.torch import LazyTensor as KEOLazyTensor
 
     class MaternKernel(KeOpsKernel):
+        """
+        Implements the Matern kernel using KeOps as a driver for kernel matrix multiplies.
+
+        This class can be used as a drop in replacement for gpytorch.kernels.MaternKernel in most cases, and supports
+        the same arguments. There are currently a few limitations, for example a lack of batch mode support. However,
+        most other features like ARD will work.
+        """
         def __init__(self, nu=2.5, **kwargs):
             if nu not in {0.5, 1.5, 2.5}:
                 raise RuntimeError("nu expected to be 0.5, 1.5, or 2.5")

--- a/gpytorch/kernels/keops/matern_kernel.py
+++ b/gpytorch/kernels/keops/matern_kernel.py
@@ -1,58 +1,64 @@
 #!/usr/bin/env python3
 import torch
 import math
-from pykeops.torch import LazyTensor as KEOLazyTensor
-from ..kernel import Kernel
+from .keops_kernel import KeOpsKernel
 from gpytorch.lazy import KeOpsLazyTensor
 
+try:
+    from pykeops.torch import LazyTensor as KEOLazyTensor
 
-class MaternKernel(Kernel):
-    def __init__(self, nu=2.5, **kwargs):
-        if nu not in {0.5, 1.5, 2.5}:
-            raise RuntimeError("nu expected to be 0.5, 1.5, or 2.5")
-        super(MaternKernel, self).__init__(has_lengthscale=True, **kwargs)
-        self.nu = nu
+    class MaternKernel(KeOpsKernel):
+        def __init__(self, nu=2.5, **kwargs):
+            if nu not in {0.5, 1.5, 2.5}:
+                raise RuntimeError("nu expected to be 0.5, 1.5, or 2.5")
+            super(MaternKernel, self).__init__(has_lengthscale=True, **kwargs)
+            self.nu = nu
 
-    def covar_func(self, x1, x2, diag=False):
-        # TODO: x1 / x2 size checks are a work around for a very minor bug in KeOps.
-        # This bug is fixed on KeOps master, and we'll remove that part of the check
-        # when they cut a new release.
-        if diag or x1.size(-2) == 1 or x2.size(-2) == 1:
-            distance = self.covar_dist(x1, x2, diag=diag)
-            exp_component = torch.exp(-math.sqrt(self.nu * 2) * distance)
-
-            if self.nu == 0.5:
-                constant_component = 1
-            elif self.nu == 1.5:
-                constant_component = (math.sqrt(3) * distance).add(1)
-            elif self.nu == 2.5:
-                constant_component = (math.sqrt(5) * distance).add(1).add(5.0 / 3.0 * distance ** 2)
-            return constant_component * exp_component
-        else:
-            with torch.autograd.enable_grad():
-                x1_ = KEOLazyTensor(x1[:, None, :])
-                x2_ = KEOLazyTensor(x2[None, :, :])
-
-                distance = ((x1_ - x2_) ** 2).sum(-1).sqrt()
-                exp_component = (-math.sqrt(self.nu * 2) * distance).exp()
+        def covar_func(self, x1, x2, diag=False):
+            # TODO: x1 / x2 size checks are a work around for a very minor bug in KeOps.
+            # This bug is fixed on KeOps master, and we'll remove that part of the check
+            # when they cut a new release.
+            if diag or x1.size(-2) == 1 or x2.size(-2) == 1:
+                distance = self.covar_dist(x1, x2, diag=diag)
+                exp_component = torch.exp(-math.sqrt(self.nu * 2) * distance)
 
                 if self.nu == 0.5:
                     constant_component = 1
                 elif self.nu == 1.5:
-                    constant_component = (math.sqrt(3) * distance) + 1
+                    constant_component = (math.sqrt(3) * distance).add(1)
                 elif self.nu == 2.5:
-                    constant_component = (math.sqrt(5) * distance) + (1 + 5.0 / 3.0 * distance ** 2)
-
+                    constant_component = (math.sqrt(5) * distance).add(1).add(5.0 / 3.0 * distance ** 2)
                 return constant_component * exp_component
+            else:
+                with torch.autograd.enable_grad():
+                    x1_ = KEOLazyTensor(x1[:, None, :])
+                    x2_ = KEOLazyTensor(x2[None, :, :])
 
-    def forward(self, x1, x2, diag=False, **params):
-        mean = x1.contiguous().view(-1, x1.size(-1)).mean(0)[(None,) * (x1.dim() - 1)]
+                    distance = ((x1_ - x2_) ** 2).sum(-1).sqrt()
+                    exp_component = (-math.sqrt(self.nu * 2) * distance).exp()
 
-        x1_ = (x1 - mean).div(self.lengthscale)
-        x2_ = (x2 - mean).div(self.lengthscale)
+                    if self.nu == 0.5:
+                        constant_component = 1
+                    elif self.nu == 1.5:
+                        constant_component = (math.sqrt(3) * distance) + 1
+                    elif self.nu == 2.5:
+                        constant_component = (math.sqrt(5) * distance) + (1 + 5.0 / 3.0 * distance ** 2)
 
-        if diag:
-            return self.covar_func(x1_, x2_, diag=True)
+                    return constant_component * exp_component
 
-        covar_func = lambda x1, x2, diag=False: self.covar_func(x1, x2, diag)
-        return KeOpsLazyTensor(x1_, x2_, covar_func)
+        def forward(self, x1, x2, diag=False, **params):
+            mean = x1.contiguous().view(-1, x1.size(-1)).mean(0)[(None,) * (x1.dim() - 1)]
+
+            x1_ = (x1 - mean).div(self.lengthscale)
+            x2_ = (x2 - mean).div(self.lengthscale)
+
+            if diag:
+                return self.covar_func(x1_, x2_, diag=True)
+
+            covar_func = lambda x1, x2, diag=False: self.covar_func(x1, x2, diag)
+            return KeOpsLazyTensor(x1_, x2_, covar_func)
+
+except ImportError:
+    class MaternKernel(KeOpsKernel):
+        def __init__(self, *args, **kwargs):
+            super().__init__()

--- a/gpytorch/kernels/keops/rbf_kernel.py
+++ b/gpytorch/kernels/keops/rbf_kernel.py
@@ -1,38 +1,45 @@
 import torch
-from pykeops.torch import LazyTensor as KEOLazyTensor
-from ..kernel import Kernel
+
+from .keops_kernel import KeOpsKernel
 from ..rbf_kernel import postprocess_rbf
 from gpytorch.lazy import KeOpsLazyTensor
 
+try:
+    from pykeops.torch import LazyTensor as KEOLazyTensor
 
-class RBFKernel(Kernel):
-    def __init__(self, **kwargs):
-        super(RBFKernel, self).__init__(has_lengthscale=True, **kwargs)
+    class RBFKernel(KeOpsKernel):
+        def __init__(self, **kwargs):
+            super(RBFKernel, self).__init__(has_lengthscale=True, **kwargs)
 
-    def covar_func(self, x1, x2, diag=False):
-        # TODO: x1 / x2 size checks are a work around for a very minor bug in KeOps.
-        # This bug is fixed on KeOps master, and we'll remove that part of the check
-        # when they cut a new release.
-        if diag or x1.size(-2) == 1 or x2.size(-2) == 1:
-            return self.covar_dist(
-                x1, x2, square_dist=True, diag=diag,
-                dist_postprocess_func=postprocess_rbf,
-                postprocess=True
-            )
-        else:
-            with torch.autograd.enable_grad():
-                x1_ = KEOLazyTensor(x1[:, None, :])
-                x2_ = KEOLazyTensor(x2[None, :, :])
+        def covar_func(self, x1, x2, diag=False):
+            # TODO: x1 / x2 size checks are a work around for a very minor bug in KeOps.
+            # This bug is fixed on KeOps master, and we'll remove that part of the check
+            # when they cut a new release.
+            if diag or x1.size(-2) == 1 or x2.size(-2) == 1:
+                return self.covar_dist(
+                    x1, x2, square_dist=True, diag=diag,
+                    dist_postprocess_func=postprocess_rbf,
+                    postprocess=True
+                )
+            else:
+                with torch.autograd.enable_grad():
+                    x1_ = KEOLazyTensor(x1[:, None, :])
+                    x2_ = KEOLazyTensor(x2[None, :, :])
 
-                K = (-((x1_ - x2_) ** 2).sum(-1) / 2).exp()
+                    K = (-((x1_ - x2_) ** 2).sum(-1) / 2).exp()
 
-                return K
+                    return K
 
-    def forward(self, x1, x2, diag=False, **params):
-        x1_ = x1.div(self.lengthscale)
-        x2_ = x2.div(self.lengthscale)
-        if diag:
-            return self.covar_func(x1_, x2_, diag=True)
+        def forward(self, x1, x2, diag=False, **params):
+            x1_ = x1.div(self.lengthscale)
+            x2_ = x2.div(self.lengthscale)
+            if diag:
+                return self.covar_func(x1_, x2_, diag=True)
 
-        covar_func = lambda x1, x2, diag=False: self.covar_func(x1, x2, diag)
-        return KeOpsLazyTensor(x1_, x2_, covar_func)
+            covar_func = lambda x1, x2, diag=False: self.covar_func(x1, x2, diag)
+            return KeOpsLazyTensor(x1_, x2_, covar_func)
+
+except ImportError:
+    class RBFKernel(KeOpsKernel):
+        def __init__(self, *args, **kwargs):
+            super().__init__()

--- a/gpytorch/kernels/keops/rbf_kernel.py
+++ b/gpytorch/kernels/keops/rbf_kernel.py
@@ -1,0 +1,38 @@
+import torch
+from pykeops.torch import LazyTensor as KEOLazyTensor
+from ..kernel import Kernel
+from ..rbf_kernel import postprocess_rbf
+from gpytorch.lazy import KeOpsLazyTensor
+
+
+class RBFKernel(Kernel):
+    def __init__(self, **kwargs):
+        super(RBFKernel, self).__init__(has_lengthscale=True, **kwargs)
+
+    def covar_func(self, x1, x2, diag=False):
+        # TODO: x1 / x2 size checks are a work around for a very minor bug in KeOps.
+        # This bug is fixed on KeOps master, and we'll remove that part of the check
+        # when they cut a new release.
+        if diag or x1.size(-2) == 1 or x2.size(-2) == 1:
+            return self.covar_dist(
+                x1, x2, square_dist=True, diag=diag,
+                dist_postprocess_func=postprocess_rbf,
+                postprocess=True
+            )
+        else:
+            with torch.autograd.enable_grad():
+                x1_ = KEOLazyTensor(x1[:, None, :])
+                x2_ = KEOLazyTensor(x2[None, :, :])
+
+                K = (-((x1_ - x2_) ** 2).sum(-1) / 2).exp()
+
+                return K
+
+    def forward(self, x1, x2, diag=False, **params):
+        x1_ = x1.div(self.lengthscale)
+        x2_ = x2.div(self.lengthscale)
+        if diag:
+            return self.covar_func(x1_, x2_, diag=True)
+
+        covar_func = lambda x1, x2, diag=False: self.covar_func(x1, x2, diag)
+        return KeOpsLazyTensor(x1_, x2_, covar_func)

--- a/gpytorch/kernels/keops/rbf_kernel.py
+++ b/gpytorch/kernels/keops/rbf_kernel.py
@@ -8,6 +8,13 @@ try:
     from pykeops.torch import LazyTensor as KEOLazyTensor
 
     class RBFKernel(KeOpsKernel):
+        """
+        Implements the RBF kernel using KeOps as a driver for kernel matrix multiplies.
+
+        This class can be used as a drop in replacement for gpytorch.kernels.RBFKernel in most cases, and supports
+        the same arguments. There are currently a few limitations, for example a lack of batch mode support. However,
+        most other features like ARD will work.
+        """
         def __init__(self, **kwargs):
             super(RBFKernel, self).__init__(has_lengthscale=True, **kwargs)
 

--- a/gpytorch/kernels/keops/rbf_kernel.py
+++ b/gpytorch/kernels/keops/rbf_kernel.py
@@ -30,8 +30,8 @@ try:
                 )
             else:
                 with torch.autograd.enable_grad():
-                    x1_ = KEOLazyTensor(x1[:, None, :])
-                    x2_ = KEOLazyTensor(x2[None, :, :])
+                    x1_ = KEOLazyTensor(x1[..., :, None, :])
+                    x2_ = KEOLazyTensor(x2[..., None, :, :])
 
                     K = (-((x1_ - x2_) ** 2).sum(-1) / 2).exp()
 

--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -11,6 +11,7 @@ from .chol_lazy_tensor import CholLazyTensor
 from .constant_mul_lazy_tensor import ConstantMulLazyTensor
 from .diag_lazy_tensor import DiagLazyTensor
 from .interpolated_lazy_tensor import InterpolatedLazyTensor
+from .keops_lazy_tensor import KeOpsLazyTensor
 from .kronecker_product_lazy_tensor import KroneckerProductLazyTensor
 from .lazy_evaluated_kernel_tensor import LazyEvaluatedKernelTensor
 from .matmul_lazy_tensor import MatmulLazyTensor
@@ -41,6 +42,7 @@ __all__ = [
     "DiagLazyTensor",
     "ExtraComputationWarning",
     "InterpolatedLazyTensor",
+    "KeOpsLazyTensor",
     "KroneckerProductLazyTensor",
     "MatmulLazyTensor",
     "MulLazyTensor",

--- a/gpytorch/lazy/keops_lazy_tensor.py
+++ b/gpytorch/lazy/keops_lazy_tensor.py
@@ -2,7 +2,6 @@ import torch
 from .lazy_tensor import LazyTensor
 from ..utils.memoize import cached
 from ..utils.getitem import _noop_index
-from .. import settings
 
 
 class KeOpsLazyTensor(LazyTensor):

--- a/gpytorch/lazy/keops_lazy_tensor.py
+++ b/gpytorch/lazy/keops_lazy_tensor.py
@@ -31,9 +31,11 @@ class KeOpsLazyTensor(LazyTensor):
     def _matmul(self, rhs):
         # TODO: replace with `self.covar_mat @ rhs` on next PyKeOps release.
         batch_shape = self.batch_shape
-
-        # Equivalent to dim=-3, but KeOps LT doesn't support relative index in sum.
-        return (self.covar_mat * rhs[..., None, :, :]).sum(dim=len(batch_shape) + 1)
+        if len(batch_shape):
+            # Equivalent to dim=-3, but KeOps LT doesn't support relative index in sum.
+            return (self.covar_mat * rhs[..., None, :, :].contiguous()).sum(dim=len(batch_shape) + 1)
+        else:
+            return self.covar_mat @ rhs
 
     def _size(self):
         return torch.Size(self.covar_mat.shape)

--- a/gpytorch/lazy/keops_lazy_tensor.py
+++ b/gpytorch/lazy/keops_lazy_tensor.py
@@ -29,7 +29,11 @@ class KeOpsLazyTensor(LazyTensor):
         return self.covar_func(self.x1, self.x2, **self.params)
 
     def _matmul(self, rhs):
-        return self.covar_mat @ rhs
+        # TODO: replace with `self.covar_mat @ rhs` on next PyKeOps release.
+        batch_shape = self.batch_shape
+
+        # Equivalent to dim=-3, but KeOps LT doesn't support relative index in sum.
+        return (self.covar_mat * rhs[..., None, :, :]).sum(dim=len(batch_shape) + 1)
 
     def _size(self):
         return torch.Size(self.covar_mat.shape)

--- a/gpytorch/lazy/keops_lazy_tensor.py
+++ b/gpytorch/lazy/keops_lazy_tensor.py
@@ -1,0 +1,87 @@
+import torch
+from .lazy_tensor import LazyTensor
+from ..utils.memoize import cached
+from ..utils.getitem import _noop_index
+from .. import settings
+
+
+class KeOpsLazyTensor(LazyTensor):
+    def __init__(self, x1, x2, covar_func, **params):
+        super().__init__(x1, x2, covar_func=covar_func, **params)
+
+        self.x1 = x1
+        self.x2 = x2
+        self.covar_func = covar_func
+        self.params = params
+
+    @cached(name="kernel_diag")
+    def diag(self):
+        """
+        Getting the diagonal of a kernel can be handled more efficiently by
+        transposing the batch and data dimension before calling the kernel.
+        Implementing it this way allows us to compute predictions more efficiently
+        in cases where only the variances are required.
+        """
+        return self.covar_func(self.x1, self.x2, diag=True)
+
+    @property
+    @cached(name="covar_mat")
+    def covar_mat(self):
+        return self.covar_func(self.x1, self.x2, **self.params)
+
+    def _matmul(self, rhs):
+        return self.covar_mat @ rhs
+
+    def _size(self):
+        return torch.Size(self.covar_mat.shape)
+
+    def _transpose_nonbatch(self):
+        return KeOpsLazyTensor(self.x2, self.x1, self.covar_func)
+
+    def _get_indices(self, row_index, col_index, *batch_indices):
+        x1_ = self.x1[row_index]
+        x2_ = self.x2[col_index]
+        return self.covar_func(x1_, x2_, **self.params)
+
+    def _getitem(self, row_index, col_index, *batch_indices):
+        x1 = self.x1
+        x2 = self.x2
+        dim_index = _noop_index
+
+        # Get the indices of x1 and x2 that matter for the kernel
+        # Call x1[*batch_indices, row_index, :]
+        try:
+            x1 = x1[(*batch_indices, row_index, dim_index)]
+        # We're going to handle multi-batch indexing with a try-catch loop
+        # This way - in the default case, we can avoid doing expansions of x1 which can be timely
+        except IndexError:
+            if isinstance(batch_indices, slice):
+                x1 = x1.expand(1, *self.x1.shape[-2:])[(*batch_indices, row_index, dim_index)]
+            elif isinstance(batch_indices, tuple):
+                if any(not isinstance(bi, slice) for bi in batch_indices):
+                    raise RuntimeError(
+                        f"Attempting to tensor index a non-batch matrix's batch dimensions. "
+                        "Got batch index {batch_indices} but my shape was {self.shape}"
+                    )
+                x1 = x1.expand(*([1] * len(batch_indices)), *self.x1.shape[-2:])
+                x1 = x1[(*batch_indices, row_index, dim_index)]
+
+        # Call x2[*batch_indices, row_index, :]
+        try:
+            x2 = x2[(*batch_indices, col_index, dim_index)]
+        # We're going to handle multi-batch indexing with a try-catch loop
+        # This way - in the default case, we can avoid doing expansions of x1 which can be timely
+        except IndexError:
+            if isinstance(batch_indices, slice):
+                x2 = x2.expand(1, *self.x2.shape[-2:])[(*batch_indices, row_index, dim_index)]
+            elif isinstance(batch_indices, tuple):
+                if any([not isinstance(bi, slice) for bi in batch_indices]):
+                    raise RuntimeError(
+                        f"Attempting to tensor index a non-batch matrix's batch dimensions. "
+                        "Got batch index {batch_indices} but my shape was {self.shape}"
+                    )
+                x2 = x2.expand(*([1] * len(batch_indices)), *self.x2.shape[-2:])
+                x2 = x2[(*batch_indices, row_index, dim_index)]
+
+        # Now construct a kernel with those indices
+        return self.__class__(x1, x2, covar_func=self.covar_func, **self.params)

--- a/gpytorch/lazy/keops_lazy_tensor.py
+++ b/gpytorch/lazy/keops_lazy_tensor.py
@@ -38,9 +38,9 @@ class KeOpsLazyTensor(LazyTensor):
         return KeOpsLazyTensor(self.x2, self.x1, self.covar_func)
 
     def _get_indices(self, row_index, col_index, *batch_indices):
-        x1_ = self.x1[row_index]
-        x2_ = self.x2[col_index]
-        return self.covar_func(x1_, x2_, **self.params)
+        x1_ = self.x1[(*batch_indices, row_index)]
+        x2_ = self.x2[(*batch_indices, col_index)]
+        return self.covar_func(x1_, x2_, diag=True, **self.params)
 
     def _getitem(self, row_index, col_index, *batch_indices):
         x1 = self.x1

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -348,7 +348,7 @@ class LazyTensor(ABC):
             else:
                 grads.append(None)
 
-        return grads
+        return tuple(grads)
 
     ####
     # Class definitions

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,9 @@ setup(
         "pyro": [
             "pyro-ppl>=0.3.0",
         ],
+        "keops": [
+            "pykeops>=1.1.1",
+        ],
         "test": [
             "flake8",
             "flake8-print",

--- a/test/kernels/keops/test_matern_kernel.py
+++ b/test/kernels/keops/test_matern_kernel.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import torch
+import unittest
+from gpytorch.kernels.keops import MaternKernel
+from gpytorch.kernels import MaternKernel as GMaternKernel
+
+try:
+    import pykeops  # noqa
+
+    class TestMaternKeOpsKernel(unittest.TestCase):
+        def test_forward_nu25_x1_eq_x2(self):
+            if not torch.cuda.is_available():
+                return
+
+            x1 = torch.randn(100, 3).cuda()
+
+            kern1 = MaternKernel(nu=2.5).cuda()
+            kern2 = GMaternKernel(nu=2.5).cuda()
+
+            k1 = kern1(x1, x1).evaluate()
+            k2 = kern2(x1, x1).evaluate()
+
+            self.assertLess(torch.norm(k1 - k2), 1e-5)
+
+        def test_forward_nu25_x1_neq_x2(self):
+            if not torch.cuda.is_available():
+                return
+
+            x1 = torch.randn(100, 3).cuda()
+            x2 = torch.randn(50, 3).cuda()
+
+            kern1 = MaternKernel(nu=2.5).cuda()
+            kern2 = GMaternKernel(nu=2.5).cuda()
+
+            k1 = kern1(x1, x2).evaluate()
+            k2 = kern2(x1, x2).evaluate()
+
+            self.assertLess(torch.norm(k1 - k2), 1e-5)
+
+        def test_forward_nu15_x1_eq_x2(self):
+            if not torch.cuda.is_available():
+                return
+
+            x1 = torch.randn(100, 3).cuda()
+
+            kern1 = MaternKernel(nu=2.5).cuda()
+            kern2 = GMaternKernel(nu=2.5).cuda()
+
+            k1 = kern1(x1, x1).evaluate()
+            k2 = kern2(x1, x1).evaluate()
+
+            self.assertLess(torch.norm(k1 - k2), 1e-5)
+
+        def test_forward_nu15_x1_neq_x2(self):
+            if not torch.cuda.is_available():
+                return
+
+            x1 = torch.randn(100, 3).cuda()
+            x2 = torch.randn(50, 3).cuda()
+
+            kern1 = MaternKernel(nu=1.5).cuda()
+            kern2 = GMaternKernel(nu=1.5).cuda()
+
+            k1 = kern1(x1, x2).evaluate()
+            k2 = kern2(x1, x2).evaluate()
+
+            self.assertLess(torch.norm(k1 - k2), 1e-5)
+
+        def test_forward_nu05_x1_eq_x2(self):
+            if not torch.cuda.is_available():
+                return
+
+            x1 = torch.randn(100, 3).cuda()
+
+            kern1 = MaternKernel(nu=0.5).cuda()
+            kern2 = GMaternKernel(nu=0.5).cuda()
+
+            k1 = kern1(x1, x1).evaluate()
+            k2 = kern2(x1, x1).evaluate()
+
+            self.assertLess(torch.norm(k1 - k2), 1e-5)
+
+        def test_forward_nu05_x1_neq_x2(self):
+            if not torch.cuda.is_available():
+                return
+
+            x1 = torch.randn(100, 3).cuda()
+            x2 = torch.randn(50, 3).cuda()
+
+            kern1 = MaternKernel(nu=0.5).cuda()
+            kern2 = GMaternKernel(nu=0.5).cuda()
+
+            k1 = kern1(x1, x2).evaluate()
+            k2 = kern2(x1, x2).evaluate()
+
+            self.assertLess(torch.norm(k1 - k2), 1e-5)
+
+except ImportError:
+    pass
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/kernels/keops/test_matern_kernel.py
+++ b/test/kernels/keops/test_matern_kernel.py
@@ -4,97 +4,79 @@ import torch
 import unittest
 from gpytorch.kernels.keops import MaternKernel
 from gpytorch.kernels import MaternKernel as GMaternKernel
+from gpytorch.test.base_kernel_test_case import BaseKernelTestCase
 
 try:
     import pykeops  # noqa
 
+    class TestMatern25KeOpsBaseKernel(unittest.TestCase, BaseKernelTestCase):
+        def create_kernel_no_ard(self, **kwargs):
+            return MaternKernel(nu=2.5, **kwargs)
+
+        def create_kernel_ard(self, num_dims, **kwargs):
+            return MaternKernel(nu=2.5, ard_num_dims=num_dims, **kwargs)
+
     class TestMaternKeOpsKernel(unittest.TestCase):
-        def test_forward_nu25_x1_eq_x2(self):
+        def test_forward_x1_eq_x2(self, nu):
             if not torch.cuda.is_available():
                 return
 
             x1 = torch.randn(100, 3).cuda()
 
-            kern1 = MaternKernel(nu=2.5).cuda()
-            kern2 = GMaternKernel(nu=2.5).cuda()
+            kern1 = MaternKernel(nu=nu).cuda()
+            kern2 = GMaternKernel(nu=nu).cuda()
 
             k1 = kern1(x1, x1).evaluate()
             k2 = kern2(x1, x1).evaluate()
 
-            self.assertLess(torch.norm(k1 - k2), 1e-5)
+            self.assertLess(torch.norm(k1 - k2), 1e-4)
+
+        def test_forward_x1_neq_x2(self, nu):
+            if not torch.cuda.is_available():
+                return
+
+            x1 = torch.randn(100, 3).cuda()
+            x2 = torch.randn(50, 3).cuda()
+
+            kern1 = MaternKernel(nu=nu).cuda()
+            kern2 = GMaternKernel(nu=nu).cuda()
+
+            k1 = kern1(x1, x2).evaluate()
+            k2 = kern2(x1, x2).evaluate()
+
+            self.assertLess(torch.norm(k1 - k2), 1e-4)
+
+        def test_forward_nu25_x1_eq_x2(self):
+            return self.test_forward_x1_eq_x2(nu=2.5)
 
         def test_forward_nu25_x1_neq_x2(self):
-            if not torch.cuda.is_available():
-                return
-
-            x1 = torch.randn(100, 3).cuda()
-            x2 = torch.randn(50, 3).cuda()
-
-            kern1 = MaternKernel(nu=2.5).cuda()
-            kern2 = GMaternKernel(nu=2.5).cuda()
-
-            k1 = kern1(x1, x2).evaluate()
-            k2 = kern2(x1, x2).evaluate()
-
-            self.assertLess(torch.norm(k1 - k2), 1e-5)
+            return self.test_forward_nu05_x1_neq_x2(nu=2.5)
 
         def test_forward_nu15_x1_eq_x2(self):
+            return self.test_forward_x1_eq_x2(nu=1.5)
+
+        def test_forward_nu15_x1_neq_x2(self):
+            return self.test_forward_x1_neq_x2(nu=1.5)
+
+        def test_forward_nu05_x1_eq_x2(self):
+            return self.test_forward_x1_eq_x2(nu=0.5)
+
+        def test_forward_nu05_x1_neq_x2(self):
+            return self.test_forward_x1_neq_x2(nu=0.5)
+
+        def test_batch_matmul(self):
             if not torch.cuda.is_available():
                 return
 
-            x1 = torch.randn(100, 3).cuda()
-
+            x1 = torch.randn(3, 2, 100, 3).cuda()
             kern1 = MaternKernel(nu=2.5).cuda()
             kern2 = GMaternKernel(nu=2.5).cuda()
 
-            k1 = kern1(x1, x1).evaluate()
-            k2 = kern2(x1, x1).evaluate()
+            rhs = torch.randn(3, 2, 100, 1).cuda()
+            res1 = kern1(x1, x1).matmul(rhs)
+            res2 = kern2(x1, x1).matmul(rhs)
 
-            self.assertLess(torch.norm(k1 - k2), 1e-5)
-
-        def test_forward_nu15_x1_neq_x2(self):
-            if not torch.cuda.is_available():
-                return
-
-            x1 = torch.randn(100, 3).cuda()
-            x2 = torch.randn(50, 3).cuda()
-
-            kern1 = MaternKernel(nu=1.5).cuda()
-            kern2 = GMaternKernel(nu=1.5).cuda()
-
-            k1 = kern1(x1, x2).evaluate()
-            k2 = kern2(x1, x2).evaluate()
-
-            self.assertLess(torch.norm(k1 - k2), 1e-5)
-
-        def test_forward_nu05_x1_eq_x2(self):
-            if not torch.cuda.is_available():
-                return
-
-            x1 = torch.randn(100, 3).cuda()
-
-            kern1 = MaternKernel(nu=0.5).cuda()
-            kern2 = GMaternKernel(nu=0.5).cuda()
-
-            k1 = kern1(x1, x1).evaluate()
-            k2 = kern2(x1, x1).evaluate()
-
-            self.assertLess(torch.norm(k1 - k2), 1e-5)
-
-        def test_forward_nu05_x1_neq_x2(self):
-            if not torch.cuda.is_available():
-                return
-
-            x1 = torch.randn(100, 3).cuda()
-            x2 = torch.randn(50, 3).cuda()
-
-            kern1 = MaternKernel(nu=0.5).cuda()
-            kern2 = GMaternKernel(nu=0.5).cuda()
-
-            k1 = kern1(x1, x2).evaluate()
-            k2 = kern2(x1, x2).evaluate()
-
-            self.assertLess(torch.norm(k1 - k2), 1e-5)
+            self.assertLess(torch.norm(res1 - res2), 1e-4)
 
 except ImportError:
     pass

--- a/test/kernels/keops/test_rbf_kernel.py
+++ b/test/kernels/keops/test_rbf_kernel.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import torch
+import unittest
+from gpytorch.kernels.keops import RBFKernel
+from gpytorch.kernels import RBFKernel as GRBFKernel
+
+try:
+    import pykeops  # noqa
+
+    class TestRBFKeOpsKernel(unittest.TestCase):
+        def test_forward_x1_eq_x2(self):
+            if not torch.cuda.is_available():
+                return
+
+            x1 = torch.randn(100, 3).cuda()
+
+            kern1 = RBFKernel().cuda()
+            kern2 = GRBFKernel().cuda()
+
+            k1 = kern1(x1, x1).evaluate()
+            k2 = kern2(x1, x1).evaluate()
+
+            self.assertLess(torch.norm(k1 - k2), 1e-5)
+
+        def test_forward_x1_neq_x2(self):
+            if not torch.cuda.is_available():
+                return
+
+            x1 = torch.randn(100, 3).cuda()
+            x2 = torch.randn(50, 3).cuda()
+
+            kern1 = RBFKernel().cuda()
+            kern2 = GRBFKernel().cuda()
+
+            k1 = kern1(x1, x2).evaluate()
+            k2 = kern2(x1, x2).evaluate()
+
+            self.assertLess(torch.norm(k1 - k2), 1e-5)
+
+except ImportError:
+    pass
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/kernels/keops/test_rbf_kernel.py
+++ b/test/kernels/keops/test_rbf_kernel.py
@@ -4,9 +4,17 @@ import torch
 import unittest
 from gpytorch.kernels.keops import RBFKernel
 from gpytorch.kernels import RBFKernel as GRBFKernel
+from gpytorch.test.base_kernel_test_case import BaseKernelTestCase
 
 try:
     import pykeops  # noqa
+
+    class TestRBFKeOpsBaseKernel(unittest.TestCase, BaseKernelTestCase):
+        def create_kernel_no_ard(self, **kwargs):
+            return RBFKernel(**kwargs)
+
+        def create_kernel_ard(self, num_dims, **kwargs):
+            return RBFKernel(ard_num_dims=num_dims, **kwargs)
 
     class TestRBFKeOpsKernel(unittest.TestCase):
         def test_forward_x1_eq_x2(self):
@@ -21,7 +29,7 @@ try:
             k1 = kern1(x1, x1).evaluate()
             k2 = kern2(x1, x1).evaluate()
 
-            self.assertLess(torch.norm(k1 - k2), 1e-5)
+            self.assertLess(torch.norm(k1 - k2), 1e-4)
 
         def test_forward_x1_neq_x2(self):
             if not torch.cuda.is_available():
@@ -36,7 +44,21 @@ try:
             k1 = kern1(x1, x2).evaluate()
             k2 = kern2(x1, x2).evaluate()
 
-            self.assertLess(torch.norm(k1 - k2), 1e-5)
+            self.assertLess(torch.norm(k1 - k2), 1e-4)
+
+        def test_batch_matmul(self):
+            if not torch.cuda.is_available():
+                return
+
+            x1 = torch.randn(3, 2, 100, 3).cuda()
+            kern1 = RBFKernel().cuda()
+            kern2 = GRBFKernel().cuda()
+
+            rhs = torch.randn(3, 2, 100, 1).cuda()
+            res1 = kern1(x1, x1).matmul(rhs)
+            res2 = kern2(x1, x1).matmul(rhs)
+
+            self.assertLess(torch.norm(res1 - res2), 1e-4)
 
 except ImportError:
     pass


### PR DESCRIPTION
This PR implements two new kernels `kernels.keops.RBFKernel` and `kernels.keops.MaternKernel`, that when swapped in for our default ones use KeOps to drive kernel matmuls.

Initial results suggest that the efficient matmuls of KeOps combined with the GPyTorch bells and whistles like preconditioning allow for training on datasets like 3droad (`n=~400k`) in minutes.