### PR TITLE
Support `noise` kwarg for more likelihoods

### DIFF
--- a/gpytorch/likelihoods/likelihood_list.py
+++ b/gpytorch/likelihoods/likelihood_list.py
@@ -30,4 +30,17 @@ class LikelihoodList(Likelihood):
         ]
 
     def __call__(self, *args, **kwargs):
-        return [likelihood(*args_, **kwargs) for likelihood, args_ in zip(self.likelihoods, _get_tuple_args_(*args))]
+        if "noise" in kwargs:
+            noise = kwargs.pop("noise")
+            # if noise kwarg is passed, assume it's an iterable of noise tensors
+            return [
+                likelihood(*args_, {**kwargs, "noise": noise_})
+                for likelihood, args_, noise_ in zip(
+                    self.likelihoods, _get_tuple_args_(*args), noise
+                )
+            ]
+        else:
+            return [
+                likelihood(*args_, **kwargs)
+                for likelihood, args_ in zip(self.likelihoods, _get_tuple_args_(*args))
+            ]


### PR DESCRIPTION
Adds the following functionality:
1. All noise models now pass through a noise kwarg -- that is, if noise is specified it will override the nosie regardless of the noise model. This is useful in that it provides a consistent interface regardless of the particular likelihoodused
2. `Likelihoodlist` now also supports a `noise` kwarg - in this case it is expected to be an iterable of tensors. specifying the noise level for each element of the likelihood list.