### PR TITLE
Grid size for each dim [WIP]

### DIFF
--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -75,7 +75,7 @@ class GridKernel(Kernel):
 
         if not self.interpolation_mode:
             full_grid = create_data_from_grid(self.grid)
-            self.full_grid.detach().resize_(full_grid).copy_(full_grid)
+            self.full_grid.detach_().resize_(full_grid).copy_(full_grid)
 
         if hasattr(self, "_cached_kernel_mat"):
             del self._cached_kernel_mat

--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -34,9 +34,20 @@ class GridKernel(Kernel):
         super(GridKernel, self).__init__(active_dims=active_dims)
         self.interpolation_mode = interpolation_mode
         self.base_kernel = base_kernel
-        self.register_buffer("grid", grid)
+        self.num_dims = len(grid)
+        self.register_buffer_list('grid', grid)
         if not self.interpolation_mode:
             self.register_buffer("full_grid", create_data_from_grid(grid))
+
+    def register_buffer_list(self, base_name, tensors):
+        """Helper to register several buffers at once under a single base name"""
+        for i, tensor in enumerate(tensors):
+            self.register_buffer(base_name + '_' + str(i), tensor)
+
+    @property
+    def grid(self):
+        return [getattr(self, 'grid' + '_' + str(i)) for i in range(self.num_dims)]
+
 
     def train(self, mode=True):
         if hasattr(self, "_cached_kernel_mat"):
@@ -47,7 +58,11 @@ class GridKernel(Kernel):
         """
         Supply a new `grid` if it ever changes.
         """
-        self.grid.detach().resize_(grid.size()).copy_(grid)
+        if not isinstance(grid, list):
+            raise RuntimeError("Update_grid requires that grid is a list of "
+                               "tensors of grid points along each axis.")
+        for dim in range(len(self.grid)):
+            self.grid[dim].detach().resize_(grid[dim].size()).copy_(grid[dim])
 
         if not self.interpolation_mode:
             full_grid = create_data_from_grid(self.grid)
@@ -60,7 +75,7 @@ class GridKernel(Kernel):
     def forward(self, x1, x2, diag=False, last_dim_is_batch=False, **params):
         grid = self.grid
 
-        if not self.interpolation_mode:
+        if not self.interpolation_mode:  # TODO: Update based on possible jagged grid shapes?
             if len(x1.shape[:-2]):
                 full_grid = self.full_grid.expand(*x1.shape[:-2], *self.full_grid.shape[-2:])
             else:
@@ -70,22 +85,32 @@ class GridKernel(Kernel):
             if not self.training and hasattr(self, "_cached_kernel_mat"):
                 return self._cached_kernel_mat
 
-            n_dim = x1.size(-1)
+            if isinstance(x1, list):
+                # we assume it is provided as a 'jagged tensor' representing a grid.
+                n_dim = len(x1)
+            else:
+                n_dim = x1.size(-1)
 
             if settings.use_toeplitz.on():
-                first_item = grid[0:1]
-                covar_columns = self.base_kernel(first_item, grid, diag=False, last_dim_is_batch=True, **params)
-                covar_columns = delazify(covar_columns).squeeze(-2)
+                first_item = [self.grid[i][0:1] for i in range(len(self.grid))] # n_dim x 1
+                # Instead of using last_dim_is_batch, use iterations... b/c "last dim" varies for each input dimension.
+                # covar_columns = self.base_kernel(first_item, grid, diag=False, last_dim_is_batch=True, **params)
+                # Also, like, how do I get this to work when last_dim_is_batch=True???
+                covar_columns = [self.base_kernel(first_item[i], grid[i], last_dim_is_batch=False, **params) for i in
+                                 range(n_dim)] # n_dim x 1 x grid_size[i]
+                # covar_columns = delazify(covar_columns).squeeze(-2)
+                covar_columns = [delazify(c).squeeze(-2) for c in covar_columns]
                 if last_dim_is_batch:
-                    covars = [ToeplitzLazyTensor(covar_columns.squeeze(-2))]
+                    covars = [ToeplitzLazyTensor(c.squeeze(dim=-2)) for c in covar_columns]
                 else:
-                    covars = [ToeplitzLazyTensor(covar_columns[i : i + 1].squeeze(-2)) for i in range(n_dim)]
+                    covars = [ToeplitzLazyTensor(c) for c in
+                              covar_columns]  # TODO at least one of these two is not right, likely batch.
             else:
-                full_covar = self.base_kernel(grid, grid, last_dim_is_batch=True, **params)
+                full_covar = [self.base_kernel(grid[i], grid[i], **params) for i in range(n_dim)]
                 if last_dim_is_batch:
                     covars = [full_covar]
                 else:
-                    covars = [full_covar[i : i + 1].squeeze(0) for i in range(n_dim)]
+                    covars = full_covar  # TODO: same message as above.
 
             if len(covars) > 1:
                 covar = KroneckerProductLazyTensor(*covars[::-1])

--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -94,11 +94,7 @@ class GridKernel(Kernel):
             if not self.training and hasattr(self, "_cached_kernel_mat"):
                 return self._cached_kernel_mat
 
-            if isinstance(x1, list):
-                # we assume it is provided as a 'jagged tensor' representing a grid.
-                n_dim = len(x1)
-            else:
-                n_dim = x1.size(-1)
+            n_dim = self.num_dims
 
             if settings.use_toeplitz.on():
                 first_item = [self.grid[i][0:1] for i in range(len(self.grid))] # n_dim x 1
@@ -115,14 +111,14 @@ class GridKernel(Kernel):
                     covars = [ToeplitzLazyTensor(c) for c in
                               covar_columns]  # TODO at least one of these two is not right, likely batch.
             else:
-                full_covar = [self.base_kernel(grid[i], grid[i], **params) for i in range(n_dim)]
+                full_covar = [self.base_kernel(proj, proj, last_dim_is_batch=False, **params) for proj in grid]
                 if last_dim_is_batch:
                     covars = [full_covar]
                 else:
                     covars = full_covar  # TODO: same message as above.
 
             if len(covars) > 1:
-                covar = KroneckerProductLazyTensor(*covars[::-1])
+                covar = KroneckerProductLazyTensor(*covars)
             else:
                 covar = covars[0]
 

--- a/gpytorch/lazy/sum_batch_lazy_tensor.py
+++ b/gpytorch/lazy/sum_batch_lazy_tensor.py
@@ -54,3 +54,6 @@ class SumBatchLazyTensor(BlockLazyTensor):
     def diag(self):
         diag = self.base_lazy_tensor.diag().sum(-2)
         return diag
+
+    def evaluate(self):
+        return self.base_lazy_tensor.evaluate().sum(dim=-3)  # BlockLazyTensors always use dim3 for the block_dim

--- a/gpytorch/lazy/toeplitz_lazy_tensor.py
+++ b/gpytorch/lazy/toeplitz_lazy_tensor.py
@@ -7,6 +7,14 @@ from ..utils.toeplitz import sym_toeplitz_matmul, sym_toeplitz_derivative_quadra
 
 class ToeplitzLazyTensor(LazyTensor):
     def __init__(self, column):
+        """
+        Args:
+            :attr: `column` (Tensor)
+                If `column` is a 1D Tensor of length `n`, this represents a
+                Toeplitz matrix with `column` as its first column.
+                If `column` is `b_1 x b_2 x ... x b_k x n`, then this represents a batch
+                `b_1 x b_2 x ... x b_k` of Toeplitz matrices.
+        """
         super(ToeplitzLazyTensor, self).__init__(column)
         self.column = column
 
@@ -35,7 +43,7 @@ class ToeplitzLazyTensor(LazyTensor):
         if res.dim() > self.column.dim():
             res = res.view(-1, *self.column.shape).sum(0)
 
-        return res,
+        return (res,)
 
     def _size(self):
         return torch.Size((*self.column.shape, self.column.size(-1)))

--- a/gpytorch/likelihoods/likelihood_list.py
+++ b/gpytorch/likelihoods/likelihood_list.py
@@ -30,4 +30,17 @@ class LikelihoodList(Likelihood):
         ]
 
     def __call__(self, *args, **kwargs):
-        return [likelihood(*args_, **kwargs) for likelihood, args_ in zip(self.likelihoods, _get_tuple_args_(*args))]
+        if "noise" in kwargs:
+            noise = kwargs.pop("noise")
+            # if noise kwarg is passed, assume it's an iterable of noise tensors
+            return [
+                likelihood(*args_, {**kwargs, "noise": noise_})
+                for likelihood, args_, noise_ in zip(
+                    self.likelihoods, _get_tuple_args_(*args), noise
+                )
+            ]
+        else:
+            return [
+                likelihood(*args_, **kwargs)
+                for likelihood, args_ in zip(self.likelihoods, _get_tuple_args_(*args))
+            ]

--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -28,11 +28,11 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
         res = output.log_prob(target)
 
         # Add terms for SGPR / when inducing points are learned
-        added_loss = torch.zeros_like(res)
-        for added_loss_term in self.model.added_loss_terms():
-            added_loss = added_loss.add(added_loss_term.loss())
-
-        res = res.add(added_loss)
+        if self.model.added_loss_terms():
+            added_loss = torch.zeros_like(res)
+            for added_loss_term in self.model.added_loss_terms():
+                added_loss = added_loss.add(added_loss_term.loss(*params))
+            res = res.add(added_loss)
 
         # Add log probs of priors on the (functions of) parameters
         for _, prior, closure, _ in self.named_priors():

--- a/gpytorch/mlls/inducing_point_kernel_added_loss_term.py
+++ b/gpytorch/mlls/inducing_point_kernel_added_loss_term.py
@@ -9,7 +9,10 @@ class InducingPointKernelAddedLossTerm(AddedLossTerm):
         self.variational_dist = variational_dist
         self.likelihood = likelihood
 
-    def loss(self):
+    def loss(self, *params):
         prior_covar = self.prior_dist.lazy_covariance_matrix
         variational_covar = self.variational_dist.lazy_covariance_matrix
-        return 0.5 * (prior_covar.diag() - variational_covar.diag()).sum() / self.likelihood.noise
+        diag = prior_covar.diag() - variational_covar.diag()
+        shape = prior_covar.shape[:-1]
+        noise_diag = self.likelihood._shaped_noise_covar(shape, *params).diag()
+        return 0.5 * (diag / noise_diag).sum()

--- a/gpytorch/utils/interpolation.py
+++ b/gpytorch/utils/interpolation.py
@@ -2,6 +2,8 @@
 
 import torch
 from .broadcasting import _matmul_broadcast_shape
+from functools import reduce
+from operator import mul
 
 
 class Interpolation(object):
@@ -37,11 +39,14 @@ class Interpolation(object):
         return res
 
     def interpolate(self, x_grid, x_target, interp_points=range(-2, 2)):
-        # Do some boundary checking
-        grid_mins = x_grid.min(0)[0]
-        grid_maxs = x_grid.max(0)[0]
+        num_dims = len(x_grid)
+        grid_sizes = [len(x_grid[i]) for i in range(num_dims)]
+        # Do some boundary checking, # min/max along each dimension
+        x_target_max = x_target.max(0)[0]
         x_target_min = x_target.min(0)[0]
-        x_target_max = x_target.min(0)[0]
+        grid_mins = torch.stack([x_grid[i].min() for i in range(num_dims)], dim=0).to(x_target_min)
+        grid_maxs = torch.stack([x_grid[i].max() for i in range(num_dims)], dim=0).to(x_target_max)
+
         lt_min_mask = (x_target_min - grid_mins).lt(-1e-7)
         gt_max_mask = (x_target_max - grid_maxs).gt(1e-7)
         if lt_min_mask.sum().item():
@@ -74,31 +79,34 @@ class Interpolation(object):
             )
 
         # Now do interpolation
-        interp_points = torch.tensor(interp_points, dtype=x_grid.dtype, device=x_grid.device)
-        interp_points_flip = interp_points.flip(0)
+        interp_points = torch.tensor(interp_points, dtype=x_grid[0].dtype, device=x_grid[0].device)
+        interp_points_flip = interp_points.flip(0)  # [1, 0, -1, -2]
 
-        num_grid_points = x_grid.size(0)
         num_target_points = x_target.size(0)
         num_dim = x_target.size(-1)
         num_coefficients = len(interp_points)
 
         interp_values = torch.ones(
-            num_target_points, num_coefficients ** num_dim, dtype=x_grid.dtype, device=x_grid.device
+            num_target_points, num_coefficients ** num_dim, dtype=x_grid[0].dtype, device=x_grid[0].device
         )
         interp_indices = torch.zeros(
-            num_target_points, num_coefficients ** num_dim, dtype=torch.long, device=x_grid.device
+            num_target_points, num_coefficients ** num_dim, dtype=torch.long, device=x_grid[0].device
         )
 
         for i in range(num_dim):
-            grid_delta = x_grid[1, i] - x_grid[0, i]
-            lower_grid_pt_idxs = torch.floor((x_target[:, i] - x_grid[0, i]) / grid_delta).squeeze()
-            lower_pt_rel_dists = (x_target[:, i] - x_grid[0, i]) / grid_delta - lower_grid_pt_idxs
-            lower_grid_pt_idxs = lower_grid_pt_idxs - interp_points.max()
+            num_grid_points = x_grid[i].size(0)
+            grid_delta = x_grid[i][1] - x_grid[i][0]
+            # left-bounding grid point in index space
+            lower_grid_pt_idxs = torch.floor((x_target[:, i] - x_grid[i][0]) / grid_delta).squeeze()
+            # distance from that left-bounding grid point, again in index space
+            lower_pt_rel_dists = (x_target[:, i] - x_grid[i][0]) / grid_delta - lower_grid_pt_idxs
+            lower_grid_pt_idxs = lower_grid_pt_idxs - interp_points.max()  # ends up being the left-most (relevant) pt
             lower_grid_pt_idxs.detach_()
 
             if len(lower_grid_pt_idxs.shape) == 0:
                 lower_grid_pt_idxs = lower_grid_pt_idxs.unsqueeze(0)
 
+            # get the interp. coeff. based on distances to interpolating points
             scaled_dist = lower_pt_rel_dists.unsqueeze(-1) + interp_points_flip.unsqueeze(-2)
             dim_interp_values = self._cubic_interpolation_kernel(scaled_dist)
 
@@ -109,7 +117,7 @@ class Interpolation(object):
 
             if num_left > 0:
                 left_boundary_pts.squeeze_(1)
-                x_grid_first = x_grid[:num_coefficients, i].unsqueeze(1).t().expand(num_left, num_coefficients)
+                x_grid_first = x_grid[i][:num_coefficients].unsqueeze(1).t().expand(num_left, num_coefficients)
 
                 grid_targets = x_target.select(1, i)[left_boundary_pts].unsqueeze(1).expand(num_left, num_coefficients)
                 dists = torch.abs(x_grid_first - grid_targets)
@@ -125,7 +133,7 @@ class Interpolation(object):
 
             if num_right > 0:
                 right_boundary_pts.squeeze_(1)
-                x_grid_last = x_grid[-num_coefficients:, i].unsqueeze(1).t().expand(num_right, num_coefficients)
+                x_grid_last = x_grid[i][-num_coefficients:].unsqueeze(1).t().expand(num_right, num_coefficients)
 
                 grid_targets = x_target.select(1, i)[right_boundary_pts].unsqueeze(1)
                 grid_targets = grid_targets.expand(num_right, num_coefficients)
@@ -138,13 +146,15 @@ class Interpolation(object):
                     lower_grid_pt_idxs[right_boundary_pts[j]] = num_grid_points - num_coefficients
 
             offset = (interp_points - interp_points.min()).long().unsqueeze(-2)
-            dim_interp_indices = lower_grid_pt_idxs.long().unsqueeze(-1) + offset
+            dim_interp_indices = lower_grid_pt_idxs.long().unsqueeze(-1) + offset  # indices of corresponding ind. pts.
 
             n_inner_repeat = num_coefficients ** i
             n_outer_repeat = num_coefficients ** (num_dim - i - 1)
-            index_coeff = num_grid_points ** (num_dim - i - 1)
+            # index_coeff = num_grid_points ** (num_dim - i - 1)  # TODO: double check
+            index_coeff = reduce(mul, grid_sizes[i + 1:], 1)  # Think this is right...
             dim_interp_indices = dim_interp_indices.unsqueeze(-1).repeat(1, n_inner_repeat, n_outer_repeat)
             dim_interp_values = dim_interp_values.unsqueeze(-1).repeat(1, n_inner_repeat, n_outer_repeat)
+            # compute the lexicographical position of the indices in the d-dimensional grid points
             interp_indices = interp_indices.add(dim_interp_indices.view(num_target_points, -1).mul(index_coeff))
             interp_values = interp_values.mul(dim_interp_values.view(num_target_points, -1))
 

--- a/test/kernels/test_grid_kernel.py
+++ b/test/kernels/test_grid_kernel.py
@@ -4,47 +4,111 @@ import torch
 import unittest
 from gpytorch.kernels import RBFKernel, GridKernel, GridInterpolationKernel
 from gpytorch.lazy import KroneckerProductLazyTensor
+from gpytorch.utils import grid as grid_module
 
 cv = GridInterpolationKernel(RBFKernel(), grid_size=10, grid_bounds=[(0, 1), (0, 2)])
 grid = cv.grid
 
-grid_size = grid.size(-2)
-grid_dim = grid.size(-1)
+grid_size = grid[0].size(-1)
+grid_dim = len(grid)
 grid_data = torch.zeros(int(pow(grid_size, grid_dim)), grid_dim)
 prev_points = None
 for i in range(grid_dim):
     for j in range(grid_size):
-        grid_data[j * grid_size ** i : (j + 1) * grid_size ** i, i].fill_(grid[j, i])
+        grid_data[j * grid_size ** i: (j + 1) * grid_size ** i, i].fill_(grid[i][j])
         if prev_points is not None:
-            grid_data[j * grid_size ** i : (j + 1) * grid_size ** i, :i].copy_(prev_points)
+            grid_data[j * grid_size ** i: (j + 1) * grid_size ** i, :i].copy_(prev_points)
     prev_points = grid_data[: grid_size ** (i + 1), : (i + 1)]
+
+cv2 = GridInterpolationKernel(RBFKernel(), grid_size=[8, 12], grid_bounds=[(0, 1), (0, 2)])
+grid2 = cv2.grid
+grid_data2 = grid_module.create_data_from_grid(grid2)
 
 
 class TestGridKernel(unittest.TestCase):
+    def setUp(self):
+        self.grid = grid
+        self.grid_data = grid_data
+
     def test_grid_grid(self):
         base_kernel = RBFKernel()
-        kernel = GridKernel(base_kernel, grid)
-        grid_covar = kernel(grid_data, grid_data).evaluate_kernel()
+        kernel = GridKernel(base_kernel, self.grid)
+        grid_covar = kernel(self.grid_data, self.grid_data).evaluate_kernel()
         self.assertIsInstance(grid_covar, KroneckerProductLazyTensor)
-        grid_eval = kernel(grid_data, grid_data).evaluate()
-        actual_eval = base_kernel(grid_data, grid_data).evaluate()
+        grid_eval = kernel(self.grid_data, self.grid_data).evaluate()
+        actual_eval = base_kernel(self.grid_data, self.grid_data).evaluate()
         self.assertLess(torch.norm(grid_eval - actual_eval), 2e-5)
 
     def test_nongrid_grid(self):
         base_kernel = RBFKernel()
         data = torch.randn(5, 2)
-        kernel = GridKernel(base_kernel, grid)
-        grid_eval = kernel(grid_data, data).evaluate()
-        actual_eval = base_kernel(grid_data, data).evaluate()
+        kernel = GridKernel(base_kernel, self.grid)
+        grid_eval = kernel(self.grid_data, data).evaluate()
+        actual_eval = base_kernel(self.grid_data, data).evaluate()
         self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
 
     def test_nongrid_nongrid(self):
         base_kernel = RBFKernel()
         data = torch.randn(5, 2)
-        kernel = GridKernel(base_kernel, grid)
+        kernel = GridKernel(base_kernel, self.grid)
         grid_eval = kernel(data, data).evaluate()
         actual_eval = base_kernel(data, data).evaluate()
         self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
+
+
+class TestGridKernelDifferentSizes(TestGridKernel):
+    def setUp(self):
+        self.grid = grid2
+        self.grid_data = grid_data2
+
+
+class TestCreateGridFromData(unittest.TestCase):
+    def test_create_grid_from_data(self):
+        from itertools import product
+        small_grid = [torch.tensor([1.44, 3.31]),
+                      torch.tensor([-1., 2., 5.]),
+                      torch.tensor([-7, 7])]
+        grid_data = grid_module.create_data_from_grid(small_grid)
+        order = torch.argsort(grid_data.sum(dim=1))
+        grid_data = grid_data[order, :]
+
+        # brute force creation here to make sure the efficient code is correct
+        actual = torch.zeros(2 * 3 * 2, 3, dtype=torch.float)
+        for r, (i, j, k) in enumerate(product(*small_grid)):
+            actual[r, :] = torch.tensor([i, j, k], dtype=torch.float)
+        order = torch.argsort(actual.sum(dim=1))
+        actual = actual[order, :]
+
+        self.assertLess(torch.norm(grid_data - actual), 1e-5)
+
+
+class TestGridInterpolationKernel(unittest.TestCase):
+    def setUp(self):
+        self.test_pts1 = torch.tensor([[.9651, .6965],
+                                       [.5340, .4923],
+                                       [.5934, .8918],
+                                       [.4249, .1549]], dtype=torch.float)
+        self.test_pts2 = torch.tensor([[.5882, .6965],
+                                       [.3451, .2818],
+                                       [.9133, .9649],
+                                       [.3561, .6711]], dtype=torch.float)
+
+    def test_interpolation_gets_close(self):
+        ski_kernel = GridInterpolationKernel(RBFKernel(), [100, 101], grid_bounds=[[0, 1], [0, 1]])
+        # ski_kernel = GridInterpolationKernel(RBFKernel(), [1000, 1010], num_dims=2) seems to be off due to boundaries?
+        ski_eval = ski_kernel(self.test_pts1, self.test_pts2).evaluate()
+
+        rbf_eval = RBFKernel()(self.test_pts1, self.test_pts2).evaluate()  # will be somewhat off due to interpolation
+
+        self.assertLess(torch.norm(ski_eval - rbf_eval), 1e-3)
+
+    def test_last_dim_is_batch(self):
+        ski_kernel = GridInterpolationKernel(RBFKernel(), [100, 110], grid_bounds=[[0, 1], [0, 1]])
+        comb_points = torch.stack([self.test_pts1, self.test_pts2], dim=2)
+        ski_eval = ski_kernel(comb_points, last_dim_is_batch=True).evaluate()
+
+        rbf_eval = RBFKernel()(comb_points, last_dim_is_batch=True).evaluate()
+        self.assertLess(torch.norm(ski_eval - rbf_eval), 1e-3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Enables `GridInterpolationKernel` to use different grid sizes for each dimension.

I took a stab at issue #853 by converting the `grid` property of GridInterpolatingKernel to a list of tensors. This change did branch into several modules, but the changes are very superficial. It could make it slightly slower since each dimension is not computed in batch this way, but the grids can't be very high dimensional regardless.

The tests I added to `test_grid_kernel.py` reveal, however, that, while the functionality is retained when the grid sizes are the same, **some bug causes it to break if the grid sizes are different from each other** (even [100, 101]. I will try to fix this bug tomorrow (Friday), but since I heard that a time-sensitive matter depends on this functionality, I wanted to go ahead and get this work in progress in front of maintainers in case someone (@KeAWang, @jacobrgardner ?) is able to finish this before I can. 

(I also added comments to the interpolation code to make it more readable for myself and perhaps others in the future.)