### PR TITLE
Override evaluate for SumBatchLazyTensor

### DIFF
--- a/gpytorch/lazy/sum_batch_lazy_tensor.py
+++ b/gpytorch/lazy/sum_batch_lazy_tensor.py
@@ -54,3 +54,6 @@ class SumBatchLazyTensor(BlockLazyTensor):
     def diag(self):
         diag = self.base_lazy_tensor.diag().sum(-2)
         return diag
+
+    def evaluate(self):
+        return self.base_lazy_tensor.evaluate().sum(dim=-3)  # BlockLazyTensors always use dim3 for the block_dim


### PR DESCRIPTION
Fixes #866 

As far as I can tell, there are still some lingering edge cases involving using the default `_getitem` for KroneckerProductLazyTensor. However, in my opinion, the "right" way to fix this is probably to add an overridden `_getitem` for Kronecker products, since it's one of the more commonly used LTs.

Since this will involve refactoring KPLT so that it only represents KPs of 2 tensors at a time (e.g., `KPLT(lt1, lt2, lt3) -> KPLT(KPLT(lt1, lt2), lt3)`), this is a much larger project.

For now, This fixes this specific instance of the problem in a reasonable way, since `SumBatchLazyTensor` as it is currently written will materialize a matrix the size of the base lazy tensor before summing anyways when calling `evaluate()` (see `BlockLazyTensor`'s `_matmul` method).