### PR TITLE
Register backward hooks to grad functions for cache clearing.

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -22,6 +22,10 @@ from ..utils.memoize import cached, add_to_cache
 import functools
 
 
+def clear_cache_hook(module, *args, **kwargs):
+    module._memoize_cache = {}
+
+
 def prediction_strategy(train_inputs, train_prior_dist, train_labels, likelihood):
     train_train_covar = train_prior_dist.lazy_covariance_matrix
     if isinstance(train_train_covar, LazyEvaluatedKernelTensor):
@@ -73,9 +77,6 @@ class DefaultPredictionStrategy(object):
         res = train_train_covar_inv_root
         if settings.detach_test_caches.on():
             res = res.detach()
-
-        def clear_cache_hook(module, *args, **kwargs):
-            module._memoize_cache = {}
 
         if res.grad_fn is not None:
             wrapper = functools.partial(clear_cache_hook, self)
@@ -268,9 +269,6 @@ class DefaultPredictionStrategy(object):
 
         if settings.detach_test_caches.on():
             mean_cache = mean_cache.detach()
-
-        def clear_cache_hook(module, *args, **kwargs):
-            module._memoize_cache = {}
 
         if mean_cache.grad_fn is not None:
             wrapper = functools.partial(clear_cache_hook, self)


### PR DESCRIPTION
Right now, if you backward through GP predictions to the training data or GP hyperparameters and update either one, the caches don't get cleared but are dirty (the stuff they depend on has changed).

This PR adds hooks to the grad functions of the mean and covariance caches so that if they are backwarded through they get cleared.

Importantly, if you backward through predictions but NOT the caches because `settings.detach_test_caches` is True by default (e.g., you want derivatives w.r.t. test inputs only), the caches will not be cleared because they don't need to be.

In practice, what this does is eliminate the need to manually toggle back and forth between train mode and test mode in models that are trained with a GP component in prediction mode.

Fixes #891