### PR TITLE
Roll PyTorch in CI to 1.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
       pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html;
       python setup.py build develop;
     else
-      pip install torch==1.2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html;
+      pip install torch==1.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html;
     fi
 
 script:


### PR DESCRIPTION
Since 1.3.0 is out, I thought it would be better to test against the latest stable version.

cc @gpleiss @Balandat 