### PR TITLE
Fix MLL computation for heteroskedastic noise models

### DIFF
--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import torch
 from .marginal_log_likelihood import MarginalLogLikelihood
 from ..likelihoods import _GaussianLikelihoodBase
 from ..distributions import MultivariateNormal
@@ -27,12 +26,9 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
         output = self.likelihood(output, *params)
         res = output.log_prob(target)
 
-        # Add terms for SGPR / when inducing points are learned
-        if self.model.added_loss_terms():
-            added_loss = torch.zeros_like(res)
-            for added_loss_term in self.model.added_loss_terms():
-                added_loss = added_loss.add(added_loss_term.loss(*params))
-            res = res.add(added_loss)
+        # Add additional terms (SGPR / learned inducing points, heteroskedastic likelihood models)
+        for added_loss_term in self.model.added_loss_terms():
+            res = res.add(added_loss_term.loss(*params))
 
         # Add log probs of priors on the (functions of) parameters
         for _, prior, closure, _ in self.named_priors():

--- a/gpytorch/mlls/noise_model_added_loss_term.py
+++ b/gpytorch/mlls/noise_model_added_loss_term.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from .added_loss_term import AddedLossTerm
+
+
+class NoiseModelAddedLossTerm(AddedLossTerm):
+    def __init__(self, noise_model):
+        from .exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+        self.noise_mll = ExactMarginalLogLikelihood(noise_model.likelihood, noise_model)
+
+    def loss(self, *params):
+        output = self.noise_mll.model(*params)
+        targets = self.noise_mll.model.train_targets
+        return self.noise_mll(output, targets)


### PR DESCRIPTION
Previously, when using a heteroskedastic noise model with a separate model providing the noise, joint training would not work properly because
1. the noise model would be evaluated in prior mode (wheras we need the noise model's posterior predictions for the noise in the actual model)
2. the MLL did not account for the MLL of the noise model.

For 1. the fix is to simply ensure that the noise model is in eval mode when called inside `HeteroskedasticNoise`'s `forward` method. Note that this also requires ensuring to not detach the test caches of the main model during evaluation, since o/w some of the noise model's parameters are chopped off from the compute graph.

For 2. this PR introduces the `NoiseModelAddedLossTerm`.