### PR TITLE
Fix performance bug in predictions when test_train_covar is lazy.

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -309,13 +309,11 @@ class DefaultPredictionStrategy(object):
         Returns:
             :obj:`torch.tensor`: The predictive posterior mean of the test points
         """
-        # For efficiency - we can use addmv in the 2d case
-        if test_train_covar.dim() == 2:
-            res = torch.addmv(test_mean, delazify(test_train_covar), self.mean_cache)
-        # In other cases - we'll use the standard infrastructure
-        else:
-            res = (test_train_covar @ self.mean_cache.unsqueeze(-1)).squeeze(-1)
-            res = res + test_mean
+        # NOTE TO FUTURE SELF:
+        # You **cannot* use addmv here, because test_train_covar may not actually be a non lazy tensor even for an exact
+        # GP, and using addmv requires you to delazify test_train_covar, which is obviously a huge no-no!
+        res = (test_train_covar @ self.mean_cache.unsqueeze(-1)).squeeze(-1)
+        res = res + test_mean
         return res
 
     def exact_predictive_covar(self, test_test_covar, test_train_covar):


### PR DESCRIPTION
Right now, our code for the predictive mean explicitly delazifies `test_train_covar` in the non batch case so that we can use a fused `addmv` call rather than `a + m.matmul(v)`.

This is all well and good as a minor optimization when `test_train_covar` has no lazy components, but is a complete disaster if it is lazy. For example, predictions with the new `KeOpsLazyTensor` ended up being a factor of 20 slower than they ought to be as a result of this.

This fixes #832 cc/ @stanbiryukov