### PR TITLE
Fix addcmul broadcasting

### DIFF
--- a/gpytorch/lazy/cat_lazy_tensor.py
+++ b/gpytorch/lazy/cat_lazy_tensor.py
@@ -7,10 +7,7 @@ from . import delazify
 from ..utils.broadcasting import _mul_broadcast_shape, _matmul_broadcast_shape
 from ..utils.getitem import _noop_index
 from .. import settings
-
-
-# TODO: Use bool instead of uint8 dtype once pytorch #21113 is in stable release
-bool_compat = (torch.ones(1) > 0).dtype
+from ..utils.deprecation import bool_compat
 
 
 def cat(inputs, dim=0, output_device=None):

--- a/gpytorch/lazy/cat_lazy_tensor.py
+++ b/gpytorch/lazy/cat_lazy_tensor.py
@@ -9,6 +9,10 @@ from ..utils.getitem import _noop_index
 from .. import settings
 
 
+# TODO: Use bool instead of uint8 dtype once pytorch #21113 is in stable release
+bool_compat = (torch.ones(1) > 0).dtype
+
+
 def cat(inputs, dim=0, output_device=None):
     if all(torch.is_tensor(i) for i in inputs):
         return torch.cat(inputs, dim=dim)
@@ -137,8 +141,7 @@ class CatLazyTensor(LazyTensor):
 
         # Find out for which indices we switch to different tensors
         target_tensors = self.idx_to_tensor_idx[cat_dim_indices]
-        # TODO: Use bool instead of uint8 dtype once pytorch #21113 is in stable release
-        does_switch_tensor = torch.ones(target_tensors.numel() + 1, dtype=torch.uint8, device=self.device)
+        does_switch_tensor = torch.ones(target_tensors.numel() + 1, dtype=bool_compat, device=self.device)
         torch.ne(target_tensors[:-1], target_tensors[1:], out=does_switch_tensor[1:-1])
 
         # Get the LazyTensors that will comprise the new LazyTensor
@@ -190,8 +193,7 @@ class CatLazyTensor(LazyTensor):
         elif torch.is_tensor(cat_dim_indices):
             # Find out for which indices we switch to different tensors
             target_tensors = self.idx_to_tensor_idx[cat_dim_indices]
-            # TODO: Use bool instead of uint8 dtype once pytorch #21113 is in stable release
-            does_switch_tensor = torch.ones(target_tensors.numel() + 1, dtype=torch.uint8, device=self.device)
+            does_switch_tensor = torch.ones(target_tensors.numel() + 1, dtype=bool_compat, device=self.device)
             torch.ne(target_tensors[:-1], target_tensors[1:], out=does_switch_tensor[1:-1])
 
             # Get the LazyTensors that will comprise the new LazyTensor

--- a/gpytorch/utils/deprecation.py
+++ b/gpytorch/utils/deprecation.py
@@ -2,6 +2,15 @@
 
 import warnings
 import functools
+import torch
+from unittest.mock import MagicMock
+
+
+# TODO: Use bool instead of uint8 dtype once pytorch #21113 is in stable release
+if isinstance(torch, MagicMock):
+    bool_compat = torch.uint8
+else:
+    bool_compat = (torch.ones(1) > 0).dtype
 
 
 class DeprecationError(Exception):

--- a/gpytorch/utils/linear_cg.py
+++ b/gpytorch/utils/linear_cg.py
@@ -3,10 +3,7 @@
 import torch
 import warnings
 from .. import settings
-
-
-# TODO: Use bool instead of uint8 dtype once pytorch #21113 is in stable release
-bool_compat = (torch.ones(1) > 0).dtype
+from .deprecation import bool_compat
 
 
 def _default_preconditioner(x):


### PR DESCRIPTION
PyTorch does not allow (any more, for addcmul operator) to resize the input tensor. To allow the output shaped differently from the input, we have to save it in the temporary tensor. We cannot do `res = torch.addcmul(res, -1, a, c)` because functions are supposed to modify res in-place.

Addresses #822

Fixed by @VitalyFedyunin