### PR TITLE
Support heteroskedastic likelihoods for IP added loss term

### DIFF
--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -28,11 +28,11 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
         res = output.log_prob(target)
 
         # Add terms for SGPR / when inducing points are learned
-        added_loss = torch.zeros_like(res)
-        for added_loss_term in self.model.added_loss_terms():
-            added_loss = added_loss.add(added_loss_term.loss())
-
-        res = res.add(added_loss)
+        if self.model.added_loss_terms():
+            added_loss = torch.zeros_like(res)
+            for added_loss_term in self.model.added_loss_terms():
+                added_loss = added_loss.add(added_loss_term.loss(*params))
+            res = res.add(added_loss)
 
         # Add log probs of priors on the (functions of) parameters
         for _, prior, closure, _ in self.named_priors():

--- a/gpytorch/mlls/inducing_point_kernel_added_loss_term.py
+++ b/gpytorch/mlls/inducing_point_kernel_added_loss_term.py
@@ -9,7 +9,10 @@ class InducingPointKernelAddedLossTerm(AddedLossTerm):
         self.variational_dist = variational_dist
         self.likelihood = likelihood
 
-    def loss(self):
+    def loss(self, *params):
         prior_covar = self.prior_dist.lazy_covariance_matrix
         variational_covar = self.variational_dist.lazy_covariance_matrix
-        return 0.5 * (prior_covar.diag() - variational_covar.diag()).sum() / self.likelihood.noise
+        diag = prior_covar.diag() - variational_covar.diag()
+        shape = prior_covar.shape[:-1]
+        noise_diag = self.likelihood._shaped_noise_covar(shape, *params).diag()
+        return 0.5 * (diag / noise_diag).sum()


### PR DESCRIPTION
The “added_loss” term of type `InducingPointKernelAddedLossTerm` that is added for inducing point kernels hard-codes the assumption that the likelihood has a noise attribute:
https://github.com/cornellius-gp/gpytorch/blob/14c043754540351fb024f20746ddc66b434642ed/gpytorch/mlls/inducing_point_kernel_added_loss_term.py#L15

Likelihoods that use a general noise model do not have this attribute.

Essentially, this added loos term is the trace term in eq (9) of http://proceedings.mlr.press/v5/titsias09a/titsias09a.pdf
Looking at (14) in https://pdfs.semanticscholar.org/db7b/e492a629a98db7f9d77d552fd3568ff42189.pdf, it seems that this term should generalize to heteroskedastic noise models if we use `0.5 * Tr(Sigma^-1 (K_nn – Q_nn))` instead of `0.5 / sigma^2 Tr(K_nn – Q_nn)`, where `Sigma` is the noise covariance provided by the likelihood. This PR implements this for diagonal `Sigma`.

This is by analogy --  haven't done the math on this -- would be good if someone can confirm this makes sense.