### PR TITLE
Add precommit hook config, run black and isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = matplotlib,numpy,pyro,setuptools,sphinx_rtd_theme,torch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    -   id: flake8
+        args: [--config=setup.cfg]
+        exclude: ^(examples/*)|(docs/*)
+    -   id: check-byte-order-marker
+    -   id: check-case-conflict
+    -   id: check-merge-conflict
+    -   id: end-of-file-fixer
+    -   id: forbid-new-submodules
+    -   id: mixed-line-ending
+        args: [--fix=lf]
+    -   id: trailing-whitespace
+    -   id: debug-statements
+-   repo: https://github.com/ambv/black
+    rev: 19.10b0
+    hooks:
+    -   id: black
+        exclude: ^(build/*)|(docs/*)|(examples/*)
+        args: [-l 120, --target-version=py36]
+-   repo: https://github.com/asottile/seed-isort-config
+    rev: v1.9.3
+    hooks:
+    -   id: seed-isort-config
+        args: [--application-directories=comparison]
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+    -   id: isort
+        language_version: python3
+        exclude: ^(build/*)|(docs/*)|(examples/*)
+        args: [-w 120, -m 3, -tc, --project=gpytorch]
+-   repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 1.11.0
+    hooks:
+    -   id: require-ascii
+        exclude: ^(examples/LBFGS.py)
+    -   id: script-must-have-extension
+    -   id: forbid-binary
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.7
+    hooks:
+    -   id: forbid-crlf
+    -   id: forbid-tabs

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ pip install flake8  # if not already installed
 flake8
 ```
 
+If you plan on submitting a pull request, please make use of our pre-commit hooks to ensure that your commits adhere
+to the general style guidelines enforced by the repo. To do this, navigate to your local repository and run:
+```bash
+pip install pre-commit
+pre-commit install
+```
+
 ## The Team
 
 GPyTorch is primarily maintained by:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,16 +26,14 @@ import sphinx_rtd_theme  # noqa
 
 def read(*names, **kwargs):
     with io.open(
-        os.path.join(os.path.dirname(__file__), "..", "..", *names),
-        encoding=kwargs.get("encoding", "utf8")
+        os.path.join(os.path.dirname(__file__), "..", "..", *names), encoding=kwargs.get("encoding", "utf8")
     ) as fp:
         return fp.read()
 
 
 def find_version(*file_paths):
     version_file = read(*file_paths)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")

--- a/examples/LBFGS.py
+++ b/examples/LBFGS.py
@@ -5,7 +5,6 @@ from functools import reduce
 from copy import deepcopy
 from torch.optim import Optimizer
 
-#%% Helper Functions for L-BFGS
 
 def is_legal(v):
     """
@@ -18,6 +17,7 @@ def is_legal(v):
     legal = not torch.isnan(v).any() and not torch.isinf(v)
 
     return legal
+
 
 def polyinterp(points, x_min_bound=None, x_max_bound=None, plot=False):
     """
@@ -46,15 +46,15 @@ def polyinterp(points, x_min_bound=None, x_max_bound=None, plot=False):
 
     """
     no_points = points.shape[0]
-    order = np.sum(1 - np.isnan(points[:,1:3]).astype('int')) - 1
+    order = np.sum(1 - np.isnan(points[:, 1:3]).astype("int")) - 1
 
     x_min = np.min(points[:, 0])
     x_max = np.max(points[:, 0])
 
     # compute bounds of interpolation area
-    if(x_min_bound is None):
+    if x_min_bound is None:
         x_min_bound = x_min
-    if(x_max_bound is None):
+    if x_max_bound is None:
         x_max_bound = x_max
 
     # explicit formula for quadratic interpolation
@@ -65,11 +65,16 @@ def polyinterp(points, x_min_bound=None, x_max_bound=None, plot=False):
         # if x1 = 0, then is given by:
         # x_min = - (g1*x2^2)/(2(f2 - f1 - g1*x2))
 
-        if(points[0, 0] == 0):
-            x_sol = -points[0, 2]*points[1, 0]**2/(2*(points[1, 1] - points[0, 1] - points[0, 2]*points[1, 0]))
+        if points[0, 0] == 0:
+            x_sol = (
+                -points[0, 2] * points[1, 0] ** 2 / (2 * (points[1, 1] - points[0, 1] - points[0, 2] * points[1, 0]))
+            )
         else:
-            a = -(points[0, 1] - points[1, 1] - points[0, 2]*(points[0, 0] - points[1, 0]))/(points[0, 0] - points[1, 0])**2
-            x_sol = points[0, 0] - points[0, 2]/(2*a)
+            a = (
+                -(points[0, 1] - points[1, 1] - points[0, 2] * (points[0, 0] - points[1, 0]))
+                / (points[0, 0] - points[1, 0]) ** 2
+            )
+            x_sol = points[0, 0] - points[0, 2] / (2 * a)
 
         x_sol = np.minimum(np.maximum(x_min_bound, x_sol), x_max_bound)
 
@@ -79,41 +84,43 @@ def polyinterp(points, x_min_bound=None, x_max_bound=None, plot=False):
         # d1 = g1 + g2 - 3((f1 - f2)/(x1 - x2))
         # d2 = sqrt(d1^2 - g1*g2)
         # x_min = x2 - (x2 - x1)*((g2 + d2 - d1)/(g2 - g1 + 2*d2))
-        d1 = points[0, 2] + points[1, 2] - 3*((points[0, 1] - points[1, 1])/(points[0, 0] - points[1, 0]))
-        d2 = np.sqrt(d1**2 - points[0, 2]*points[1, 2])
+        d1 = points[0, 2] + points[1, 2] - 3 * ((points[0, 1] - points[1, 1]) / (points[0, 0] - points[1, 0]))
+        d2 = np.sqrt(d1 ** 2 - points[0, 2] * points[1, 2])
         if np.isreal(d2):
-            x_sol = points[1, 0] - (points[1, 0] - points[0, 0])*((points[1, 2] + d2 - d1)/(points[1, 2] - points[0, 2] + 2*d2))
+            x_sol = points[1, 0] - (points[1, 0] - points[0, 0]) * (
+                (points[1, 2] + d2 - d1) / (points[1, 2] - points[0, 2] + 2 * d2)
+            )
             x_sol = np.minimum(np.maximum(x_min_bound, x_sol), x_max_bound)
         else:
-            x_sol = (x_max_bound + x_min_bound)/2
+            x_sol = (x_max_bound + x_min_bound) / 2
 
     # solve linear system
     else:
         # define linear constraints
-        A = np.zeros((0, order+1))
+        A = np.zeros((0, order + 1))
         b = np.zeros((0, 1))
 
         # add linear constraints on function values
         for i in range(no_points):
             if not np.isnan(points[i, 1]):
-                constraint = np.zeros((1, order+1))
+                constraint = np.zeros((1, order + 1))
                 for j in range(order, -1, -1):
-                    constraint[0, order - j] = points[i, 0]**j
+                    constraint[0, order - j] = points[i, 0] ** j
                 A = np.append(A, constraint, 0)
                 b = np.append(b, points[i, 1])
 
         # add linear constraints on gradient values
         for i in range(no_points):
             if not np.isnan(points[i, 2]):
-                constraint = np.zeros((1, order+1))
+                constraint = np.zeros((1, order + 1))
                 for j in range(order):
-                    constraint[0, j] = (order-j)*points[i,0]**(order-j-1)
+                    constraint[0, j] = (order - j) * points[i, 0] ** (order - j - 1)
                 A = np.append(A, constraint, 0)
                 b = np.append(b, points[i, 2])
 
         # check if system is solvable
-        if(A.shape[0] != A.shape[1] or np.linalg.matrix_rank(A) != A.shape[0]):
-            x_sol = (x_min_bound + x_max_bound)/2
+        if A.shape[0] != A.shape[1] or np.linalg.matrix_rank(A) != A.shape[0]:
+            x_sol = (x_min_bound + x_max_bound) / 2
             f_min = np.Inf
         else:
             # solve linear system for interpolating polynomial
@@ -122,7 +129,7 @@ def polyinterp(points, x_min_bound=None, x_max_bound=None, plot=False):
             # compute critical points
             dcoeff = np.zeros(order)
             for i in range(len(coeff) - 1):
-                dcoeff[i] = coeff[i]*(order-i)
+                dcoeff[i] = coeff[i] * (order - i)
 
             crit_pts = np.array([x_min_bound, x_max_bound])
             crit_pts = np.append(crit_pts, points[:, 0])
@@ -133,7 +140,7 @@ def polyinterp(points, x_min_bound=None, x_max_bound=None, plot=False):
 
             # test critical points
             f_min = np.Inf
-            x_sol = (x_min_bound + x_max_bound)/2 # defaults to bisection
+            x_sol = (x_min_bound + x_max_bound) / 2  # defaults to bisection
             for crit_pt in crit_pts:
                 if np.isreal(crit_pt) and crit_pt >= x_min_bound and crit_pt <= x_max_bound:
                     F_cp = np.polyval(coeff, crit_pt)
@@ -141,16 +148,15 @@ def polyinterp(points, x_min_bound=None, x_max_bound=None, plot=False):
                         x_sol = np.real(crit_pt)
                         f_min = np.real(F_cp)
 
-            if(plot):
+            if plot:
                 plt.figure()
-                x = np.arange(x_min_bound, x_max_bound, (x_max_bound - x_min_bound)/10000)
+                x = np.arange(x_min_bound, x_max_bound, (x_max_bound - x_min_bound) / 10000)
                 f = np.polyval(coeff, x)
                 plt.plot(x, f)
-                plt.plot(x_sol, f_min, 'x')
+                plt.plot(x_sol, f_min, "x")
 
     return x_sol
 
-#%% L-BFGS Optimizer
 
 class LBFGS(Optimizer):
     """
@@ -202,37 +208,34 @@ class LBFGS(Optimizer):
 
     """
 
-    def __init__(self, params, lr=1, history_size=10, line_search='Wolfe',
-                 dtype=torch.float, debug=False):
+    def __init__(self, params, lr=1, history_size=10, line_search="Wolfe", dtype=torch.float, debug=False):
 
         # ensure inputs are valid
         if not 0.0 <= lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
         if not 0 <= history_size:
             raise ValueError("Invalid history size: {}".format(history_size))
-        if line_search not in ['Armijo', 'Wolfe', 'None']:
+        if line_search not in ["Armijo", "Wolfe", "None"]:
             raise ValueError("Invalid line search: {}".format(line_search))
 
-        defaults = dict(lr=lr, history_size=history_size, line_search=line_search,
-                        dtype=dtype, debug=debug)
+        defaults = dict(lr=lr, history_size=history_size, line_search=line_search, dtype=dtype, debug=debug)
         super(LBFGS, self).__init__(params, defaults)
 
         if len(self.param_groups) != 1:
-            raise ValueError("L-BFGS doesn't support per-parameter options "
-                             "(parameter groups)")
+            raise ValueError("L-BFGS doesn't support per-parameter options " "(parameter groups)")
 
-        self._params = self.param_groups[0]['params']
+        self._params = self.param_groups[0]["params"]
         self._numel_cache = None
 
-        state = self.state['global_state']
-        state.setdefault('n_iter', 0)
-        state.setdefault('curv_skips', 0)
-        state.setdefault('fail_skips', 0)
-        state.setdefault('H_diag',1)
-        state.setdefault('fail', True)
+        state = self.state["global_state"]
+        state.setdefault("n_iter", 0)
+        state.setdefault("curv_skips", 0)
+        state.setdefault("fail_skips", 0)
+        state.setdefault("H_diag", 1)
+        state.setdefault("fail", True)
 
-        state['old_dirs'] = []
-        state['old_stps'] = []
+        state["old_dirs"] = []
+        state["old_stps"] = []
 
     def _numel(self):
         if self._numel_cache is None:
@@ -256,7 +259,7 @@ class LBFGS(Optimizer):
         for p in self._params:
             numel = p.numel()
             # view as to avoid deprecated pointwise semantics
-            p.data.add_(step_size, update[offset:offset + numel].view_as(p.data))
+            p.data.add_(step_size, update[offset : offset + numel].view_as(p.data))
             offset += numel
         assert offset == self._numel()
 
@@ -286,7 +289,7 @@ class LBFGS(Optimizer):
         """
 
         group = self.param_groups[0]
-        group['line_search'] = line_search
+        group["line_search"] = line_search
 
         return
 
@@ -303,24 +306,24 @@ class LBFGS(Optimizer):
         """
 
         group = self.param_groups[0]
-        history_size = group['history_size']
+        history_size = group["history_size"]
 
-        state = self.state['global_state']
-        old_dirs = state.get('old_dirs')    # change in gradients
-        old_stps = state.get('old_stps')    # change in iterates
-        H_diag = state.get('H_diag')
+        state = self.state["global_state"]
+        old_dirs = state.get("old_dirs")  # change in gradients
+        old_stps = state.get("old_stps")  # change in iterates
+        H_diag = state.get("H_diag")
 
         # compute the product of the inverse Hessian approximation and the gradient
         num_old = len(old_dirs)
 
-        if 'rho' not in state:
-            state['rho'] = [None] * history_size
-            state['alpha'] = [None] * history_size
-        rho = state['rho']
-        alpha = state['alpha']
+        if "rho" not in state:
+            state["rho"] = [None] * history_size
+            state["alpha"] = [None] * history_size
+        rho = state["rho"]
+        alpha = state["alpha"]
 
         for i in range(num_old):
-            rho[i] = 1. / old_stps[i].dot(old_dirs[i])
+            rho[i] = 1.0 / old_stps[i].dot(old_dirs[i])
 
         q = vec
         for i in range(num_old - 1, -1, -1):
@@ -350,27 +353,27 @@ class LBFGS(Optimizer):
         assert len(self.param_groups) == 1
 
         # load parameters
-        if(eps <= 0):
-            raise(ValueError('Invalid eps; must be positive.'))
+        if eps <= 0:
+            raise (ValueError("Invalid eps; must be positive."))
 
         group = self.param_groups[0]
-        history_size = group['history_size']
-        debug = group['debug']
+        history_size = group["history_size"]
+        debug = group["debug"]
 
         # variables cached in state (for tracing)
-        state = self.state['global_state']
-        fail = state.get('fail')
+        state = self.state["global_state"]
+        fail = state.get("fail")
 
         # check if line search failed
         if not fail:
 
-            d = state.get('d')
-            t = state.get('t')
-            old_dirs = state.get('old_dirs')
-            old_stps = state.get('old_stps')
-            H_diag = state.get('H_diag')
-            prev_flat_grad = state.get('prev_flat_grad')
-            Bs = state.get('Bs')
+            d = state.get("d")
+            t = state.get("t")
+            old_dirs = state.get("old_dirs")
+            old_stps = state.get("old_stps")
+            H_diag = state.get("H_diag")
+            prev_flat_grad = state.get("prev_flat_grad")
+            Bs = state.get("Bs")
 
             # compute y's
             y = flat_grad.sub(prev_flat_grad)
@@ -379,14 +382,14 @@ class LBFGS(Optimizer):
             ys = y.dot(s)  # y*s
 
             # update L-BFGS matrix
-            if ys > eps*sBs or damping == True:
+            if ys > eps * sBs or damping == True:
 
                 # perform Powell damping
-                if damping == True and ys < eps*sBs:
+                if damping == True and ys < eps * sBs:
                     if debug:
-                        print('Applying Powell damping...')
-                    theta = ((1-eps)*sBs)/(sBs - ys)
-                    y = theta*y + (1-theta)*Bs
+                        print("Applying Powell damping...")
+                    theta = ((1 - eps) * sBs) / (sBs - ys)
+                    y = theta * y + (1 - theta) * Bs
 
                 # updating memory
                 if len(old_dirs) == history_size:
@@ -401,21 +404,21 @@ class LBFGS(Optimizer):
                 # update scale of initial Hessian approximation
                 H_diag = ys / y.dot(y)  # (y*y)
 
-                state['old_dirs'] = old_dirs
-                state['old_stps'] = old_stps
-                state['H_diag'] = H_diag
+                state["old_dirs"] = old_dirs
+                state["old_stps"] = old_stps
+                state["H_diag"] = H_diag
 
             else:
                 # save skip
-                state['curv_skips'] += 1
+                state["curv_skips"] += 1
                 if debug:
-                    print('Curvature pair skipped due to failed criterion')
+                    print("Curvature pair skipped due to failed criterion")
 
         else:
             # save skip
-            state['fail_skips'] += 1
+            state["fail_skips"] += 1
             if debug:
-                print('Line search failed; curvature pair update skipped')
+                print("Line search failed; curvature pair update skipped")
 
         return
 
@@ -497,20 +500,20 @@ class LBFGS(Optimizer):
 
         # load parameter options
         group = self.param_groups[0]
-        lr = group['lr']
-        line_search = group['line_search']
-        dtype = group['dtype']
-        debug = group['debug']
+        lr = group["lr"]
+        line_search = group["line_search"]
+        dtype = group["dtype"]
+        debug = group["debug"]
 
         # variables cached in state (for tracing)
-        state = self.state['global_state']
-        d = state.get('d')
-        t = state.get('t')
-        prev_flat_grad = state.get('prev_flat_grad')
-        Bs = state.get('Bs')
+        state = self.state["global_state"]
+        d = state.get("d")
+        t = state.get("t")
+        prev_flat_grad = state.get("prev_flat_grad")
+        Bs = state.get("Bs")
 
         # keep track of nb of iterations
-        state['n_iter'] += 1
+        state["n_iter"] += 1
 
         # set search direction
         d = p_k
@@ -531,86 +534,88 @@ class LBFGS(Optimizer):
             g_Sk = g_Ok.clone()
 
         # perform Armijo backtracking line search
-        if(line_search == 'Armijo'):
+        if line_search == "Armijo":
 
             # load options
-            if(options):
-                if('closure' not in options.keys()):
-                    raise(ValueError('closure option not specified.'))
+            if options:
+                if "closure" not in options.keys():
+                    raise (ValueError("closure option not specified."))
                 else:
-                    closure = options['closure']
+                    closure = options["closure"]
 
-                if('gtd' not in options.keys()):
+                if "gtd" not in options.keys():
                     gtd = g_Ok.dot(d)
                 else:
-                    gtd = options['gtd']
+                    gtd = options["gtd"]
 
-                if('current_loss' not in options.keys()):
+                if "current_loss" not in options.keys():
                     F_k = closure()
                     closure_eval += 1
                 else:
-                    F_k = options['current_loss']
+                    F_k = options["current_loss"]
 
-                if('eta' not in options.keys()):
+                if "eta" not in options.keys():
                     eta = 2
-                elif(options['eta'] <= 0):
-                    raise(ValueError('Invalid eta; must be positive.'))
+                elif options["eta"] <= 0:
+                    raise (ValueError("Invalid eta; must be positive."))
                 else:
-                    eta = options['eta']
+                    eta = options["eta"]
 
-                if('c1' not in options.keys()):
+                if "c1" not in options.keys():
                     c1 = 1e-4
-                elif(options['c1'] >= 1 or options['c1'] <= 0):
-                    raise(ValueError('Invalid c1; must be strictly between 0 and 1.'))
+                elif options["c1"] >= 1 or options["c1"] <= 0:
+                    raise (ValueError("Invalid c1; must be strictly between 0 and 1."))
                 else:
-                    c1 = options['c1']
+                    c1 = options["c1"]
 
-                if('max_ls' not in options.keys()):
+                if "max_ls" not in options.keys():
                     max_ls = 10
-                elif(options['max_ls'] <= 0):
-                    raise(ValueError('Invalid max_ls; must be positive.'))
+                elif options["max_ls"] <= 0:
+                    raise (ValueError("Invalid max_ls; must be positive."))
                 else:
-                    max_ls = options['max_ls']
+                    max_ls = options["max_ls"]
 
-                if('interpolate' not in options.keys()):
+                if "interpolate" not in options.keys():
                     interpolate = True
                 else:
-                    interpolate = options['interpolate']
+                    interpolate = options["interpolate"]
 
-                if('inplace' not in options.keys()):
+                if "inplace" not in options.keys():
                     inplace = True
                 else:
-                    inplace = options['inplace']
+                    inplace = options["inplace"]
 
-                if('ls_debug' not in options.keys()):
+                if "ls_debug" not in options.keys():
                     ls_debug = False
                 else:
-                    ls_debug = options['ls_debug']
+                    ls_debug = options["ls_debug"]
 
             else:
-                raise(ValueError('Options are not specified; need closure evaluating function.'))
+                raise (ValueError("Options are not specified; need closure evaluating function."))
 
             # initialize values
-            if(interpolate):
-                if(torch.cuda.is_available()):
+            if interpolate:
+                if torch.cuda.is_available():
                     F_prev = torch.tensor(np.nan, dtype=dtype).cuda()
                 else:
                     F_prev = torch.tensor(np.nan, dtype=dtype)
 
             ls_step = 0
-            t_prev = 0 # old steplength
-            fail = False # failure flag
+            t_prev = 0  # old steplength
+            fail = False  # failure flag
 
             # begin print for debug mode
             if ls_debug:
-                print('==================================== Begin Armijo line search ===================================')
-                print('F(x): %.8e  g*d: %.8e' %(F_k, gtd))
+                print(
+                    "==================================== Begin Armijo line search ==================================="
+                )
+                print("F(x): %.8e  g*d: %.8e" % (F_k, gtd))
 
             # check if search direction is descent direction
             if gtd >= 0:
                 desc_dir = False
                 if debug:
-                    print('Not a descent direction!')
+                    print("Not a descent direction!")
             else:
                 desc_dir = True
 
@@ -624,15 +629,17 @@ class LBFGS(Optimizer):
             closure_eval += 1
 
             # print info if debugging
-            if(ls_debug):
-                print('LS Step: %d  t: %.8e  F(x+td): %.8e  F-c1*t*g*d: %.8e  F(x): %.8e'
-                      %(ls_step, t, F_new, F_k + c1*t*gtd, F_k))
+            if ls_debug:
+                print(
+                    "LS Step: %d  t: %.8e  F(x+td): %.8e  F-c1*t*g*d: %.8e  F(x): %.8e"
+                    % (ls_step, t, F_new, F_k + c1 * t * gtd, F_k)
+                )
 
             # check Armijo condition
-            while F_new > F_k + c1*t*gtd or not is_legal(F_new):
+            while F_new > F_k + c1 * t * gtd or not is_legal(F_new):
 
                 # check if maximum number of iterations reached
-                if(ls_step >= max_ls):
+                if ls_step >= max_ls:
                     if inplace:
                         self._add_update(-t, d)
                     else:
@@ -651,26 +658,33 @@ class LBFGS(Optimizer):
                     # compute new steplength
 
                     # if first step or not interpolating, then multiply by factor
-                    if(ls_step == 0 or not interpolate or not is_legal(F_new)):
-                        t = t/eta
+                    if ls_step == 0 or not interpolate or not is_legal(F_new):
+                        t = t / eta
 
                     # if second step, use function value at new point along with
                     # gradient and function at current iterate
-                    elif(ls_step == 1 or not is_legal(F_prev)):
+                    elif ls_step == 1 or not is_legal(F_prev):
                         t = polyinterp(np.array([[0, F_k.item(), gtd.item()], [t_new, F_new.item(), np.nan]]))
 
                     # otherwise, use function values at new point, previous point,
                     # and gradient and function at current iterate
                     else:
-                        t = polyinterp(np.array([[0, F_k.item(), gtd.item()], [t_new, F_new.item(), np.nan],
-                                                [t_prev, F_prev.item(), np.nan]]))
+                        t = polyinterp(
+                            np.array(
+                                [
+                                    [0, F_k.item(), gtd.item()],
+                                    [t_new, F_new.item(), np.nan],
+                                    [t_prev, F_prev.item(), np.nan],
+                                ]
+                            )
+                        )
 
                     # if values are too extreme, adjust t
-                    if(interpolate):
-                        if(t < 1e-3*t_new):
-                            t = 1e-3*t_new
-                        elif(t > 0.6*t_new):
-                            t = 0.6*t_new
+                    if interpolate:
+                        if t < 1e-3 * t_new:
+                            t = 1e-3 * t_new
+                        elif t > 0.6 * t_new:
+                            t = 0.6 * t_new
 
                         # store old point
                         F_prev = F_new
@@ -678,19 +692,21 @@ class LBFGS(Optimizer):
 
                     # update iterate and reevaluate
                     if inplace:
-                        self._add_update(t-t_new, d)
+                        self._add_update(t - t_new, d)
                     else:
                         self._load_params(current_params)
                         self._add_update(t, d)
 
                     F_new = closure()
                     closure_eval += 1
-                    ls_step += 1 # iterate
+                    ls_step += 1  # iterate
 
                     # print info if debugging
-                    if(ls_debug):
-                        print('LS Step: %d  t: %.8e  F(x+td):   %.8e  F-c1*t*g*d: %.8e  F(x): %.8e'
-                              %(ls_step, t, F_new, F_k + c1*t*gtd, F_k))
+                    if ls_debug:
+                        print(
+                            "LS Step: %d  t: %.8e  F(x+td):   %.8e  F-c1*t*g*d: %.8e  F(x): %.8e"
+                            % (ls_step, t, F_new, F_k + c1 * t * gtd, F_k)
+                        )
 
             # store Bs
             if Bs is None:
@@ -700,102 +716,104 @@ class LBFGS(Optimizer):
 
             # print final steplength
             if ls_debug:
-                print('Final Steplength:', t)
-                print('===================================== End Armijo line search ====================================')
+                print("Final Steplength:", t)
+                print(
+                    "===================================== End Armijo line search ===================================="
+                )
 
-            state['d'] = d
-            state['prev_flat_grad'] = prev_flat_grad
-            state['t'] = t
-            state['Bs'] = Bs
-            state['fail'] = fail
+            state["d"] = d
+            state["prev_flat_grad"] = prev_flat_grad
+            state["t"] = t
+            state["Bs"] = Bs
+            state["fail"] = fail
 
             return F_new, t, ls_step, closure_eval, desc_dir, fail
 
         # perform weak Wolfe line search
-        elif(line_search == 'Wolfe'):
+        elif line_search == "Wolfe":
 
             # load options
-            if(options):
-                if('closure' not in options.keys()):
-                    raise(ValueError('closure option not specified.'))
+            if options:
+                if "closure" not in options.keys():
+                    raise (ValueError("closure option not specified."))
                 else:
-                    closure = options['closure']
+                    closure = options["closure"]
 
-                if('current_loss' not in options.keys()):
+                if "current_loss" not in options.keys():
                     F_k = closure()
                     closure_eval += 1
                 else:
-                    F_k = options['current_loss']
+                    F_k = options["current_loss"]
 
-                if('gtd' not in options.keys()):
+                if "gtd" not in options.keys():
                     gtd = g_Ok.dot(d)
                 else:
-                    gtd = options['gtd']
+                    gtd = options["gtd"]
 
-                if('eta' not in options.keys()):
+                if "eta" not in options.keys():
                     eta = 2
-                elif(options['eta'] <= 1):
-                    raise(ValueError('Invalid eta; must be greater than 1.'))
+                elif options["eta"] <= 1:
+                    raise (ValueError("Invalid eta; must be greater than 1."))
                 else:
-                    eta = options['eta']
+                    eta = options["eta"]
 
-                if('c1' not in options.keys()):
+                if "c1" not in options.keys():
                     c1 = 1e-4
-                elif(options['c1'] >= 1 or options['c1'] <= 0):
-                    raise(ValueError('Invalid c1; must be strictly between 0 and 1.'))
+                elif options["c1"] >= 1 or options["c1"] <= 0:
+                    raise (ValueError("Invalid c1; must be strictly between 0 and 1."))
                 else:
-                    c1 = options['c1']
+                    c1 = options["c1"]
 
-                if('c2' not in options.keys()):
+                if "c2" not in options.keys():
                     c2 = 0.9
-                elif(options['c2'] >= 1 or options['c2'] <= 0):
-                    raise(ValueError('Invalid c2; must be strictly between 0 and 1.'))
-                elif(options['c2'] <= c1):
-                    raise(ValueError('Invalid c2; must be strictly larger than c1.'))
+                elif options["c2"] >= 1 or options["c2"] <= 0:
+                    raise (ValueError("Invalid c2; must be strictly between 0 and 1."))
+                elif options["c2"] <= c1:
+                    raise (ValueError("Invalid c2; must be strictly larger than c1."))
                 else:
-                    c2 = options['c2']
+                    c2 = options["c2"]
 
-                if('max_ls' not in options.keys()):
+                if "max_ls" not in options.keys():
                     max_ls = 10
-                elif(options['max_ls'] <= 0):
-                    raise(ValueError('Invalid max_ls; must be positive.'))
+                elif options["max_ls"] <= 0:
+                    raise (ValueError("Invalid max_ls; must be positive."))
                 else:
-                    max_ls = options['max_ls']
+                    max_ls = options["max_ls"]
 
-                if('interpolate' not in options.keys()):
+                if "interpolate" not in options.keys():
                     interpolate = True
                 else:
-                    interpolate = options['interpolate']
+                    interpolate = options["interpolate"]
 
-                if('inplace' not in options.keys()):
+                if "inplace" not in options.keys():
                     inplace = True
                 else:
-                    inplace = options['inplace']
+                    inplace = options["inplace"]
 
-                if('ls_debug' not in options.keys()):
+                if "ls_debug" not in options.keys():
                     ls_debug = False
                 else:
-                    ls_debug = options['ls_debug']
+                    ls_debug = options["ls_debug"]
 
             else:
-                raise(ValueError('Options are not specified; need closure evaluating function.'))
+                raise (ValueError("Options are not specified; need closure evaluating function."))
 
             # initialize counters
             ls_step = 0
-            grad_eval = 0 # tracks gradient evaluations
-            t_prev = 0 # old steplength
+            grad_eval = 0  # tracks gradient evaluations
+            t_prev = 0  # old steplength
 
             # initialize bracketing variables and flag
             alpha = 0
-            beta = float('Inf')
+            beta = float("Inf")
             fail = False
 
             # initialize values for line search
-            if(interpolate):
+            if interpolate:
                 F_a = F_k
                 g_a = gtd
 
-                if(torch.cuda.is_available()):
+                if torch.cuda.is_available():
                     F_b = torch.tensor(np.nan, dtype=dtype).cuda()
                     g_b = torch.tensor(np.nan, dtype=dtype).cuda()
                 else:
@@ -804,14 +822,16 @@ class LBFGS(Optimizer):
 
             # begin print for debug mode
             if ls_debug:
-                print('==================================== Begin Wolfe line search ====================================')
-                print('F(x): %.8e  g*d: %.8e' %(F_k, gtd))
+                print(
+                    "==================================== Begin Wolfe line search ===================================="
+                )
+                print("F(x): %.8e  g*d: %.8e" % (F_k, gtd))
 
             # check if search direction is descent direction
             if gtd >= 0:
                 desc_dir = False
                 if debug:
-                    print('Not a descent direction!')
+                    print("Not a descent direction!")
             else:
                 desc_dir = True
 
@@ -828,7 +848,7 @@ class LBFGS(Optimizer):
             while True:
 
                 # check if maximum number of line search steps have been reached
-                if(ls_step >= max_ls):
+                if ls_step >= max_ls:
                     if inplace:
                         self._add_update(-t, d)
                     else:
@@ -844,23 +864,21 @@ class LBFGS(Optimizer):
                     break
 
                 # print info if debugging
-                if(ls_debug):
-                    print('LS Step: %d  t: %.8e  alpha: %.8e  beta: %.8e'
-                          %(ls_step, t, alpha, beta))
-                    print('Armijo:  F(x+td): %.8e  F-c1*t*g*d: %.8e  F(x): %.8e'
-                          %(F_new, F_k + c1*t*gtd, F_k))
+                if ls_debug:
+                    print("LS Step: %d  t: %.8e  alpha: %.8e  beta: %.8e" % (ls_step, t, alpha, beta))
+                    print("Armijo:  F(x+td): %.8e  F-c1*t*g*d: %.8e  F(x): %.8e" % (F_new, F_k + c1 * t * gtd, F_k))
 
                 # check Armijo condition
-                if(F_new > F_k + c1*t*gtd):
+                if F_new > F_k + c1 * t * gtd:
 
                     # set upper bound
                     beta = t
                     t_prev = t
 
                     # update interpolation quantities
-                    if(interpolate):
+                    if interpolate:
                         F_b = F_new
-                        if(torch.cuda.is_available()):
+                        if torch.cuda.is_available():
                             g_b = torch.tensor(np.nan, dtype=dtype).cuda()
                         else:
                             g_b = torch.tensor(np.nan, dtype=dtype)
@@ -874,19 +892,18 @@ class LBFGS(Optimizer):
                     gtd_new = g_new.dot(d)
 
                     # print info if debugging
-                    if(ls_debug):
-                        print('Wolfe: g(x+td)*d: %.8e  c2*g*d: %.8e  gtd: %.8e'
-                              %(gtd_new, c2*gtd, gtd))
+                    if ls_debug:
+                        print("Wolfe: g(x+td)*d: %.8e  c2*g*d: %.8e  gtd: %.8e" % (gtd_new, c2 * gtd, gtd))
 
                     # check curvature condition
-                    if(gtd_new < c2*gtd):
+                    if gtd_new < c2 * gtd:
 
                         # set lower bound
                         alpha = t
                         t_prev = t
 
                         # update interpolation quantities
-                        if(interpolate):
+                        if interpolate:
                             F_a = F_new
                             g_a = gtd_new
 
@@ -896,31 +913,31 @@ class LBFGS(Optimizer):
                 # compute new steplength
 
                 # if first step or not interpolating, then bisect or multiply by factor
-                if(not interpolate or not is_legal(F_b)):
-                    if(beta == float('Inf')):
-                        t = eta*t
+                if not interpolate or not is_legal(F_b):
+                    if beta == float("Inf"):
+                        t = eta * t
                     else:
-                        t = (alpha + beta)/2.0
+                        t = (alpha + beta) / 2.0
 
                 # otherwise interpolate between a and b
                 else:
-                    t = polyinterp(np.array([[alpha, F_a.item(), g_a.item()],[beta, F_b.item(), g_b.item()]]))
+                    t = polyinterp(np.array([[alpha, F_a.item(), g_a.item()], [beta, F_b.item(), g_b.item()]]))
 
                     # if values are too extreme, adjust t
-                    if(beta == float('Inf')):
-                        if(t > 2*eta*t_prev):
-                            t = 2*eta*t_prev
-                        elif(t < eta*t_prev):
-                            t = eta*t_prev
+                    if beta == float("Inf"):
+                        if t > 2 * eta * t_prev:
+                            t = 2 * eta * t_prev
+                        elif t < eta * t_prev:
+                            t = eta * t_prev
                     else:
-                        if(t < alpha + 0.2*(beta - alpha)):
-                            t = alpha + 0.2*(beta - alpha)
-                        elif(t > (beta - alpha)/2.0):
-                            t = (beta - alpha)/2.0
+                        if t < alpha + 0.2 * (beta - alpha):
+                            t = alpha + 0.2 * (beta - alpha)
+                        elif t > (beta - alpha) / 2.0:
+                            t = (beta - alpha) / 2.0
 
                     # if we obtain nonsensical value from interpolation
-                    if(t <= 0):
-                        t = (beta - alpha)/2.0
+                    if t <= 0:
+                        t = (beta - alpha) / 2.0
 
                 # update parameters
                 if inplace:
@@ -942,14 +959,16 @@ class LBFGS(Optimizer):
 
             # print final steplength
             if ls_debug:
-                print('Final Steplength:', t)
-                print('===================================== End Wolfe line search =====================================')
+                print("Final Steplength:", t)
+                print(
+                    "===================================== End Wolfe line search ====================================="
+                )
 
-            state['d'] = d
-            state['prev_flat_grad'] = prev_flat_grad
-            state['t'] = t
-            state['Bs'] = Bs
-            state['fail'] = fail
+            state["d"] = d
+            state["prev_flat_grad"] = prev_flat_grad
+            state["t"] = t
+            state["Bs"] = Bs
+            state["fail"] = fail
 
             return F_new, g_new, t, ls_step, closure_eval, grad_eval, desc_dir, fail
 
@@ -964,18 +983,20 @@ class LBFGS(Optimizer):
             else:
                 Bs.copy_(g_Sk.mul(-t))
 
-            state['d'] = d
-            state['prev_flat_grad'] = prev_flat_grad
-            state['t'] = t
-            state['Bs'] = Bs
-            state['fail'] = False
+            state["d"] = d
+            state["prev_flat_grad"] = prev_flat_grad
+            state["t"] = t
+            state["Bs"] = Bs
+            state["fail"] = False
 
             return t
 
     def step(self, p_k, g_Ok, g_Sk=None, options={}):
         return self._step(p_k, g_Ok, g_Sk, options)
 
+
 #%% Full-Batch (Deterministic) L-BFGS Optimizer (Wrapper)
+
 
 class FullBatchLBFGS(LBFGS):
     """
@@ -1004,10 +1025,8 @@ class FullBatchLBFGS(LBFGS):
 
     """
 
-    def __init__(self, params, lr=1, history_size=10, line_search='Wolfe',
-                 dtype=torch.float, debug=False):
-        super(FullBatchLBFGS, self).__init__(params, lr, history_size, line_search,
-             dtype, debug)
+    def __init__(self, params, lr=1, history_size=10, line_search="Wolfe", dtype=torch.float, debug=False):
+        super(FullBatchLBFGS, self).__init__(params, lr, history_size, line_search, dtype, debug)
 
     def step(self, options={}):
         """
@@ -1082,22 +1101,22 @@ class FullBatchLBFGS(LBFGS):
         """
 
         # load options for damping and eps
-        if('damping' not in options.keys()):
+        if "damping" not in options.keys():
             damping = False
         else:
-            damping = options['damping']
+            damping = options["damping"]
 
-        if('eps' not in options.keys()):
+        if "eps" not in options.keys():
             eps = 1e-2
         else:
-            eps = options['eps']
+            eps = options["eps"]
 
         # gather gradient
         grad = self._gather_flat_grad()
 
         # update curvature if after 1st iteration
-        state = self.state['global_state']
-        if(state['n_iter'] > 0):
+        state = self.state["global_state"]
+        if state["n_iter"] > 0:
             self.curvature_update(grad, eps, damping)
 
         # compute search direction

--- a/gpytorch/beta_features.py
+++ b/gpytorch/beta_features.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import warnings
+
 from .settings import _feature_flag, _value_context
 
 
@@ -12,7 +13,7 @@ class _moved_beta_feature(object):
     def __call__(self, *args, **kwargs):
         warnings.warn(
             "`{}` has moved to `gpytorch.settings.{}`.".format(self.orig_name, self.new_cls.__name__),
-            DeprecationWarning
+            DeprecationWarning,
         )
         return self.new_cls(*args, **kwargs)
 

--- a/gpytorch/constraints/__init__.py
+++ b/gpytorch/constraints/__init__.py
@@ -1,8 +1,3 @@
 from .constraints import GreaterThan, Interval, LessThan, Positive
 
-__all__ = [
-    "GreaterThan",
-    "Interval",
-    "LessThan",
-    "Positive",
-]
+__all__ = ["GreaterThan", "Interval", "LessThan", "Positive"]

--- a/gpytorch/distributions/delta.py
+++ b/gpytorch/distributions/delta.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
 import numbers
+
 import torch
-from .distribution import Distribution
-from .multivariate_normal import MultivariateNormal
 from torch.distributions.kl import register_kl
 
+from .distribution import Distribution
+from .multivariate_normal import MultivariateNormal
 
 try:
     from pyro.distributions import Delta
@@ -26,19 +27,19 @@ except ImportError:
             under differentiable transformation.
         :param int event_dim: Optional event dimension, defaults to zero.
         """
+
         has_rsample = True
 
         def __init__(self, v, log_density=0.0, event_dim=0, validate_args=None):
             if event_dim > v.dim():
-                raise ValueError('Expected event_dim <= v.dim(), actual {} vs {}'.format(event_dim, v.dim()))
+                raise ValueError("Expected event_dim <= v.dim(), actual {} vs {}".format(event_dim, v.dim()))
             batch_dim = v.dim() - event_dim
             batch_shape = v.shape[:batch_dim]
             event_shape = v.shape[batch_dim:]
             if isinstance(log_density, numbers.Number):
                 log_density = torch.full(batch_shape, log_density, dtype=v.dtype, device=v.device)
             elif validate_args and log_density.shape != batch_shape:
-                raise ValueError('Expected log_density.shape = {}, actual {}'.format(
-                    log_density.shape, batch_shape))
+                raise ValueError("Expected log_density.shape = {}, actual {}".format(log_density.shape, batch_shape))
             self.v = v
             self.log_density = log_density
             super().__init__(batch_shape, event_shape, validate_args=validate_args)

--- a/gpytorch/distributions/distribution.py
+++ b/gpytorch/distributions/distribution.py
@@ -8,6 +8,7 @@ class _DistributionBase(TDistribution):
     The base class of Distributions. (Same as torch.distribution.Distribution
     or pyro.distribution.Distribution).
     """
+
     @property
     def islazy(self):
         return self._islazy

--- a/gpytorch/distributions/multitask_multivariate_normal.py
+++ b/gpytorch/distributions/multitask_multivariate_normal.py
@@ -22,6 +22,7 @@ class MultitaskMultivariateNormal(MultivariateNormal):
         inter-task covariances for each observation. If False, it is interpreted as block-diagonal
         w.r.t. inter-observation covariance for each task.
     """
+
     def __init__(self, mean, covariance_matrix, validate_args=False, interleaved=True):
         if not torch.is_tensor(mean) and not isinstance(mean, LazyTensor):
             raise RuntimeError("The mean of a MultitaskMultivariateNormal must be a Tensor or LazyTensor")
@@ -127,9 +128,7 @@ class MultitaskMultivariateNormal(MultivariateNormal):
 
         # https://github.com/cornellius-gp/gpytorch/issues/468
         covar_blocks_lazy = CatLazyTensor(
-            *[mvn.lazy_covariance_matrix.unsqueeze(0) for mvn in mvns],
-            dim=0,
-            output_device=mean.device
+            *[mvn.lazy_covariance_matrix.unsqueeze(0) for mvn in mvns], dim=0, output_device=mean.device
         )
         covar_lazy = BlockDiagLazyTensor(covar_blocks_lazy, block_dim=0)
         return cls(mean=mean, covariance_matrix=covar_lazy, interleaved=False)

--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -8,9 +8,9 @@ from torch.distributions.kl import register_kl
 from torch.distributions.utils import _standard_normal, lazy_property
 
 from .. import settings
-from ..lazy import LazyTensor, lazify, delazify
-from .distribution import Distribution
+from ..lazy import LazyTensor, delazify, lazify
 from ..utils.broadcasting import _mul_broadcast_shape
+from .distribution import Distribution
 
 
 class MultivariateNormal(TMultivariateNormal, Distribution):
@@ -120,7 +120,8 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
                 padded_batch_shape = (*(1 for _ in range(diff.dim() + 1 - covar.dim())), *covar.batch_shape)
                 covar = covar.repeat(
                     *(diff_size // covar_size for diff_size, covar_size in zip(diff.shape[:-1], padded_batch_shape)),
-                    1, 1
+                    1,
+                    1,
                 )
 
         # Get log determininat and first part of quadratic form

--- a/gpytorch/functions/__init__.py
+++ b/gpytorch/functions/__init__.py
@@ -2,11 +2,11 @@
 
 import torch
 
+from ..utils.deprecation import _deprecated_function_for
 from ._dsmm import DSMM
 from ._log_normal_cdf import LogNormalCDF
-from ..utils.deprecation import _deprecated_function_for
-from .rbf_covariance import RBFCovariance
 from .matern_covariance import MaternCovariance
+from .rbf_covariance import RBFCovariance
 
 
 def add_diag(input, diag):
@@ -23,6 +23,7 @@ def add_diag(input, diag):
         :obj:`Tensor` (bxnxn or nxn)
     """
     from ..lazy import lazify
+
     return lazify(input).add_diag(diag)
 
 
@@ -119,6 +120,7 @@ def inv_matmul(mat, right_tensor, left_tensor=None):
         - :obj:`torch.tensor` - :math:`A^{-1}R` or :math:`LA^{-1}R`.
     """
     from ..lazy import lazify
+
     return lazify(mat).inv_matmul(right_tensor, left_tensor)
 
 
@@ -151,6 +153,7 @@ def inv_quad_logdet(mat, inv_quad_rhs=None, logdet=False, reduce_inv_quad=True):
         - scalar - log determinant
     """
     from ..lazy import lazify
+
     return lazify(mat).inv_quad_logdet(inv_quad_rhs, logdet, reduce_inv_quad=reduce_inv_quad)
 
 
@@ -172,6 +175,7 @@ def root_decomposition(mat):
     low-rank version of a matrix
     """
     from ..lazy import lazify
+
     return lazify(mat).root_decomposition()
 
 
@@ -182,6 +186,7 @@ def root_inv_decomposition(mat, initial_vectors=None, test_vectors=None):
     low-rank version of a matrix
     """
     from ..lazy import lazify
+
     return lazify(mat).root_inv_decomposition(initial_vectors, test_vectors)
 
 
@@ -204,6 +209,5 @@ __all__ = [
     "root_decomposition",
     "root_inv_decomposition",
     # Deprecated
-    "log_det"
-    "inv_quad_log_det"
+    "log_det" "inv_quad_log_det",
 ]

--- a/gpytorch/functions/_inv_matmul.py
+++ b/gpytorch/functions/_inv_matmul.py
@@ -2,6 +2,7 @@
 
 import torch
 from torch.autograd import Function
+
 from .. import settings
 
 
@@ -40,7 +41,7 @@ class InvMatmul(Function):
         if ctx.has_left:
             rhs = torch.cat([left_tensor.transpose(-1, -2), right_tensor], -1)
             solves = _solve(lazy_tsr, rhs)
-            res = solves[..., left_tensor.size(-2):]
+            res = solves[..., left_tensor.size(-2) :]
             res = left_tensor @ res
         else:
             solves = _solve(lazy_tsr, right_tensor)
@@ -64,8 +65,8 @@ class InvMatmul(Function):
         # Extract items that were saved
         if ctx.has_left:
             solves, left_tensor, right_tensor, *matrix_args = ctx.saved_tensors
-            left_solves = solves[..., :left_tensor.size(-2)]
-            right_solves = solves[..., left_tensor.size(-2):]
+            left_solves = solves[..., : left_tensor.size(-2)]
+            right_solves = solves[..., left_tensor.size(-2) :]
         else:
             right_solves, right_tensor, *matrix_args = ctx.saved_tensors
 
@@ -94,8 +95,7 @@ class InvMatmul(Function):
                     # To ensure that this term is symmetric, we concatenate the left and right solves together,
                     # and divide the result by 1/2
                     arg_grads = lazy_tsr._quad_form_derivative(
-                        torch.cat([left_solves, right_solves], -1),
-                        torch.cat([right_solves, left_solves], -1).mul(-0.5)
+                        torch.cat([left_solves, right_solves], -1), torch.cat([right_solves, left_solves], -1).mul(-0.5)
                     )
                 if ctx.needs_input_grad[2]:
                     right_grad = left_solves
@@ -112,8 +112,7 @@ class InvMatmul(Function):
                 if any(ctx.needs_input_grad[4:]):
                     # We do this concatenation to ensure that the gradient of lazy_tsr is symmetric
                     arg_grads = lazy_tsr._quad_form_derivative(
-                        torch.cat([left_solves, right_solves], -1),
-                        torch.cat([right_solves, left_solves], -1).mul(-0.5)
+                        torch.cat([left_solves, right_solves], -1), torch.cat([right_solves, left_solves], -1).mul(-0.5)
                     )
                 if ctx.needs_input_grad[2]:
                     right_grad = left_solves

--- a/gpytorch/functions/_inv_quad.py
+++ b/gpytorch/functions/_inv_quad.py
@@ -2,6 +2,7 @@
 
 import torch
 from torch.autograd import Function
+
 from .. import settings
 
 
@@ -23,6 +24,7 @@ class InvQuad(Function):
     Given a PSD matrix A (or a batch of PSD matrices A), this function computes b A^{-1} b
     where b is a vector or batch of vectors
     """
+
     @staticmethod
     def forward(ctx, representation_tree, *args):
         """

--- a/gpytorch/functions/_log_normal_cdf.py
+++ b/gpytorch/functions/_log_normal_cdf.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import math
-from torch.autograd import Function
+
 import torch
+from torch.autograd import Function
 from torch.distributions import Normal
 
 
@@ -91,7 +92,7 @@ class LogNormalCDF(Function):
             ctx.denominator = denominator
             ctx.numerator = numerator
 
-        log_phi_z.masked_scatter_(z_is_ordinary, torch.log(Normal(0., 1.).cdf(z.masked_select(z_is_ordinary))))
+        log_phi_z.masked_scatter_(z_is_ordinary, torch.log(Normal(0.0, 1.0).cdf(z.masked_select(z_is_ordinary))))
 
         ctx.save_for_backward(z, log_phi_z)
         return log_phi_z

--- a/gpytorch/functions/_root_decomposition.py
+++ b/gpytorch/functions/_root_decomposition.py
@@ -2,8 +2,9 @@
 
 import torch
 from torch.autograd import Function
-from ..utils import lanczos
+
 from .. import settings
+from ..utils import lanczos
 
 
 class RootDecomposition(Function):
@@ -19,7 +20,7 @@ class RootDecomposition(Function):
         root,
         inverse,
         initial_vectors,
-        *matrix_args
+        *matrix_args,
     ):
         """
         *matrix_args - The arguments representing the symmetric matrix A (or batch of PSD matrices A)
@@ -105,6 +106,7 @@ class RootDecomposition(Function):
     def backward(ctx, root_grad_output, inverse_grad_output):
         # Taken from http://homepages.inf.ed.ac.uk/imurray2/pub/16choldiff/choldiff.pdf
         if any(ctx.needs_input_grad):
+
             def is_empty(tensor):
                 return tensor.numel() == 0 or (tensor.numel() == 1 and tensor[0] == 0)
 

--- a/gpytorch/functions/matern_covariance.py
+++ b/gpytorch/functions/matern_covariance.py
@@ -1,13 +1,13 @@
-import torch
 import math
+
+import torch
 
 
 class MaternCovariance(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x1, x2, lengthscale, nu, dist_func):
         if any(ctx.needs_input_grad[:2]):
-            raise RuntimeError("MaternCovariance cannot compute gradients with "
-                               "respect to x1 and x2")
+            raise RuntimeError("MaternCovariance cannot compute gradients with " "respect to x1 and x2")
         if lengthscale.size(-1) > 1:
             raise ValueError("MaternCovariance cannot handle multiple lengthscales")
         # Subtract mean for numerical stability. Won't affect computations

--- a/gpytorch/functions/rbf_covariance.py
+++ b/gpytorch/functions/rbf_covariance.py
@@ -5,8 +5,7 @@ class RBFCovariance(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x1, x2, lengthscale, sq_dist_func):
         if any(ctx.needs_input_grad[:2]):
-            raise RuntimeError("RBFCovariance cannot compute gradients with "
-                               "respect to x1 and x2")
+            raise RuntimeError("RBFCovariance cannot compute gradients with " "respect to x1 and x2")
         if lengthscale.size(-1) > 1:
             raise ValueError("RBFCovariance cannot handle multiple lengthscales")
         needs_grad = any(ctx.needs_input_grad)
@@ -15,7 +14,7 @@ class RBFCovariance(torch.autograd.Function):
         unitless_sq_dist = sq_dist_func(x1_, x2_)
         # clone because inplace operations will mess with what's saved for backward
         unitless_sq_dist_ = unitless_sq_dist.clone() if needs_grad else unitless_sq_dist
-        covar_mat = unitless_sq_dist_.div_(-2.).exp_()
+        covar_mat = unitless_sq_dist_.div_(-2.0).exp_()
         if needs_grad:
             d_output_d_input = unitless_sq_dist.mul_(covar_mat).div_(lengthscale)
             ctx.save_for_backward(d_output_d_input)

--- a/gpytorch/kernels/inducing_point_kernel.py
+++ b/gpytorch/kernels/inducing_point_kernel.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 
-import math
-import torch
 import copy
-from .kernel import Kernel
-from ..lazy import delazify, DiagLazyTensor, MatmulLazyTensor, RootLazyTensor, PsdSumLazyTensor
+import math
+
+import torch
+
 from ..distributions import MultivariateNormal
+from ..lazy import DiagLazyTensor, MatmulLazyTensor, PsdSumLazyTensor, RootLazyTensor, delazify
 from ..mlls import InducingPointKernelAddedLossTerm
 from ..utils.cholesky import psd_safe_cholesky
+from .kernel import Kernel
 
 
 class InducingPointKernel(Kernel):
@@ -113,7 +115,7 @@ class InducingPointKernel(Kernel):
             base_kernel=copy.deepcopy(self.base_kernel),
             inducing_points=copy.deepcopy(self.inducing_points),
             likelihood=self.likelihood,
-            active_dims=self.active_dims
+            active_dims=self.active_dims,
         )
 
         if replace_inv_root:

--- a/gpytorch/kernels/keops/__init__.py
+++ b/gpytorch/kernels/keops/__init__.py
@@ -1,7 +1,4 @@
 from .matern_kernel import MaternKernel
 from .rbf_kernel import RBFKernel
 
-__all__ = [
-    "MaternKernel",
-    "RBFKernel",
-]
+__all__ = ["MaternKernel", "RBFKernel"]

--- a/gpytorch/kernels/keops/keops_kernel.py
+++ b/gpytorch/kernels/keops/keops_kernel.py
@@ -1,6 +1,8 @@
-import torch
-from ..kernel import Kernel
 from abc import abstractmethod
+
+import torch
+
+from ..kernel import Kernel
 
 try:
     from pykeops.torch import LazyTensor as KEOLazyTensor
@@ -13,7 +15,9 @@ try:
         def covar_func(self, x1: torch.Tensor, x2: torch.Tensor) -> KEOLazyTensor:
             raise NotImplementedError("KeOpsKernels must define a covar_func method")
 
+
 except ImportError:
+
     class KeOpsKernel(Kernel):
         def __init__(self, *args, **kwargs):
             raise RuntimeError("You must have KeOps installed to use a KeOpsKernel")

--- a/gpytorch/kernels/keops/matern_kernel.py
+++ b/gpytorch/kernels/keops/matern_kernel.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
-import torch
 import math
-from .keops_kernel import KeOpsKernel
+
+import torch
+
 from gpytorch.lazy import KeOpsLazyTensor
+
+from .keops_kernel import KeOpsKernel
 
 try:
     from pykeops.torch import LazyTensor as KEOLazyTensor
@@ -15,6 +18,7 @@ try:
         the same arguments. There are currently a few limitations, for example a lack of batch mode support. However,
         most other features like ARD will work.
         """
+
         def __init__(self, nu=2.5, **kwargs):
             if nu not in {0.5, 1.5, 2.5}:
                 raise RuntimeError("nu expected to be 0.5, 1.5, or 2.5")
@@ -65,7 +69,9 @@ try:
             covar_func = lambda x1, x2, diag=False: self.covar_func(x1, x2, diag)
             return KeOpsLazyTensor(x1_, x2_, covar_func)
 
+
 except ImportError:
+
     class MaternKernel(KeOpsKernel):
         def __init__(self, *args, **kwargs):
             super().__init__()

--- a/gpytorch/kernels/keops/rbf_kernel.py
+++ b/gpytorch/kernels/keops/rbf_kernel.py
@@ -1,8 +1,9 @@
 import torch
 
-from .keops_kernel import KeOpsKernel
-from ..rbf_kernel import postprocess_rbf
 from gpytorch.lazy import KeOpsLazyTensor
+
+from ..rbf_kernel import postprocess_rbf
+from .keops_kernel import KeOpsKernel
 
 try:
     from pykeops.torch import LazyTensor as KEOLazyTensor
@@ -15,6 +16,7 @@ try:
         the same arguments. There are currently a few limitations, for example a lack of batch mode support. However,
         most other features like ARD will work.
         """
+
         def __init__(self, **kwargs):
             super(RBFKernel, self).__init__(has_lengthscale=True, **kwargs)
 
@@ -24,9 +26,7 @@ try:
             # when they cut a new release.
             if diag or x1.size(-2) == 1 or x2.size(-2) == 1:
                 return self.covar_dist(
-                    x1, x2, square_dist=True, diag=diag,
-                    dist_postprocess_func=postprocess_rbf,
-                    postprocess=True
+                    x1, x2, square_dist=True, diag=diag, dist_postprocess_func=postprocess_rbf, postprocess=True
                 )
             else:
                 with torch.autograd.enable_grad():
@@ -46,7 +46,9 @@ try:
             covar_func = lambda x1, x2, diag=False: self.covar_func(x1, x2, diag)
             return KeOpsLazyTensor(x1_, x2_, covar_func)
 
+
 except ImportError:
+
     class RBFKernel(KeOpsKernel):
         def __init__(self, *args, **kwargs):
             super().__init__()

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
 
-from abc import abstractmethod
-import torch
 import warnings
-from torch.nn import ModuleList
-from ..lazy import lazify, delazify, LazyEvaluatedKernelTensor, ZeroLazyTensor
-from ..module import Module
-from ..models.exact_prediction_strategies import DefaultPredictionStrategy, SumPredictionStrategy
-from .. import settings
-from ..utils.deprecation import _ClassWithDeprecatedBatchSize, _deprecate_kwarg_with_transform
-from ..constraints import Positive
+from abc import abstractmethod
 from copy import deepcopy
+
+import torch
+from torch.nn import ModuleList
+
+from .. import settings
+from ..constraints import Positive
+from ..lazy import LazyEvaluatedKernelTensor, ZeroLazyTensor, delazify, lazify
+from ..models.exact_prediction_strategies import DefaultPredictionStrategy, SumPredictionStrategy
+from ..module import Module
+from ..utils.deprecation import _ClassWithDeprecatedBatchSize, _deprecate_kwarg_with_transform
 
 
 def default_postprocess_script(x):
@@ -36,7 +38,7 @@ class Distance(torch.nn.Module):
         else:
             x2_norm = x2.pow(2).sum(dim=-1, keepdim=True)
             x2_pad = torch.ones_like(x2_norm)
-        x1_ = torch.cat([-2. * x1, x1_norm, x1_pad], dim=-1)
+        x1_ = torch.cat([-2.0 * x1, x1_norm, x1_pad], dim=-1)
         x2_ = torch.cat([x2, x2_pad, x2_norm], dim=-1)
         res = x1_.matmul(x2_.transpose(-2, -1))
 
@@ -136,7 +138,7 @@ class Kernel(Module, _ClassWithDeprecatedBatchSize):
         lengthscale_prior=None,
         lengthscale_constraint=None,
         eps=1e-6,
-        **kwargs
+        **kwargs,
     ):
         super(Kernel, self).__init__()
         self._register_load_state_dict_pre_hook(self._batch_shape_state_dict_hook)
@@ -159,14 +161,16 @@ class Kernel(Module, _ClassWithDeprecatedBatchSize):
             lengthscale_constraint = Positive()
 
         if param_transform is not None:
-            warnings.warn("The 'param_transform' argument is now deprecated. If you want to use a different "
-                          "transformation, specify a different 'lengthscale_constraint' instead.")
+            warnings.warn(
+                "The 'param_transform' argument is now deprecated. If you want to use a different "
+                "transformation, specify a different 'lengthscale_constraint' instead."
+            )
 
         if has_lengthscale:
             lengthscale_num_dims = 1 if ard_num_dims is None else ard_num_dims
             self.register_parameter(
                 name="raw_lengthscale",
-                parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, lengthscale_num_dims))
+                parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, lengthscale_num_dims)),
             )
             if lengthscale_prior is not None:
                 self.register_prior(
@@ -255,7 +259,7 @@ class Kernel(Module, _ClassWithDeprecatedBatchSize):
         square_dist=False,
         dist_postprocess_func=default_postprocess_script,
         postprocess=True,
-        **params
+        **params,
     ):
         r"""
         This is a helper method for computing the Euclidean distance between

--- a/gpytorch/kernels/linear_kernel.py
+++ b/gpytorch/kernels/linear_kernel.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
-import torch
 import warnings
-from .kernel import Kernel
-from ..lazy import MatmulLazyTensor, RootLazyTensor
+
+import torch
+
 from ..constraints import Positive
+from ..lazy import MatmulLazyTensor, RootLazyTensor
+from .kernel import Kernel
 
 
 class LinearKernel(Kernel):
@@ -42,41 +44,20 @@ class LinearKernel(Kernel):
             `len(active_dims)` should equal `num_dimensions`.
     """
 
-    def __init__(
-        self,
-        num_dimensions=None,
-        offset_prior=None,
-        variance_prior=None,
-        variance_constraint=None,
-        **kwargs
-    ):
+    def __init__(self, num_dimensions=None, offset_prior=None, variance_prior=None, variance_constraint=None, **kwargs):
         super(LinearKernel, self).__init__(**kwargs)
         if variance_constraint is None:
             variance_constraint = Positive()
 
         if num_dimensions is not None:
-            warnings.warn(
-                "The `num_dimensions` argument is deprecated and no longer used.",
-                DeprecationWarning
-            )
-            self.register_parameter(
-                name="offset",
-                parameter=torch.nn.Parameter(torch.zeros(1, 1, num_dimensions))
-            )
+            warnings.warn("The `num_dimensions` argument is deprecated and no longer used.", DeprecationWarning)
+            self.register_parameter(name="offset", parameter=torch.nn.Parameter(torch.zeros(1, 1, num_dimensions)))
         if offset_prior is not None:
-            warnings.warn(
-                "The `offset_prior` argument is deprecated and no longer used.",
-                DeprecationWarning
-            )
-        self.register_parameter(
-            name="raw_variance", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, 1))
-        )
+            warnings.warn("The `offset_prior` argument is deprecated and no longer used.", DeprecationWarning)
+        self.register_parameter(name="raw_variance", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, 1)))
         if variance_prior is not None:
             self.register_prior(
-                "variance_prior",
-                variance_prior,
-                lambda: self.variance,
-                lambda v: self._set_variance(v)
+                "variance_prior", variance_prior, lambda: self.variance, lambda v: self._set_variance(v)
             )
 
         self.register_constraint("raw_variance", variance_constraint)

--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import math
+
 import torch
-from .kernel import Kernel
+
 from ..functions import MaternCovariance
+from .kernel import Kernel
 
 
 class MaternKernel(Kernel):
@@ -82,12 +84,7 @@ class MaternKernel(Kernel):
         self.nu = nu
 
     def forward(self, x1, x2, diag=False, **params):
-        if (
-            x1.requires_grad
-            or x2.requires_grad
-            or (self.ard_num_dims is not None and self.ard_num_dims > 1)
-            or diag
-        ):
+        if x1.requires_grad or x2.requires_grad or (self.ard_num_dims is not None and self.ard_num_dims > 1) or diag:
             mean = x1.reshape(-1, x1.size(-1)).mean(0)[(None,) * (x1.dim() - 1)]
 
             x1_ = (x1 - mean).div(self.lengthscale)
@@ -102,5 +99,6 @@ class MaternKernel(Kernel):
             elif self.nu == 2.5:
                 constant_component = (math.sqrt(5) * distance).add(1).add(5.0 / 3.0 * distance ** 2)
             return constant_component * exp_component
-        return MaternCovariance().apply(x1, x2, self.lengthscale, self.nu,
-                                        lambda x1, x2: self.covar_dist(x1, x2, **params))
+        return MaternCovariance().apply(
+            x1, x2, self.lengthscale, self.nu, lambda x1, x2: self.covar_dist(x1, x2, **params)
+        )

--- a/gpytorch/kernels/newton_girard_additive_kernel.py
+++ b/gpytorch/kernels/newton_girard_additive_kernel.py
@@ -1,6 +1,7 @@
 import torch
-from .kernel import Kernel
+
 from ..constraints import Positive
+from .kernel import Kernel
 
 
 class NewtonGirardAdditiveKernel(Kernel):
@@ -12,10 +13,7 @@ class NewtonGirardAdditiveKernel(Kernel):
         :param active_dims:
         :param kwargs:
         """
-        super(NewtonGirardAdditiveKernel, self).__init__(has_lengthscale=False,
-                                                         active_dims=active_dims,
-                                                         **kwargs
-                                                         )
+        super(NewtonGirardAdditiveKernel, self).__init__(has_lengthscale=False, active_dims=active_dims, **kwargs)
 
         self.base_kernel = base_kernel
         self.num_dims = num_dims
@@ -27,11 +25,10 @@ class NewtonGirardAdditiveKernel(Kernel):
             self.max_degree = max_degree
 
         self.register_parameter(
-            name='raw_outputscale',
-            parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, self.max_degree))
+            name="raw_outputscale", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, self.max_degree))
         )
         outputscale_constraint = Positive()
-        self.register_constraint('raw_outputscale', outputscale_constraint)
+        self.register_constraint("raw_outputscale", outputscale_constraint)
         self.outputscale_constraint = outputscale_constraint
         self.outputscale = [1 / self.max_degree for _ in range(self.max_degree)]
 
@@ -94,17 +91,17 @@ class NewtonGirardAdditiveKernel(Kernel):
             kslong = torch.arange(1, deg + 1, device=kern_values.device, dtype=torch.long)  # use for indexing
 
             # note that s_k is 0-indexed, so we must subtract 1 from kslong
-            sum_ = (m1.pow(ks - 1)
-                    * e_n.index_select(kernel_dim, deg - kslong)
-                    * s_k.index_select(kernel_dim, kslong - 1)
-                    ).sum(dim=kernel_dim) / deg
+            sum_ = (
+                m1.pow(ks - 1) * e_n.index_select(kernel_dim, deg - kslong) * s_k.index_select(kernel_dim, kslong - 1)
+            ).sum(dim=kernel_dim) / deg
             if kernel_dim == -3:
                 e_n[..., deg, :, :] = sum_
             else:
                 e_n[..., deg, :] = sum_
 
         if kernel_dim == -3:
-            return (self.outputscale.unsqueeze(-1).unsqueeze(-1)
-                    * e_n.narrow(kernel_dim, 1, self.max_degree)).sum(dim=kernel_dim)
+            return (self.outputscale.unsqueeze(-1).unsqueeze(-1) * e_n.narrow(kernel_dim, 1, self.max_degree)).sum(
+                dim=kernel_dim
+            )
         else:
             return (self.outputscale.unsqueeze(-1) * e_n.narrow(kernel_dim, 1, self.max_degree)).sum(dim=kernel_dim)

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import math
+
 import torch
-from .kernel import Kernel
+
 from ..constraints import Positive
+from .kernel import Kernel
 
 
 class PeriodicKernel(Kernel):
@@ -76,8 +78,8 @@ class PeriodicKernel(Kernel):
             period_length_constraint = Positive()
 
         self.register_parameter(
-            name="raw_period_length",
-            parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, 1)))
+            name="raw_period_length", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, 1))
+        )
 
         if period_length_prior is not None:
             self.register_prior(

--- a/gpytorch/kernels/polynomial_kernel.py
+++ b/gpytorch/kernels/polynomial_kernel.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
-import torch
-from .kernel import Kernel
 from typing import Optional
+
+import torch
+
+from ..constraints import Interval, Positive
 from ..priors import Prior
-from ..constraints import Positive, Interval
+from .kernel import Kernel
 
 
 class PolynomialKernel(Kernel):
@@ -33,20 +35,13 @@ class PolynomialKernel(Kernel):
     """
 
     def __init__(
-        self,
-        power: int,
-        offset_prior: Optional[Prior] = None,
-        offset_constraint: Optional[Interval] = None,
-        **kwargs
+        self, power: int, offset_prior: Optional[Prior] = None, offset_constraint: Optional[Interval] = None, **kwargs
     ):
         super().__init__(**kwargs)
         if offset_constraint is None:
             offset_constraint = Positive()
 
-        self.register_parameter(
-            name="raw_offset",
-            parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1))
-        )
+        self.register_parameter(name="raw_offset", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1)))
 
         # We want the power to be a float so we dont have to worry about its device / dtype.
         if torch.is_tensor(power):
@@ -58,12 +53,7 @@ class PolynomialKernel(Kernel):
         self.power = power
 
         if offset_prior is not None:
-            self.register_prior(
-                "offset_prior",
-                offset_prior,
-                lambda: self.offset,
-                lambda v: self._set_offset(v)
-            )
+            self.register_prior("offset_prior", offset_prior, lambda: self.offset, lambda v: self._set_offset(v))
 
         self.register_constraint("raw_offset", offset_constraint)
 
@@ -86,7 +76,7 @@ class PolynomialKernel(Kernel):
         x2: torch.Tensor,
         diag: Optional[bool] = False,
         last_dim_is_batch: Optional[bool] = False,
-        **params
+        **params,
     ) -> torch.Tensor:
         offset = self.offset.view(*self.batch_shape, 1, 1)
 

--- a/gpytorch/kernels/polynomial_kernel_grad.py
+++ b/gpytorch/kernels/polynomial_kernel_grad.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
-import torch
-from .polynomial_kernel import PolynomialKernel
 from typing import Optional
+
+import torch
+
+from .polynomial_kernel import PolynomialKernel
 
 
 class PolynomialKernelGrad(PolynomialKernel):
@@ -12,7 +14,7 @@ class PolynomialKernelGrad(PolynomialKernel):
         x2: torch.Tensor,
         diag: Optional[bool] = False,
         last_dim_is_batch: Optional[bool] = False,
-        **params
+        **params,
     ) -> torch.Tensor:
         offset = self.offset.view(*self.batch_shape, 1, 1)
 
@@ -40,9 +42,7 @@ class PolynomialKernelGrad(PolynomialKernel):
 
             ones_ = torch.ones(*batch_shape, d, 1, n2, dtype=x1.dtype, device=x1.device)
             K12_outer_prods = torch.matmul(x1.transpose(-2, -1).unsqueeze(-1), ones_)
-            K12 = (
-                (K12_base.unsqueeze(-3) * K12_outer_prods).transpose(-3, -2).reshape(*batch_shape, n1, d * n2)
-            )
+            K12 = (K12_base.unsqueeze(-3) * K12_outer_prods).transpose(-3, -2).reshape(*batch_shape, n1, d * n2)
 
             ones_ = torch.ones(*batch_shape, d, n1, 1, dtype=x1.dtype, device=x1.device)
             K21_outer_prods = torch.matmul(ones_, x2.transpose(-2, -1).unsqueeze(-2))

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from .kernel import Kernel
 from ..functions import RBFCovariance
+from .kernel import Kernel
 
 
 def postprocess_rbf(dist_mat):
@@ -70,21 +70,17 @@ class RBFKernel(Kernel):
         super(RBFKernel, self).__init__(has_lengthscale=True, **kwargs)
 
     def forward(self, x1, x2, diag=False, **params):
-        if (
-            x1.requires_grad
-            or x2.requires_grad
-            or (self.ard_num_dims is not None and self.ard_num_dims > 1)
-            or diag
-        ):
+        if x1.requires_grad or x2.requires_grad or (self.ard_num_dims is not None and self.ard_num_dims > 1) or diag:
             x1_ = x1.div(self.lengthscale)
             x2_ = x2.div(self.lengthscale)
-            return self.covar_dist(x1_, x2_, square_dist=True, diag=diag,
-                                   dist_postprocess_func=postprocess_rbf,
-                                   postprocess=True, **params)
-        return RBFCovariance().apply(x1, x2, self.lengthscale,
-                                     lambda x1, x2: self.covar_dist(x1, x2,
-                                                                    square_dist=True,
-                                                                    diag=False,
-                                                                    dist_postprocess_func=postprocess_rbf,
-                                                                    postprocess=False,
-                                                                    **params))
+            return self.covar_dist(
+                x1_, x2_, square_dist=True, diag=diag, dist_postprocess_func=postprocess_rbf, postprocess=True, **params
+            )
+        return RBFCovariance().apply(
+            x1,
+            x2,
+            self.lengthscale,
+            lambda x1, x2: self.covar_dist(
+                x1, x2, square_dist=True, diag=False, dist_postprocess_func=postprocess_rbf, postprocess=False, **params
+            ),
+        )

--- a/gpytorch/kernels/scale_kernel.py
+++ b/gpytorch/kernels/scale_kernel.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 import torch
-from .kernel import Kernel
-from ..lazy import delazify
+
 from ..constraints import Positive
+from ..lazy import delazify
+from .kernel import Kernel
 
 
 class ScaleKernel(Kernel):
@@ -56,7 +57,7 @@ class ScaleKernel(Kernel):
             outputscale_constraint = Positive()
 
         self.base_kernel = base_kernel
-        outputscale = torch.zeros(*self.batch_shape) if len(self.batch_shape) else torch.tensor(0.)
+        outputscale = torch.zeros(*self.batch_shape) if len(self.batch_shape) else torch.tensor(0.0)
         self.register_parameter(name="raw_outputscale", parameter=torch.nn.Parameter(outputscale))
         if outputscale_prior is not None:
             self.register_prior(

--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 
-import torch
 import warnings
-from .sum_lazy_tensor import SumLazyTensor
+
+import torch
+
+from .. import settings
+from ..utils import broadcasting, pivoted_cholesky, woodbury
 from .diag_lazy_tensor import DiagLazyTensor
 from .psd_sum_lazy_tensor import PsdSumLazyTensor
 from .root_lazy_tensor import RootLazyTensor
-
-from ..utils import broadcasting, pivoted_cholesky, woodbury
-from .. import settings
+from .sum_lazy_tensor import SumLazyTensor
 
 
 class AddedDiagLazyTensor(SumLazyTensor):
@@ -19,21 +20,14 @@ class AddedDiagLazyTensor(SumLazyTensor):
 
     def __init__(self, *lazy_tensors, preconditioner_override=None):
         lazy_tensors = list(lazy_tensors)
-        super(AddedDiagLazyTensor, self).__init__(
-            *lazy_tensors, preconditioner_override=preconditioner_override
-        )
+        super(AddedDiagLazyTensor, self).__init__(*lazy_tensors, preconditioner_override=preconditioner_override)
         if len(lazy_tensors) > 2:
             raise RuntimeError("An AddedDiagLazyTensor can only have two components")
 
         broadcasting._mul_broadcast_shape(lazy_tensors[0].shape, lazy_tensors[1].shape)
 
-        if isinstance(lazy_tensors[0], DiagLazyTensor) and isinstance(
-            lazy_tensors[1], DiagLazyTensor
-        ):
-            raise RuntimeError(
-                "Trying to lazily add two DiagLazyTensors. "
-                "Create a single DiagLazyTensor instead."
-            )
+        if isinstance(lazy_tensors[0], DiagLazyTensor) and isinstance(lazy_tensors[1], DiagLazyTensor):
+            raise RuntimeError("Trying to lazily add two DiagLazyTensors. " "Create a single DiagLazyTensor instead.")
         elif isinstance(lazy_tensors[0], DiagLazyTensor):
             self._diag_tensor = lazy_tensors[0]
             self._lazy_tensor = lazy_tensors[1]
@@ -41,21 +35,15 @@ class AddedDiagLazyTensor(SumLazyTensor):
             self._diag_tensor = lazy_tensors[1]
             self._lazy_tensor = lazy_tensors[0]
         else:
-            raise RuntimeError(
-                "One of the LazyTensors input to AddedDiagLazyTensor must be a DiagLazyTensor!"
-            )
+            raise RuntimeError("One of the LazyTensors input to AddedDiagLazyTensor must be a DiagLazyTensor!")
 
         self.preconditioner_override = preconditioner_override
 
     def _matmul(self, rhs):
-        return torch.addcmul(
-            self._lazy_tensor._matmul(rhs), self._diag_tensor._diag.unsqueeze(-1), rhs
-        )
+        return torch.addcmul(self._lazy_tensor._matmul(rhs), self._diag_tensor._diag.unsqueeze(-1), rhs)
 
     def add_diag(self, added_diag):
-        return AddedDiagLazyTensor(
-            self._lazy_tensor, self._diag_tensor.add_diag(added_diag)
-        )
+        return AddedDiagLazyTensor(self._lazy_tensor, self._diag_tensor.add_diag(added_diag))
 
     def __add__(self, other):
         from .diag_lazy_tensor import DiagLazyTensor
@@ -69,36 +57,25 @@ class AddedDiagLazyTensor(SumLazyTensor):
         if self.preconditioner_override is not None:
             return self.preconditioner_override(self)
 
-        if (
-            settings.max_preconditioner_size.value() == 0
-            or self.size(-1) < settings.min_preconditioning_size.value()
-        ):
+        if settings.max_preconditioner_size.value() == 0 or self.size(-1) < settings.min_preconditioning_size.value():
             return None, None, None
 
         if not (hasattr(self, "_woodbury_cache") or hasattr(self, "self._q_cache")):
             max_iter = settings.max_preconditioner_size.value()
-            self._piv_chol_self = pivoted_cholesky.pivoted_cholesky(
-                self._lazy_tensor, max_iter
-            )
+            self._piv_chol_self = pivoted_cholesky.pivoted_cholesky(self._lazy_tensor, max_iter)
             if torch.any(torch.isnan(self._piv_chol_self)).item():
                 warnings.warn(
                     "NaNs encountered in preconditioner computation. Attempting to continue without preconditioning."
                 )
                 return None, None, None
 
-            if (
-                self._piv_chol_self.dim() == 2
-            ):  # TODO: Whenever PyTorch supports batch mode
+            if self._piv_chol_self.dim() == 2:  # TODO: Whenever PyTorch supports batch mode
                 *batch_shape, n, k = self._piv_chol_self.shape
                 self._noise = self._diag_tensor.diag().unsqueeze(-1)
 
-                self.constant_diag = torch.equal(
-                    self._noise, self._noise[0] * torch.ones_like(self._noise)
-                )
+                self.constant_diag = torch.equal(self._noise, self._noise[0] * torch.ones_like(self._noise))
 
-                eye = torch.eye(
-                    k, dtype=self._piv_chol_self.dtype, device=self._piv_chol_self.device
-                )
+                eye = torch.eye(k, dtype=self._piv_chol_self.dtype, device=self._piv_chol_self.device)
 
                 if self.constant_diag:
                     # We can factor out the noise for for both QR and solves.
@@ -109,53 +86,28 @@ class AddedDiagLazyTensor(SumLazyTensor):
                     self._q_cache = self._q_cache[:n, :]
 
                     # Use the matrix determinant lemma for the logdet, using the fact that R'R = L_k'L_k + s*I
-                    logdet = (
-                        self._r_cache.diagonal(dim1=-1, dim2=-2)
-                        .abs()
-                        .log()
-                        .sum(-1)
-                        .mul(2)
-                    )
+                    logdet = self._r_cache.diagonal(dim1=-1, dim2=-2).abs().log().sum(-1).mul(2)
                     logdet = logdet + (n - k) * self.noise_constant.log()
-                    self._precond_logdet_cache = (
-                        logdet.view(*batch_shape)
-                        if len(batch_shape)
-                        else logdet.squeeze()
-                    )
+                    self._precond_logdet_cache = logdet.view(*batch_shape) if len(batch_shape) else logdet.squeeze()
 
                 else:
                     # With non-constant diagonals, we cant factor out the noise as easily
-                    self._q_cache, self._r_cache = torch.qr(
-                        torch.cat((self._piv_chol_self / self._noise.sqrt(), eye))
-                    )
+                    self._q_cache, self._r_cache = torch.qr(torch.cat((self._piv_chol_self / self._noise.sqrt(), eye)))
                     self._q_cache = self._q_cache[:n, :] / self._noise.sqrt()
 
-                    logdet = self._r_cache.diagonal(dim1=-1, dim2=-2).abs().log().sum(
-                        -1
-                    ).mul(2) - (1.0 / self._noise).log().sum([-1, -2])
-                    self._precond_logdet_cache = (
-                        logdet.view(*batch_shape)
-                        if len(batch_shape)
-                        else logdet.squeeze()
-                    )
+                    logdet = self._r_cache.diagonal(dim1=-1, dim2=-2).abs().log().sum(-1).mul(2) - (
+                        1.0 / self._noise
+                    ).log().sum([-1, -2])
+                    self._precond_logdet_cache = logdet.view(*batch_shape) if len(batch_shape) else logdet.squeeze()
 
             else:
                 self._woodbury_cache, self._inv_scale, self._precond_logdet_cache = woodbury.woodbury_factor(
-                    self._piv_chol_self,
-                    self._piv_chol_self,
-                    self._diag_tensor.diag(),
-                    logdet=True,
+                    self._piv_chol_self, self._piv_chol_self, self._diag_tensor.diag(), logdet=True
                 )
-                self._scaled_inv_diag = self._inv_scale / self._diag_tensor.diag().unsqueeze(
-                    -1
-                )
-                self._scaled_inv_diag_piv_chol_self = (
-                    self._piv_chol_self * self._scaled_inv_diag
-                )
+                self._scaled_inv_diag = self._inv_scale / self._diag_tensor.diag().unsqueeze(-1)
+                self._scaled_inv_diag_piv_chol_self = self._piv_chol_self * self._scaled_inv_diag
 
-            self.preconditioner_lt = PsdSumLazyTensor(
-                RootLazyTensor(self._piv_chol_self), self._diag_tensor
-            )
+            self.preconditioner_lt = PsdSumLazyTensor(RootLazyTensor(self._piv_chol_self), self._diag_tensor)
 
         # NOTE to future self:
         # We cannot memoize this precondition closure
@@ -163,14 +115,10 @@ class AddedDiagLazyTensor(SumLazyTensor):
         def precondition_closure(tensor):
             if hasattr(self, "_q_cache"):
                 if self.constant_diag:
-                    return (1 / self.noise_constant) * (
-                        tensor - self._q_cache.matmul(self._q_cache.t().matmul(tensor))
-                    )
+                    return (1 / self.noise_constant) * (tensor - self._q_cache.matmul(self._q_cache.t().matmul(tensor)))
 
                 else:
-                    return (tensor / self._noise) - self._q_cache.matmul(
-                        self._q_cache.t().matmul(tensor)
-                    )
+                    return (tensor / self._noise) - self._q_cache.matmul(self._q_cache.t().matmul(tensor))
 
             else:
                 res = woodbury.woodbury_solve(

--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 import itertools
+
 import torch
+
 from .. import settings
 from ..utils.broadcasting import _matmul_broadcast_shape
 from ..utils.memoize import cached
@@ -56,9 +58,7 @@ class BatchRepeatLazyTensor(LazyTensor):
         return batch_repeat
 
     def _expand_batch(self, batch_shape):
-        padding_dims = torch.Size(
-            tuple(1 for _ in range(max(len(batch_shape) + 2 - self.base_lazy_tensor.dim(), 0)))
-        )
+        padding_dims = torch.Size(tuple(1 for _ in range(max(len(batch_shape) + 2 - self.base_lazy_tensor.dim(), 0))))
         current_batch_shape = padding_dims + self.base_lazy_tensor.batch_shape
         return self.__class__(
             self.base_lazy_tensor, batch_repeat=self._compute_batch_repeat_size(current_batch_shape, batch_shape)
@@ -67,7 +67,7 @@ class BatchRepeatLazyTensor(LazyTensor):
     def _get_indices(self, row_index, col_index, *batch_indices):
         # First remove any new batch indices that were added - they aren't necessary
         num_true_batch_indices = self.base_lazy_tensor.dim() - 2
-        batch_indices = batch_indices[len(batch_indices) - num_true_batch_indices:]
+        batch_indices = batch_indices[len(batch_indices) - num_true_batch_indices :]
 
         # Now adjust the indices batch_indices that were repeated
         batch_indices = [
@@ -114,9 +114,7 @@ class BatchRepeatLazyTensor(LazyTensor):
             padded_base_batch_shape, batch_repeat = self.__batch_move_memo
             del self.__batch_move_memo
         else:
-            padding_dims = torch.Size(
-                tuple(1 for _ in range(max(len(output_shape) - self.base_lazy_tensor.dim(), 0)))
-            )
+            padding_dims = torch.Size(tuple(1 for _ in range(max(len(output_shape) - self.base_lazy_tensor.dim(), 0))))
             padded_base_batch_shape = padding_dims + self.base_lazy_tensor.batch_shape
             batch_repeat = self._compute_batch_repeat_size(padded_base_batch_shape, output_shape[:-2])
 
@@ -138,9 +136,7 @@ class BatchRepeatLazyTensor(LazyTensor):
         So that the tensor is now b x m x nr.
         This allows us to use the base_lazy_tensor routines.
         """
-        padding_dims = torch.Size(
-            tuple(1 for _ in range(max(len(output_shape) - self.base_lazy_tensor.dim(), 0)))
-        )
+        padding_dims = torch.Size(tuple(1 for _ in range(max(len(output_shape) - self.base_lazy_tensor.dim(), 0))))
         padded_base_batch_shape = padding_dims + self.base_lazy_tensor.batch_shape
         batch_repeat = self._compute_batch_repeat_size(padded_base_batch_shape, output_shape[:-2])
 
@@ -238,9 +234,7 @@ class BatchRepeatLazyTensor(LazyTensor):
             output_shape = _matmul_broadcast_shape(self.shape, inv_quad_rhs.shape)
             inv_quad_rhs = self._move_repeat_batches_to_columns(inv_quad_rhs, output_shape)
 
-        inv_quad_term, logdet_term = self.base_lazy_tensor.inv_quad_logdet(
-            inv_quad_rhs, logdet, reduce_inv_quad=False
-        )
+        inv_quad_term, logdet_term = self.base_lazy_tensor.inv_quad_logdet(inv_quad_rhs, logdet, reduce_inv_quad=False)
 
         if inv_quad_term is not None and inv_quad_term.numel():
             inv_quad_term = inv_quad_term.view(*inv_quad_term.shape[:-1], -1, 1, self.batch_repeat.numel())

--- a/gpytorch/lazy/block_diag_lazy_tensor.py
+++ b/gpytorch/lazy/block_diag_lazy_tensor.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import torch
-from .block_lazy_tensor import BlockLazyTensor
+
 from ..utils.memoize import cached
+from .block_lazy_tensor import BlockLazyTensor
 
 
 class BlockDiagLazyTensor(BlockLazyTensor):
@@ -19,6 +20,7 @@ class BlockDiagLazyTensor(BlockLazyTensor):
         :attr:`block_dim` (int):
             The dimension that specifies the blocks.
     """
+
     @property
     def num_blocks(self):
         return self.base_lazy_tensor.size(-3)

--- a/gpytorch/lazy/block_interleaved_lazy_tensor.py
+++ b/gpytorch/lazy/block_interleaved_lazy_tensor.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import torch
-from .block_lazy_tensor import BlockLazyTensor
+
 from ..utils.memoize import cached
+from .block_lazy_tensor import BlockLazyTensor
 
 
 class BlockInterleavedLazyTensor(BlockLazyTensor):
@@ -19,6 +20,7 @@ class BlockInterleavedLazyTensor(BlockLazyTensor):
         :attr:`block_dim` (int):
             The dimension that specifies the blocks.
     """
+
     @property
     def num_blocks(self):
         return self.base_lazy_tensor.size(-3)

--- a/gpytorch/lazy/block_lazy_tensor.py
+++ b/gpytorch/lazy/block_lazy_tensor.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
+from abc import abstractmethod
+
 import torch
+
 from .lazy_tensor import LazyTensor
 from .non_lazy_tensor import lazify
-from abc import abstractmethod
 
 
 class BlockLazyTensor(LazyTensor):
@@ -41,8 +43,9 @@ class BlockLazyTensor(LazyTensor):
         if block_dim != -3:
             positive_block_dim = base_lazy_tensor.dim() + block_dim
             base_lazy_tensor = base_lazy_tensor._permute_batch(
-                *range(positive_block_dim), *range(positive_block_dim + 1, base_lazy_tensor.dim() - 2),
-                positive_block_dim
+                *range(positive_block_dim),
+                *range(positive_block_dim + 1, base_lazy_tensor.dim() - 2),
+                positive_block_dim,
             )
 
         super(BlockLazyTensor, self).__init__(lazify(base_lazy_tensor))
@@ -103,6 +106,7 @@ class BlockLazyTensor(LazyTensor):
         # We're using a custom method here - the constant mul is applied to the base_lazy tensor
         # This preserves the block structure
         from .constant_mul_lazy_tensor import ConstantMulLazyTensor
+
         return self.__class__(ConstantMulLazyTensor(self.base_lazy_tensor, other))
 
     def _transpose_nonbatch(self):

--- a/gpytorch/lazy/constant_mul_lazy_tensor.py
+++ b/gpytorch/lazy/constant_mul_lazy_tensor.py
@@ -68,10 +68,7 @@ class ConstantMulLazyTensor(LazyTensor):
         return res * self._constant.unsqueeze(-1)
 
     def _expand_batch(self, batch_shape):
-        return self.__class__(
-            self.base_lazy_tensor._expand_batch(batch_shape),
-            self._constant.expand(*batch_shape)
-        )
+        return self.__class__(self.base_lazy_tensor._expand_batch(batch_shape), self._constant.expand(*batch_shape))
 
     def _get_indices(self, row_index, col_index, *batch_indices):
         # NOTE TO FUTURE SELF:
@@ -101,8 +98,7 @@ class ConstantMulLazyTensor(LazyTensor):
 
     def _permute_batch(self, *dims):
         return self.__class__(
-            self.base_lazy_tensor._permute_batch(*dims),
-            self._constant.expand(self.batch_shape).permute(*dims),
+            self.base_lazy_tensor._permute_batch(*dims), self._constant.expand(self.batch_shape).permute(*dims)
         )
 
     def _quad_form_derivative(self, left_vecs, right_vecs):

--- a/gpytorch/lazy/interpolated_lazy_tensor.py
+++ b/gpytorch/lazy/interpolated_lazy_tensor.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 
 import torch
-# from .block_diag_lazy_tensor import BlockDiagLazyTensor
-from .lazy_tensor import LazyTensor
-from .non_lazy_tensor import lazify, NonLazyTensor
-from .root_lazy_tensor import RootLazyTensor
+
 from ..utils import sparse
 from ..utils.broadcasting import _pad_with_singletons
 from ..utils.getitem import _noop_index
 from ..utils.interpolation import left_interp, left_t_interp
+from .lazy_tensor import LazyTensor
+from .non_lazy_tensor import NonLazyTensor, lazify
+from .root_lazy_tensor import RootLazyTensor
 
 
 class InterpolatedLazyTensor(LazyTensor):
@@ -105,8 +105,9 @@ class InterpolatedLazyTensor(LazyTensor):
         left_interp_indices = self.left_interp_indices.__getitem__((*batch_indices, row_index)).unsqueeze(-2)
         right_interp_indices = self.right_interp_indices.__getitem__((*batch_indices, col_index)).unsqueeze(-1)
         base_vals = self.base_lazy_tensor._get_indices(
-            left_interp_indices, right_interp_indices,
-            *[batch_index.view(*batch_index.shape, 1, 1) for batch_index in batch_indices]
+            left_interp_indices,
+            right_interp_indices,
+            *[batch_index.view(*batch_index.shape, 1, 1) for batch_index in batch_indices],
         )
 
         left_interp_values = self.left_interp_values.__getitem__((*batch_indices, row_index)).unsqueeze(-2)
@@ -129,15 +130,19 @@ class InterpolatedLazyTensor(LazyTensor):
             base_lazy_tensor = base_lazy_tensor._getitem(_noop_index, _noop_index, *batch_indices)
 
         # Special case: if both row and col are not indexed, then we are done
-        if (row_index is _noop_index and col_index is _noop_index):
+        if row_index is _noop_index and col_index is _noop_index:
             left_interp_indices = left_interp_indices[batch_indices]
             left_interp_values = left_interp_values[batch_indices]
             right_interp_indices = right_interp_indices[batch_indices]
             right_interp_values = right_interp_values[batch_indices]
 
             return self.__class__(
-                base_lazy_tensor, left_interp_indices, left_interp_values,
-                right_interp_indices, right_interp_values, **self._kwargs
+                base_lazy_tensor,
+                left_interp_indices,
+                left_interp_values,
+                right_interp_indices,
+                right_interp_values,
+                **self._kwargs,
             )
 
         # Normal case: we have to do some processing on either the rows or columns
@@ -149,8 +154,12 @@ class InterpolatedLazyTensor(LazyTensor):
 
         # Construct interpolated LazyTensor
         res = self.__class__(
-            base_lazy_tensor, left_interp_indices, left_interp_values,
-            right_interp_indices, right_interp_values, **self._kwargs
+            base_lazy_tensor,
+            left_interp_indices,
+            left_interp_values,
+            right_interp_indices,
+            right_interp_values,
+            **self._kwargs,
         )
         return res
 
@@ -296,7 +305,7 @@ class InterpolatedLazyTensor(LazyTensor):
             self.right_interp_values,
             self.left_interp_indices,
             self.left_interp_values,
-            **self._kwargs
+            **self._kwargs,
         )
         return res
 
@@ -348,8 +357,8 @@ class InterpolatedLazyTensor(LazyTensor):
 
         # Rearrange the indices and values
         permute_order = (*range(0, dim), *range(dim + 1, self.dim()), dim)
-        left_shape = (*left_interp_indices.shape[:dim], *left_interp_indices.shape[dim + 1:-1], -1)
-        right_shape = (*right_interp_indices.shape[:dim], *right_interp_indices.shape[dim + 1:-1], -1)
+        left_shape = (*left_interp_indices.shape[:dim], *left_interp_indices.shape[dim + 1 : -1], -1)
+        right_shape = (*right_interp_indices.shape[:dim], *right_interp_indices.shape[dim + 1 : -1], -1)
         left_interp_indices = left_interp_indices.permute(permute_order).reshape(left_shape)
         left_interp_values = left_interp_values.permute(permute_order).reshape(left_shape)
         right_interp_indices = right_interp_indices.permute(permute_order).reshape(right_shape)

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -2,7 +2,7 @@
 
 import torch
 
-from .. import settings, beta_features
+from .. import beta_features, settings
 from ..utils import broadcasting
 from ..utils.getitem import _noop_index
 from ..utils.memoize import cached
@@ -203,15 +203,19 @@ class LazyEvaluatedKernelTensor(LazyTensor):
                 torch.Size([*x1.shape[:-2], num_rows, x1.size(-1)]),
                 torch.Size([*x2.shape[:-2], x2.size(-1), num_cols]),
                 error_msg="x1 and x2 were not broadcastable to a proper kernel shape. "
-                "Got x1.shape = {} and x2.shape = {}".format(str(x1.shape), str(x2.shape))
+                "Got x1.shape = {} and x2.shape = {}".format(str(x1.shape), str(x2.shape)),
             )
-            expected_size = broadcasting._mul_broadcast_shape(
-                expected_size[:-2], self.kernel.batch_shape,
-                error_msg=(
-                    f"x1 and x2 were not broadcastable with kernel of batch_shape {self.kernel.batch_shape}. "
-                    f"Got x1.shape = {x1.shape} and x2.shape = {x2.shape}"
+            expected_size = (
+                broadcasting._mul_broadcast_shape(
+                    expected_size[:-2],
+                    self.kernel.batch_shape,
+                    error_msg=(
+                        f"x1 and x2 were not broadcastable with kernel of batch_shape {self.kernel.batch_shape}. "
+                        f"Got x1.shape = {x1.shape} and x2.shape = {x2.shape}"
+                    ),
                 )
-            ) + expected_size[-2:]
+                + expected_size[-2:]
+            )
 
         # Handle when the last dim is batch
         if self.last_dim_is_batch:
@@ -271,9 +275,7 @@ class LazyEvaluatedKernelTensor(LazyTensor):
         with settings.lazily_evaluate_kernels(False):
             temp_active_dims = self.kernel.active_dims
             self.kernel.active_dims = None
-            res = self.kernel(
-                x1, x2, diag=False, last_dim_is_batch=self.last_dim_is_batch, **self.params
-            )
+            res = self.kernel(x1, x2, diag=False, last_dim_is_batch=self.last_dim_is_batch, **self.params)
             self.kernel.active_dims = temp_active_dims
 
         # Check the size of the output

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -4,11 +4,11 @@ import math
 import warnings
 from abc import ABC, abstractmethod
 
-import gpytorch
 import torch
 
-from .. import settings
-from .. import utils
+import gpytorch
+
+from .. import settings, utils
 from ..functions._inv_matmul import InvMatmul
 from ..functions._inv_quad import InvQuad
 from ..functions._inv_quad_log_det import InvQuadLogDet
@@ -17,8 +17,8 @@ from ..functions._root_decomposition import RootDecomposition
 from ..utils.broadcasting import _matmul_broadcast_shape, _mul_broadcast_shape
 from ..utils.cholesky import psd_safe_cholesky
 from ..utils.deprecation import _deprecate_renamed_methods
+from ..utils.getitem import _compute_getitem_size, _convert_indices_to_tensors, _noop_index
 from ..utils.gradients import _ensure_symmetric_grad
-from ..utils.getitem import _noop_index, _convert_indices_to_tensors, _compute_getitem_size
 from ..utils.memoize import add_to_cache, cached
 from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
 
@@ -77,6 +77,7 @@ class LazyTensor(ABC):
         LazyTensor may be (for example) :math:`b \\times n \\times n`. Many of the methods are designed to efficiently
         operate on these batches if present.
     """
+
     def _check_args(self, *args, **kwargs):
         """
         (Optional) run checks to see that input arguments and kwargs are valid
@@ -212,7 +213,7 @@ class LazyTensor(ABC):
             `LazyTensor`
         """
         # Special case: if both row and col are not indexed, then we are done
-        if (row_index is _noop_index and col_index is _noop_index):
+        if row_index is _noop_index and col_index is _noop_index:
             if len(batch_indices):
                 components = [component[batch_indices] for component in self._args]
                 res = self.__class__(*components, **self._kwargs)
@@ -224,11 +225,11 @@ class LazyTensor(ABC):
         # We will handle this through "interpolation"
         row_interp_indices = torch.arange(0, self.size(-2), dtype=torch.long, device=self.device).view(-1, 1)
         row_interp_indices = row_interp_indices.expand(*self.batch_shape, -1, 1)
-        row_interp_values = torch.tensor(1., dtype=self.dtype, device=self.device).expand_as(row_interp_indices)
+        row_interp_values = torch.tensor(1.0, dtype=self.dtype, device=self.device).expand_as(row_interp_indices)
 
         col_interp_indices = torch.arange(0, self.size(-1), dtype=torch.long, device=self.device).view(-1, 1)
         col_interp_indices = col_interp_indices.expand(*self.batch_shape, -1, 1)
-        col_interp_values = torch.tensor(1., dtype=self.dtype, device=self.device).expand_as(col_interp_indices)
+        col_interp_values = torch.tensor(1.0, dtype=self.dtype, device=self.device).expand_as(col_interp_indices)
 
         # Construct interpolated LazyTensor
         from . import InterpolatedLazyTensor
@@ -295,18 +296,23 @@ class LazyTensor(ABC):
         # Create some interoplation indices and values
         row_interp_indices = torch.arange(0, self.size(-2), dtype=torch.long, device=self.device)
         row_interp_indices = row_interp_indices[row_index].unsqueeze_(-1).unsqueeze_(-1)
-        row_interp_values = torch.tensor(1., dtype=self.dtype, device=self.device).expand_as(row_interp_indices)
+        row_interp_values = torch.tensor(1.0, dtype=self.dtype, device=self.device).expand_as(row_interp_indices)
 
         col_interp_indices = torch.arange(0, self.size(-1), dtype=torch.long, device=self.device)
         col_interp_indices = col_interp_indices[col_index].unsqueeze_(-1).unsqueeze_(-1)
-        col_interp_values = torch.tensor(1., dtype=self.dtype, device=self.device).expand_as(col_interp_indices)
+        col_interp_values = torch.tensor(1.0, dtype=self.dtype, device=self.device).expand_as(col_interp_indices)
 
         # Construct interpolated LazyTensor
         from . import InterpolatedLazyTensor
 
-        res = InterpolatedLazyTensor(
-            base_lazy_tensor, row_interp_indices, row_interp_values, col_interp_indices, col_interp_values
-        ).evaluate().squeeze(-2).squeeze(-1)
+        res = (
+            InterpolatedLazyTensor(
+                base_lazy_tensor, row_interp_indices, row_interp_values, col_interp_indices, col_interp_values
+            )
+            .evaluate()
+            .squeeze(-2)
+            .squeeze(-1)
+        )
         return res
 
     def _quad_form_derivative(self, left_vecs, right_vecs):
@@ -391,6 +397,7 @@ class LazyTensor(ABC):
             (LazyTensor) Cholesky factor
         """
         from .non_lazy_tensor import NonLazyTensor
+
         evaluated_mat = self.evaluate()
 
         # if the tensor is a scalar, we can just take the square root
@@ -470,6 +477,7 @@ class LazyTensor(ABC):
             :obj:`gpytorch.lazy.LazyTensor`
         """
         from .constant_mul_lazy_tensor import ConstantMulLazyTensor
+
         return ConstantMulLazyTensor(self, other)
 
     def _mul_matrix(self, other):
@@ -583,7 +591,7 @@ class LazyTensor(ABC):
             True,
             False,
             None,
-            *self.representation()
+            *self.representation(),
         )
 
         return res
@@ -621,7 +629,7 @@ class LazyTensor(ABC):
             True,
             True,
             initial_vectors,
-            *self.representation()
+            *self.representation(),
         )
 
         if initial_vectors is not None and initial_vectors.size(-1) > 1:
@@ -653,6 +661,7 @@ class LazyTensor(ABC):
             :obj:`gpytorch.lazy.LazyTensor`
         """
         from .sum_batch_lazy_tensor import SumBatchLazyTensor
+
         return SumBatchLazyTensor(self, block_dim=dim)
 
     def _t_matmul(self, rhs):
@@ -921,20 +930,9 @@ class LazyTensor(ABC):
 
         func = InvMatmul
         if left_tensor is None:
-            return func.apply(
-                self.representation_tree(),
-                False,
-                right_tensor,
-                *self.representation(),
-            )
+            return func.apply(self.representation_tree(), False, right_tensor, *self.representation())
         else:
-            return func.apply(
-                self.representation_tree(),
-                True,
-                left_tensor,
-                right_tensor,
-                *self.representation(),
-            )
+            return func.apply(self.representation_tree(), True, left_tensor, right_tensor, *self.representation())
 
     def inv_quad(self, tensor, reduce_inv_quad=True):
         """
@@ -1544,8 +1542,11 @@ class LazyTensor(ABC):
             small_dim = dim1 if dim1 < dim2 else dim2
             large_dim = dim2 if dim1 < dim2 else dim1
             res = self._permute_batch(
-                *range(small_dim), large_dim, *range(small_dim + 1, large_dim), small_dim,
-                *range(large_dim + 1, ndimension - 2)
+                *range(small_dim),
+                large_dim,
+                *range(small_dim + 1, large_dim),
+                small_dim,
+                *range(large_dim + 1, ndimension - 2),
             )
 
         elif dim1 >= ndimension - 2 and dim2 >= ndimension - 2:
@@ -1662,11 +1663,7 @@ class LazyTensor(ABC):
         if len(ellipsis_locs) == 1:
             ellipsis_loc = ellipsis_locs[0]
             num_to_fill_in = ndimension - (len(index) - 1)
-            index = (
-                index[:ellipsis_loc]
-                + tuple(_noop_index for _ in range(num_to_fill_in))
-                + index[ellipsis_loc + 1 :]
-            )
+            index = index[:ellipsis_loc] + tuple(_noop_index for _ in range(num_to_fill_in)) + index[ellipsis_loc + 1 :]
 
         # Pad the index with empty indices
         index = index + tuple(_noop_index for _ in range(ndimension - len(index)))
@@ -1679,10 +1676,12 @@ class LazyTensor(ABC):
         row_has_tensor_index = torch.is_tensor(row_index)
         col_has_tensor_index = torch.is_tensor(col_index)
         # These are the cases where the row and/or column indices will be "absorbed" into other indices
-        row_col_are_absorbed = any((
-            batch_has_tensor_index and (row_has_tensor_index or col_has_tensor_index),
-            not batch_has_tensor_index and (row_has_tensor_index and col_has_tensor_index),
-        ))
+        row_col_are_absorbed = any(
+            (
+                batch_has_tensor_index and (row_has_tensor_index or col_has_tensor_index),
+                not batch_has_tensor_index and (row_has_tensor_index and col_has_tensor_index),
+            )
+        )
 
         # If we're indexing the LT with ints or slices
         # Replace the ints with slices, and we'll just squeeze the dimensions later
@@ -1708,7 +1707,7 @@ class LazyTensor(ABC):
 
         # If we selected a single row and/or column (or did tensor indexing), we'll be retuning a tensor
         # with the appropriate shape
-        if (squeeze_row or squeeze_col or row_col_are_absorbed):
+        if squeeze_row or squeeze_col or row_col_are_absorbed:
             res = delazify(res)
         if squeeze_row:
             res = res.squeeze(-2)

--- a/gpytorch/lazy/matmul_lazy_tensor.py
+++ b/gpytorch/lazy/matmul_lazy_tensor.py
@@ -2,11 +2,11 @@
 
 import torch
 
-from .lazy_tensor import LazyTensor
-from .non_lazy_tensor import lazify, NonLazyTensor
-from ..utils.broadcasting import _pad_with_singletons, _matmul_broadcast_shape
+from ..utils.broadcasting import _matmul_broadcast_shape, _pad_with_singletons
 from ..utils.getitem import _noop_index
 from ..utils.memoize import cached
+from .lazy_tensor import LazyTensor
+from .non_lazy_tensor import NonLazyTensor, lazify
 
 
 def _inner_repeat(tensor, amt):
@@ -28,8 +28,7 @@ class MatmulLazyTensor(LazyTensor):
 
     def _expand_batch(self, batch_shape):
         return self.__class__(
-            self.left_lazy_tensor._expand_batch(batch_shape),
-            self.right_lazy_tensor._expand_batch(batch_shape),
+            self.left_lazy_tensor._expand_batch(batch_shape), self.right_lazy_tensor._expand_batch(batch_shape)
         )
 
     def _get_indices(self, row_index, col_index, *batch_indices):

--- a/gpytorch/lazy/mul_lazy_tensor.py
+++ b/gpytorch/lazy/mul_lazy_tensor.py
@@ -64,10 +64,7 @@ class MulLazyTensor(LazyTensor):
         return res
 
     def _mul_constant(self, other):
-        return self.__class__(
-            self.left_lazy_tensor._mul_constant(other),
-            self.right_lazy_tensor,
-        )
+        return self.__class__(self.left_lazy_tensor._mul_constant(other), self.right_lazy_tensor)
 
     def _quad_form_derivative(self, left_vecs, right_vecs):
         if left_vecs.ndimension() == 1:
@@ -110,8 +107,7 @@ class MulLazyTensor(LazyTensor):
 
     def _expand_batch(self, batch_shape):
         return self.__class__(
-            self.left_lazy_tensor._expand_batch(batch_shape),
-            self.right_lazy_tensor._expand_batch(batch_shape),
+            self.left_lazy_tensor._expand_batch(batch_shape), self.right_lazy_tensor._expand_batch(batch_shape)
         )
 
     def diag(self):

--- a/gpytorch/lazy/non_lazy_tensor.py
+++ b/gpytorch/lazy/non_lazy_tensor.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import torch
+
 from ..lazy import LazyTensor
 
 
@@ -97,7 +98,4 @@ def lazify(obj):
         raise TypeError("object of class {} cannot be made into a LazyTensor".format(obj.__class__.__name__))
 
 
-__all__ = [
-    "NonLazyTensor",
-    "lazify",
-]
+__all__ = ["NonLazyTensor", "lazify"]

--- a/gpytorch/lazy/sum_batch_lazy_tensor.py
+++ b/gpytorch/lazy/sum_batch_lazy_tensor.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 import torch
-from .block_lazy_tensor import BlockLazyTensor
+
 from ..utils.broadcasting import _pad_with_singletons
 from ..utils.getitem import _noop_index
+from .block_lazy_tensor import BlockLazyTensor
 
 
 class SumBatchLazyTensor(BlockLazyTensor):
@@ -20,6 +21,7 @@ class SumBatchLazyTensor(BlockLazyTensor):
         :attr:`block_dim` (int):
             The dimension that specifies the blocks.
     """
+
     def _add_batch_dim(self, other):
         shape = list(other.shape)
         expand_shape = list(other.shape)

--- a/gpytorch/lazy/sum_lazy_tensor.py
+++ b/gpytorch/lazy/sum_lazy_tensor.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
-from ..utils.memoize import cached
 from ..utils.broadcasting import _mul_broadcast_shape
-from .non_lazy_tensor import lazify
+from ..utils.memoize import cached
 from .lazy_tensor import LazyTensor
+from .non_lazy_tensor import lazify
 from .zero_lazy_tensor import ZeroLazyTensor
 
 
@@ -24,17 +24,11 @@ class SumLazyTensor(LazyTensor):
         return self.__class__(*expanded_tensors)
 
     def _get_indices(self, row_index, col_index, *batch_indices):
-        results = [
-            lazy_tensor._get_indices(row_index, col_index, *batch_indices)
-            for lazy_tensor in self.lazy_tensors
-        ]
+        results = [lazy_tensor._get_indices(row_index, col_index, *batch_indices) for lazy_tensor in self.lazy_tensors]
         return sum(results)
 
     def _getitem(self, row_index, col_index, *batch_indices):
-        results = [
-            lazy_tensor._getitem(row_index, col_index, *batch_indices)
-            for lazy_tensor in self.lazy_tensors
-        ]
+        results = [lazy_tensor._getitem(row_index, col_index, *batch_indices) for lazy_tensor in self.lazy_tensors]
         return SumLazyTensor(*results)
 
     def _matmul(self, rhs):

--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 
-from copy import deepcopy
-
 import math
 import warnings
+from copy import deepcopy
 from typing import Any, Optional
 
 import torch
 from torch import Tensor
 
 from ..distributions import MultivariateNormal, base_distributions
-from ..likelihoods import Likelihood
 from ..lazy import ZeroLazyTensor
+from ..likelihoods import Likelihood
 from ..utils.deprecation import _deprecate_kwarg_with_transform
 from .noise_models import FixedGaussianNoise, HomoskedasticNoise, Noise
 
@@ -24,8 +23,10 @@ class _GaussianLikelihoodBase(Likelihood):
         super().__init__()
         param_transform = kwargs.get("param_transform")
         if param_transform is not None:
-            warnings.warn("The 'param_transform' argument is now deprecated. If you want to use a different "
-                          "transformaton, specify a different 'noise_constraint' instead.")
+            warnings.warn(
+                "The 'param_transform' argument is now deprecated. If you want to use a different "
+                "transformaton, specify a different 'noise_constraint' instead."
+            )
 
         self.noise_covar = noise_covar
 
@@ -46,7 +47,7 @@ class _GaussianLikelihoodBase(Likelihood):
         # Potentially reshape the noise to deal with the multitask case
         noise = noise.view(*noise.shape[:-1], *input.event_shape)
 
-        res = (((target - mean) ** 2 + variance) / noise + noise.log() + math.log(2 * math.pi))
+        res = ((target - mean) ** 2 + variance) / noise + noise.log() + math.log(2 * math.pi)
         res = res.mul(-0.5)
         if num_event_dim > 1:  # Do appropriate summation for multitask Gaussian likelihoods
             res = res.sum(list(range(-1, -num_event_dim, -1)))
@@ -83,9 +84,7 @@ class GaussianLikelihood(_GaussianLikelihoodBase):
             kwargs, "batch_size", "batch_shape", batch_shape, lambda n: torch.Size([n])
         )
         noise_covar = HomoskedasticNoise(
-            noise_prior=noise_prior,
-            noise_constraint=noise_constraint,
-            batch_shape=batch_shape,
+            noise_prior=noise_prior, noise_constraint=noise_constraint, batch_shape=batch_shape
         )
         super().__init__(noise_covar=noise_covar)
 
@@ -130,12 +129,13 @@ class FixedNoiseGaussianLikelihood(_GaussianLikelihoodBase):
         >>> test_noises = torch.ones(21) * 0.02
         >>> pred_y = likelihood(gp_model(test_x), noise=test_noises)
     """
+
     def __init__(
         self,
         noise: Tensor,
         learn_additional_noise: Optional[bool] = False,
         batch_shape: Optional[torch.Size] = torch.Size(),
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         super().__init__(noise_covar=FixedGaussianNoise(noise=noise))
 
@@ -146,9 +146,7 @@ class FixedNoiseGaussianLikelihood(_GaussianLikelihoodBase):
             noise_prior = kwargs.get("noise_prior", None)
             noise_constraint = kwargs.get("noise_constraint", None)
             self.second_noise_covar = HomoskedasticNoise(
-                noise_prior=noise_prior,
-                noise_constraint=noise_constraint,
-                batch_shape=batch_shape,
+                noise_prior=noise_prior, noise_constraint=noise_constraint, batch_shape=batch_shape
             )
         else:
             self.second_noise_covar = None

--- a/gpytorch/likelihoods/likelihood_list.py
+++ b/gpytorch/likelihoods/likelihood_list.py
@@ -1,7 +1,8 @@
 #! /usr/bin/env python3
 
-from gpytorch.likelihoods import Likelihood
 from torch.nn import ModuleList
+
+from gpytorch.likelihoods import Likelihood
 
 
 def _get_tuple_args_(*args):
@@ -29,9 +30,7 @@ class LikelihoodList(Likelihood):
             # if noise kwarg is passed, assume it's an iterable of noise tensors
             return [
                 likelihood.forward(*args_, {**kwargs, "noise": noise_})
-                for likelihood, args_, noise_ in zip(
-                    self.likelihoods, _get_tuple_args_(*args), noise
-                )
+                for likelihood, args_, noise_ in zip(self.likelihoods, _get_tuple_args_(*args), noise)
             ]
         else:
             return [
@@ -51,12 +50,9 @@ class LikelihoodList(Likelihood):
             # if noise kwarg is passed, assume it's an iterable of noise tensors
             return [
                 likelihood(*args_, {**kwargs, "noise": noise_})
-                for likelihood, args_, noise_ in zip(
-                    self.likelihoods, _get_tuple_args_(*args), noise
-                )
+                for likelihood, args_, noise_ in zip(self.likelihoods, _get_tuple_args_(*args), noise)
             ]
         else:
             return [
-                likelihood(*args_, **kwargs)
-                for likelihood, args_ in zip(self.likelihoods, _get_tuple_args_(*args))
+                likelihood(*args_, **kwargs) for likelihood, args_ in zip(self.likelihoods, _get_tuple_args_(*args))
             ]

--- a/gpytorch/likelihoods/noise_models.py
+++ b/gpytorch/likelihoods/noise_models.py
@@ -19,27 +19,14 @@ class Noise(Module):
 
 
 class _HomoskedasticNoiseBase(Noise):
-    def __init__(
-        self,
-        noise_prior=None,
-        noise_constraint=None,
-        batch_shape=torch.Size(),
-        num_tasks=1,
-    ):
+    def __init__(self, noise_prior=None, noise_constraint=None, batch_shape=torch.Size(), num_tasks=1):
         super().__init__()
         if noise_constraint is None:
             noise_constraint = GreaterThan(1e-4)
 
-        self.register_parameter(
-            name="raw_noise", parameter=Parameter(torch.zeros(*batch_shape, num_tasks))
-        )
+        self.register_parameter(name="raw_noise", parameter=Parameter(torch.zeros(*batch_shape, num_tasks)))
         if noise_prior is not None:
-            self.register_prior(
-                "noise_prior",
-                noise_prior,
-                lambda: self.noise,
-                lambda v: self._set_noise(v),
-            )
+            self.register_prior("noise_prior", noise_prior, lambda: self.noise, lambda v: self._set_noise(v))
 
         self.register_constraint("raw_noise", noise_constraint)
 
@@ -56,9 +43,7 @@ class _HomoskedasticNoiseBase(Noise):
             value = torch.as_tensor(value).to(self.raw_noise)
         self.initialize(raw_noise=self.raw_noise_constraint.inverse_transform(value))
 
-    def forward(
-        self, *params: Any, shape: Optional[torch.Size] = None, **kwargs: Any,
-    ) -> DiagLazyTensor:
+    def forward(self, *params: Any, shape: Optional[torch.Size] = None, **kwargs: Any) -> DiagLazyTensor:
         """In the homoskedastic case, the parameters are only used to infer the required shape.
         Here are the possible scenarios:
         - non-batched noise, non-batched input, non-MT -> noise_diag shape is `n`
@@ -95,30 +80,16 @@ class _HomoskedasticNoiseBase(Noise):
 
 
 class HomoskedasticNoise(_HomoskedasticNoiseBase):
-    def __init__(
-        self, noise_prior=None, noise_constraint=None, batch_shape=torch.Size()
-    ):
+    def __init__(self, noise_prior=None, noise_constraint=None, batch_shape=torch.Size()):
         super().__init__(
-            noise_prior=noise_prior,
-            noise_constraint=noise_constraint,
-            batch_shape=batch_shape,
-            num_tasks=1,
+            noise_prior=noise_prior, noise_constraint=noise_constraint, batch_shape=batch_shape, num_tasks=1
         )
 
 
 class MultitaskHomoskedasticNoise(_HomoskedasticNoiseBase):
-    def __init__(
-        self,
-        num_tasks,
-        noise_prior=None,
-        noise_constraint=None,
-        batch_shape=torch.Size(),
-    ):
+    def __init__(self, num_tasks, noise_prior=None, noise_constraint=None, batch_shape=torch.Size()):
         super().__init__(
-            noise_prior=noise_prior,
-            noise_constraint=noise_constraint,
-            batch_shape=batch_shape,
-            num_tasks=num_tasks,
+            noise_prior=noise_prior, noise_constraint=noise_constraint, batch_shape=batch_shape, num_tasks=num_tasks
         )
 
 
@@ -149,16 +120,10 @@ class HeteroskedasticNoise(Noise):
                 output = self.noise_model(*params)
         self.noise_model.train(training)
         if not isinstance(output, MultivariateNormal):
-            raise NotImplementedError(
-                "Currently only noise models that return a MultivariateNormal are supported"
-            )
+            raise NotImplementedError("Currently only noise models that return a MultivariateNormal are supported")
         # note: this also works with MultitaskMultivariateNormal, where this
         # will return a batched DiagLazyTensors of size n x num_tasks x num_tasks
-        noise_diag = (
-            output.mean
-            if self._noise_indices is None
-            else output.mean[..., self._noise_indices]
-        )
+        noise_diag = output.mean if self._noise_indices is None else output.mean[..., self._noise_indices]
         return DiagLazyTensor(self._noise_constraint.transform(noise_diag))
 
 
@@ -168,11 +133,7 @@ class FixedGaussianNoise(Module):
         self.noise = noise
 
     def forward(
-        self,
-        *params: Any,
-        shape: Optional[torch.Size] = None,
-        noise: Optional[Tensor] = None,
-        **kwargs: Any
+        self, *params: Any, shape: Optional[torch.Size] = None, noise: Optional[Tensor] = None, **kwargs: Any
     ) -> DiagLazyTensor:
         if shape is None:
             p = params[0] if torch.is_tensor(params[0]) else params[0][0]

--- a/gpytorch/likelihoods/softmax_likelihood.py
+++ b/gpytorch/likelihoods/softmax_likelihood.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 import torch
+
 from ..distributions import base_distributions
-from .likelihood import Likelihood
 from ..utils.deprecation import _deprecate_kwarg_with_transform
+from .likelihood import Likelihood
 
 
 class SoftmaxLikelihood(Likelihood):
@@ -11,12 +12,8 @@ class SoftmaxLikelihood(Likelihood):
     Implements the Softmax (multiclass) likelihood used for GP classification.
     """
 
-    def __init__(
-        self, num_features=None, num_classes=None, mixing_weights=True, mixing_weights_prior=None, **kwargs
-    ):
-        num_classes = _deprecate_kwarg_with_transform(
-            kwargs, "n_classes", "num_classes", num_classes, lambda n: n
-        )
+    def __init__(self, num_features=None, num_classes=None, mixing_weights=True, mixing_weights_prior=None, **kwargs):
+        num_classes = _deprecate_kwarg_with_transform(kwargs, "n_classes", "num_classes", num_classes, lambda n: n)
         super().__init__()
         if num_classes is None:
             raise ValueError("num_classes is required")

--- a/gpytorch/means/linear_mean.py
+++ b/gpytorch/means/linear_mean.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 
 import torch
+
 from .mean import Mean
 
 
 class LinearMean(Mean):
     def __init__(self, input_size, batch_shape=torch.Size(), bias=True):
         super().__init__()
-        self.register_parameter(name='weights',
-                                parameter=torch.nn.Parameter(torch.randn(*batch_shape, input_size, 1)))
+        self.register_parameter(name="weights", parameter=torch.nn.Parameter(torch.randn(*batch_shape, input_size, 1)))
         if bias:
-            self.register_parameter(name='bias', parameter=torch.nn.Parameter(torch.randn(*batch_shape, 1)))
+            self.register_parameter(name="bias", parameter=torch.nn.Parameter(torch.randn(*batch_shape, 1)))
         else:
             self.bias = None
 

--- a/gpytorch/means/mean.py
+++ b/gpytorch/means/mean.py
@@ -8,6 +8,7 @@ class Mean(Module, _ClassWithDeprecatedBatchSize):
     """
     Mean function.
     """
+
     def __init__(self):
         super().__init__()
         self._register_load_state_dict_pre_hook(self._batch_shape_state_dict_hook)

--- a/gpytorch/mlls/__init__.py
+++ b/gpytorch/mlls/__init__.py
@@ -1,33 +1,30 @@
 #!/usr/bin/env python3
 
 import warnings
+
 from .added_loss_term import AddedLossTerm
 from .exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+from .gamma_robust_variational_elbo import GammaRobustVariationalELBO
 from .inducing_point_kernel_added_loss_term import InducingPointKernelAddedLossTerm
 from .marginal_log_likelihood import MarginalLogLikelihood
+from .noise_model_added_loss_term import NoiseModelAddedLossTerm
 from .predictive_log_likelihood import PredictiveLogLikelihood
-from .gamma_robust_variational_elbo import GammaRobustVariationalELBO
 from .sum_marginal_log_likelihood import SumMarginalLogLikelihood
 from .variational_elbo import VariationalELBO
-from .noise_model_added_loss_term import NoiseModelAddedLossTerm
 
 
 # Deprecated for 0.4 release
 class VariationalMarginalLogLikelihood(VariationalELBO):
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            "VariationalMarginalLogLikelihood is deprecated. Please use VariationalELBO instead.",
-            DeprecationWarning
+            "VariationalMarginalLogLikelihood is deprecated. Please use VariationalELBO instead.", DeprecationWarning
         )
         super().__init__(*args, **kwargs)
 
 
 class VariationalELBOEmpirical(VariationalELBO):
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "VariationalELBOEmpirical is deprecated. Please use VariationalELBO instead.",
-            DeprecationWarning
-        )
+        warnings.warn("VariationalELBOEmpirical is deprecated. Please use VariationalELBO instead.", DeprecationWarning)
         super().__init__(*args, **kwargs)
 
 

--- a/gpytorch/mlls/_approximate_mll.py
+++ b/gpytorch/mlls/_approximate_mll.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
-import torch
-from .marginal_log_likelihood import MarginalLogLikelihood
 from abc import ABC, abstractmethod
+
+import torch
+
+from .marginal_log_likelihood import MarginalLogLikelihood
 
 
 class _ApproximateMarginalLogLikelihood(MarginalLogLikelihood, ABC):
@@ -26,7 +28,8 @@ class _ApproximateMarginalLogLikelihood(MarginalLogLikelihood, ABC):
         :attr:`combine_terms` (bool):
             Whether or not to sum the expected NLL with the KL terms (default True)
     """
-    def __init__(self, likelihood, model, num_data, beta=1., combine_terms=True):
+
+    def __init__(self, likelihood, model, num_data, beta=1.0, combine_terms=True):
         super().__init__(likelihood, model)
         self.combine_terms = combine_terms
         self.num_data = num_data

--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-from .marginal_log_likelihood import MarginalLogLikelihood
-from ..likelihoods import _GaussianLikelihoodBase
 from ..distributions import MultivariateNormal
+from ..likelihoods import _GaussianLikelihoodBase
+from .marginal_log_likelihood import MarginalLogLikelihood
 
 
 class ExactMarginalLogLikelihood(MarginalLogLikelihood):
@@ -27,6 +27,7 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
         >>> loss = -mll(output, train_y)
         >>> loss.backward()
     """
+
     def __init__(self, likelihood, model):
         if not isinstance(likelihood, _GaussianLikelihoodBase):
             raise RuntimeError("Likelihood must be Gaussian for exact inference")
@@ -63,6 +64,7 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
 
     def pyro_factor(self, output, target, *params):
         import pyro
+
         mll = self(output, target, *params)
         pyro.factor("gp_mll", mll)
         return mll

--- a/gpytorch/mlls/gamma_robust_variational_elbo.py
+++ b/gpytorch/mlls/gamma_robust_variational_elbo.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
 import math
-import torch
+
 import numpy as np
-from ._approximate_mll import _ApproximateMarginalLogLikelihood
+import torch
+
 from ..likelihoods import _GaussianLikelihoodBase
+from ._approximate_mll import _ApproximateMarginalLogLikelihood
 
 
 class GammaRobustVariationalELBO(_ApproximateMarginalLogLikelihood):
@@ -60,6 +62,7 @@ class GammaRobustVariationalELBO(_ApproximateMarginalLogLikelihood):
     .. _Knoblauch, Jewson, Damoulas 2019:
         https://arxiv.org/pdf/1904.02063.pdf
     """
+
     def __init__(self, likelihood, model, gamma=1.03, *args, **kwargs):
         if not isinstance(likelihood, _GaussianLikelihoodBase):
             raise RuntimeError("Likelihood must be Gaussian for exact inference")

--- a/gpytorch/mlls/noise_model_added_loss_term.py
+++ b/gpytorch/mlls/noise_model_added_loss_term.py
@@ -6,6 +6,7 @@ from .added_loss_term import AddedLossTerm
 class NoiseModelAddedLossTerm(AddedLossTerm):
     def __init__(self, noise_model):
         from .exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+
         self.noise_mll = ExactMarginalLogLikelihood(noise_model.likelihood, noise_model)
 
     def loss(self, *params):

--- a/gpytorch/models/__init__.py
+++ b/gpytorch/models/__init__.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 
 import warnings
-from .gp import GP
+
+from . import deep_gps, pyro
 from .approximate_gp import ApproximateGP
 from .exact_gp import ExactGP
+from .gp import GP
 from .model_list import AbstractModelList, IndependentModelList
 from .pyro import PyroGP
-from . import deep_gps
-from . import pyro
-
 
 # Alternative name for ApproximateGP
 VariationalGP = ApproximateGP
@@ -17,20 +16,14 @@ VariationalGP = ApproximateGP
 # Deprecated for 0.4 release
 class AbstractVariationalGP(ApproximateGP):
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "AbstractVariationalGP has been renamed to ApproximateGP.",
-            DeprecationWarning
-        )
+        warnings.warn("AbstractVariationalGP has been renamed to ApproximateGP.", DeprecationWarning)
         super().__init__(*args, **kwargs)
 
 
 # Deprecated for 0.4 release
 class PyroVariationalGP(ApproximateGP):
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "PyroVariationalGP has been renamed to PyroGP.",
-            DeprecationWarning
-        )
+        warnings.warn("PyroVariationalGP has been renamed to PyroGP.", DeprecationWarning)
         super().__init__(*args, **kwargs)
 
 

--- a/gpytorch/models/deep_gps/__init__.py
+++ b/gpytorch/models/deep_gps/__init__.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
 
-from .deep_gp import AbstractDeepGPLayer, AbstractDeepGP, DeepLikelihood
+from .deep_gp import AbstractDeepGP, AbstractDeepGPLayer, DeepLikelihood
 
-__all__ = [
-    "AbstractDeepGPLayer",
-    "AbstractDeepGP",
-    "DeepLikelihood",
-]
+__all__ = ["AbstractDeepGPLayer", "AbstractDeepGP", "DeepLikelihood"]

--- a/gpytorch/models/deep_gps/deep_gp.py
+++ b/gpytorch/models/deep_gps/deep_gp.py
@@ -4,7 +4,9 @@ from gpytorch import settings
 from gpytorch.distributions import MultitaskMultivariateNormal
 from gpytorch.lazy import BlockDiagLazyTensor
 from gpytorch.likelihoods import Likelihood
-from gpytorch.models import GP, ApproximateGP
+
+from ..approximate_gp import ApproximateGP
+from ..gp import GP
 
 
 class _DeepGPVariationalStrategy(object):

--- a/gpytorch/models/deep_gps/deep_gp.py
+++ b/gpytorch/models/deep_gps/deep_gp.py
@@ -1,9 +1,10 @@
 import torch
+
+from gpytorch import settings
 from gpytorch.distributions import MultitaskMultivariateNormal
-from gpytorch.models import ApproximateGP, GP
 from gpytorch.lazy import BlockDiagLazyTensor
 from gpytorch.likelihoods import Likelihood
-from gpytorch import settings
+from gpytorch.models import GP, ApproximateGP
 
 
 class _DeepGPVariationalStrategy(object):
@@ -14,8 +15,7 @@ class _DeepGPVariationalStrategy(object):
     def sub_variational_strategies(self):
         if not hasattr(self, "_sub_variational_strategies_memo"):
             self._sub_variational_strategies_memo = [
-                module.variational_strategy for module in self.model.modules()
-                if isinstance(module, ApproximateGP)
+                module.variational_strategy for module in self.model.modules() if isinstance(module, ApproximateGP)
             ]
         return self._sub_variational_strategies_memo
 

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 
 import warnings
-import torch
 from copy import deepcopy
+
+import torch
+
+from .. import settings
 from ..distributions import MultivariateNormal
 from ..likelihoods import _GaussianLikelihoodBase
 from ..utils.broadcasting import _mul_broadcast_shape
-from .. import settings
-from .gp import GP
 from .exact_prediction_strategies import prediction_strategy
+from .gp import GP
 
 
 class ExactGP(GP):
@@ -37,7 +39,7 @@ class ExactGP(GP):
 
     @train_targets.setter
     def train_targets(self, value):
-        object.__setattr__(self, '_train_targets', value)
+        object.__setattr__(self, "_train_targets", value)
 
     def _apply(self, fn):
         if self.train_inputs is not None:
@@ -48,9 +50,7 @@ class ExactGP(GP):
     def local_load_samples(self, samples_dict, memo, prefix):
         # Pyro always puts the samples in the first batch dimension
         num_samples = next(iter(samples_dict.values())).size(0)
-        self.train_inputs = tuple(
-            tri.unsqueeze(0).expand(num_samples, *tri.shape) for tri in self.train_inputs
-        )
+        self.train_inputs = tuple(tri.unsqueeze(0).expand(num_samples, *tri.shape) for tri in self.train_inputs)
         self.train_targets = self.train_targets.unsqueeze(0).expand(num_samples, *self.train_targets.shape)
         super().local_load_samples(samples_dict, memo, prefix)
 
@@ -187,12 +187,7 @@ class ExactGP(GP):
 
         new_model.likelihood = old_likelihood.get_fantasy_likelihood(**fantasy_kwargs)
         new_model.prediction_strategy = old_pred_strat.get_fantasy_strategy(
-            inputs,
-            targets,
-            full_inputs,
-            full_targets,
-            full_output,
-            **fantasy_kwargs,
+            inputs, targets, full_inputs, full_targets, full_output, **fantasy_kwargs
         )
 
         # if the fantasies are at the same points, we need to expand the inputs for the new model
@@ -209,17 +204,12 @@ class ExactGP(GP):
             self.prediction_strategy = None
         return super(ExactGP, self).train(mode)
 
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+    def _load_from_state_dict(
+        self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
+    ):
         self.prediction_strategy = None
         super()._load_from_state_dict(
-            state_dict,
-            prefix,
-            local_metadata,
-            strict,
-            missing_keys,
-            unexpected_keys,
-            error_msgs
+            state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
         )
 
     def __call__(self, *args, **kwargs):

--- a/gpytorch/models/model_list.py
+++ b/gpytorch/models/model_list.py
@@ -3,9 +3,10 @@
 from abc import ABC, abstractproperty
 
 import torch
+from torch.nn import ModuleList
+
 from gpytorch.likelihoods import LikelihoodList
 from gpytorch.models import GP
-from torch.nn import ModuleList
 
 
 class AbstractModelList(GP, ABC):
@@ -71,8 +72,10 @@ class IndependentModelList(AbstractModelList):
             kwargs = [kwargs] * len(inputs)
 
         fantasy_models = [
-            model.get_fantasy_model(*inputs_, *targets_, **kwargs_) for model, inputs_, targets_, kwargs_
-            in zip(self.models, _get_tensor_args(*inputs), _get_tensor_args(*targets), kwargs)
+            model.get_fantasy_model(*inputs_, *targets_, **kwargs_)
+            for model, inputs_, targets_, kwargs_ in zip(
+                self.models, _get_tensor_args(*inputs), _get_tensor_args(*targets), kwargs
+            )
         ]
         return self.__class__(*fantasy_models)
 

--- a/gpytorch/models/pyro/__init__.py
+++ b/gpytorch/models/pyro/__init__.py
@@ -4,6 +4,7 @@ try:
     from .pyro_gp import PyroGP
     from ._pyro_mixin import _PyroMixin
 except ImportError:
+
     class PyroGP(object):
         def __init__(self, *args, **kwargs):
             raise RuntimeError("Cannot use a PyroGP because you dont have Pyro installed.")
@@ -19,7 +20,4 @@ except ImportError:
             raise RuntimeError("Cannot call `pyro_sample` because you dont have Pyro installed.")
 
 
-__all__ = [
-    "PyroGP",
-    "_PyroMixin",
-]
+__all__ = ["PyroGP", "_PyroMixin"]

--- a/gpytorch/models/pyro/_pyro_mixin.py
+++ b/gpytorch/models/pyro/_pyro_mixin.py
@@ -12,10 +12,9 @@ class _PyroMixin(object):
 
         # Draw samples from q(f)
         function_dist = self(input, prior=False)
-        function_dist = pyro.distributions.Normal(
-            loc=function_dist.mean,
-            scale=function_dist.stddev,
-        ).to_event(len(function_dist.event_shape) - 1)
+        function_dist = pyro.distributions.Normal(loc=function_dist.mean, scale=function_dist.stddev).to_event(
+            len(function_dist.event_shape) - 1
+        )
         return function_dist.mask(False)
 
     def pyro_model(self, input, beta=1.0, name_prefix=""):
@@ -24,21 +23,20 @@ class _PyroMixin(object):
             u_samples = pyro.sample(self.name_prefix + ".u", self.variational_strategy.prior_distribution)
 
         # Include term for GPyTorch priors
-        log_prior = torch.tensor(0., dtype=u_samples.dtype, device=u_samples.device)
+        log_prior = torch.tensor(0.0, dtype=u_samples.dtype, device=u_samples.device)
         for _, prior, closure, _ in self.named_priors():
             log_prior.add_(prior.log_prob(closure()).sum().div(self.num_data))
         pyro.factor(name_prefix + ".log_prior", log_prior)
 
         # Include factor for added loss terms
-        added_loss = torch.tensor(0., dtype=u_samples.dtype, device=u_samples.device)
+        added_loss = torch.tensor(0.0, dtype=u_samples.dtype, device=u_samples.device)
         for added_loss_term in self.added_loss_terms():
             added_loss.add_(added_loss_term.loss())
         pyro.factor(name_prefix + ".added_loss", added_loss)
 
         # Draw samples from p(f)
         function_dist = self(input, prior=True)
-        function_dist = pyro.distributions.Normal(
-            loc=function_dist.mean,
-            scale=function_dist.stddev,
-        ).to_event(len(function_dist.event_shape) - 1)
+        function_dist = pyro.distributions.Normal(loc=function_dist.mean, scale=function_dist.stddev).to_event(
+            len(function_dist.event_shape) - 1
+        )
         return function_dist.mask(False)

--- a/gpytorch/models/pyro/pyro_gp.py
+++ b/gpytorch/models/pyro/pyro_gp.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import pyro
+
 from ..gp import GP
 from ._pyro_mixin import _PyroMixin
 
@@ -54,6 +55,7 @@ class PyroGP(GP, _PyroMixin):
     .. _the beta-VAE paper:
         https://openreview.net/pdf?id=Sy2fzU9gl
     """
+
     def __init__(self, variational_strategy, likelihood, num_data, name_prefix="", beta=1.0):
         super().__init__()
         self.variational_strategy = variational_strategy

--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -6,9 +6,9 @@ import torch
 from torch import nn
 from torch.distributions import Distribution
 
+from .constraints import Interval
 from .lazy import LazyTensor
 from .utils.deprecation import DeprecationError
-from .constraints import Interval
 
 
 class Module(nn.Module):
@@ -74,7 +74,7 @@ class Module(nn.Module):
         for name, val in kwargs.items():
             if isinstance(val, int):
                 val = float(val)
-            if '.' in name:
+            if "." in name:
                 module, name = self._get_module_and_name(name)
                 module.initialize(**{name: val})
             elif not hasattr(self, name):

--- a/gpytorch/priors/torch_priors.py
+++ b/gpytorch/priors/torch_priors.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
-from torch.distributions import Gamma, MultivariateNormal, Normal, LogNormal, Uniform
+from torch.distributions import Gamma, LogNormal, MultivariateNormal, Normal, Uniform
+from torch.nn import Module as TModule
 
 from .prior import Prior
 from .utils import _bufferize_attributes, _del_attributes
-from torch.nn import Module as TModule
 
 MVN_LAZY_PROPERTIES = ("covariance_matrix", "scale_tril", "precision_matrix")
 
@@ -32,6 +32,7 @@ class LogNormalPrior(Prior, LogNormal):
     """
     Log Normal prior.
     """
+
     def __init__(self, loc, scale, validate_args=None, transform=None):
         TModule.__init__(self)
         LogNormal.__init__(self, loc=loc, scale=scale, validate_args=validate_args)
@@ -45,6 +46,7 @@ class UniformPrior(Prior, Uniform):
     """
     Uniform prior.
     """
+
     def __init__(self, a, b, validate_args=None, transform=None):
         TModule.__init__(self)
         Uniform.__init__(self, a, b, validate_args=validate_args)

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -10,7 +10,7 @@ class _feature_flag(object):
 
     @classmethod
     def off(cls):
-        return (not cls._state)
+        return not cls._state
 
     @classmethod
     def _set_state(cls, state):
@@ -123,6 +123,7 @@ class skip_posterior_variances(_feature_flag):
     ZeroLazyTensor as its covariance matrix. This allows gpytorch to not compute
     the covariance matrix when it is not needed, speeding up computations.
     """
+
     _state = False
 
 

--- a/gpytorch/test/base_likelihood_test_case.py
+++ b/gpytorch/test/base_likelihood_test_case.py
@@ -2,13 +2,14 @@
 
 from abc import abstractmethod
 
-from .base_test_case import BaseTestCase
-
 import torch
-import gpytorch
-from gpytorch.likelihoods import Likelihood
-from gpytorch.distributions import MultivariateNormal
 from torch.distributions import Distribution
+
+import gpytorch
+from gpytorch.distributions import MultivariateNormal
+from gpytorch.likelihoods import Likelihood
+
+from .base_test_case import BaseTestCase
 
 
 class BaseLikelihoodTestCase(BaseTestCase):
@@ -71,7 +72,7 @@ class BaseLikelihoodTestCase(BaseTestCase):
         output = likelihood(input)
 
         self.assertTrue(isinstance(output, Distribution))
-        self.assertEqual(output.sample().shape[-len(input.sample().shape):], input.sample().shape)
+        self.assertEqual(output.sample().shape[-len(input.sample().shape) :], input.sample().shape)
 
         # Compare against default implementation
         with gpytorch.settings.num_likelihood_samples(30000):

--- a/gpytorch/test/lazy_tensor_test_case.py
+++ b/gpytorch/test/lazy_tensor_test_case.py
@@ -2,12 +2,14 @@
 
 import math
 from abc import abstractmethod
-from itertools import product, combinations
+from itertools import combinations, product
 from unittest.mock import MagicMock, patch
 
-import gpytorch
 import torch
+
+import gpytorch
 from gpytorch.utils.gradients import _ensure_symmetric_grad
+
 from .base_test_case import BaseTestCase
 
 
@@ -260,8 +262,7 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
 
         _wrapped_cg = MagicMock(wraps=gpytorch.utils.linear_cg)
         with patch("gpytorch.utils.linear_cg", new=_wrapped_cg) as linear_cg_mock:
-            with gpytorch.settings.max_cholesky_size(math.inf if cholesky else 0), \
-                    gpytorch.settings.cg_tolerance(1e-4):
+            with gpytorch.settings.max_cholesky_size(math.inf if cholesky else 0), gpytorch.settings.cg_tolerance(1e-4):
                 # Perform the inv_matmul
                 if lhs is not None:
                     res = lazy_tensor.inv_matmul(rhs, lhs)
@@ -300,9 +301,9 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
 
             _wrapped_cg = MagicMock(wraps=gpytorch.utils.linear_cg)
             with patch("gpytorch.utils.linear_cg", new=_wrapped_cg) as linear_cg_mock:
-                with gpytorch.settings.num_trace_samples(128), \
-                        gpytorch.settings.max_cholesky_size(math.inf if cholesky else 0), \
-                        gpytorch.settings.cg_tolerance(1e-5):
+                with gpytorch.settings.num_trace_samples(128), gpytorch.settings.max_cholesky_size(
+                    math.inf if cholesky else 0
+                ), gpytorch.settings.cg_tolerance(1e-5):
 
                     res_inv_quad, res_logdet = lazy_tensor.inv_quad_logdet(
                         inv_quad_rhs=vecs, logdet=True, reduce_inv_quad=reduce_inv_quad

--- a/gpytorch/utils/deprecation.py
+++ b/gpytorch/utils/deprecation.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
-import warnings
 import functools
-import torch
+import warnings
 from unittest.mock import MagicMock
 
+import torch
 
 # TODO: Use bool instead of uint8 dtype once pytorch #21113 is in stable release
 if isinstance(torch, MagicMock):
@@ -29,7 +29,8 @@ class _ClassWithDeprecatedBatchSize(object):
                     warnings.warn(
                         f"The supplied state_dict contains a parameter ({prefix + name}) with an extra batch "
                         f"dimension ({load_param.shape} vs {param.shape}).\nDefault batch shapes are now "
-                        "deprecated in GPyTorch. You may wish to re-save your model.", DeprecationWarning
+                        "deprecated in GPyTorch. You may wish to re-save your model.",
+                        DeprecationWarning,
                     )
                     load_param.squeeze_(0)
         except Exception:
@@ -41,7 +42,7 @@ def _deprecated_function_for(old_function_name, function):
     def _deprecated_function(*args, **kwargs):
         warnings.warn(
             "The `{}` function is deprecated. Use `{}` instead".format(old_function_name, function.__name__),
-            DeprecationWarning
+            DeprecationWarning,
         )
         return function(*args, **kwargs)
 
@@ -70,7 +71,7 @@ def _deprecated_renamed_method(cls, old_method_name, new_method_name):
     def _deprecated_method(self, *args, **kwargs):
         warnings.warn(
             "The `{}` method is deprecated. Use `{}` instead".format(old_method_name, new_method_name),
-            DeprecationWarning
+            DeprecationWarning,
         )
         return getattr(self, new_method_name)(*args, **kwargs)
 

--- a/gpytorch/utils/getitem.py
+++ b/gpytorch/utils/getitem.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import torch
+
 from .. import settings
 from .broadcasting import _mul_broadcast_shape, _pad_with_singletons
 
@@ -70,9 +71,11 @@ def _compute_getitem_size(obj, indices):
                 try:
                     tensor_idx_shape = _mul_broadcast_shape(tensor_idx_shape, idx.shape)
                 except RuntimeError:
-                    raise IndexError("Incompatible tensor indices in index - got shapes of {} .".format(
-                        [idx.shape for idx in indices if torch.is_tensor(idx)]
-                    ))
+                    raise IndexError(
+                        "Incompatible tensor indices in index - got shapes of {} .".format(
+                            [idx.shape for idx in indices if torch.is_tensor(idx)]
+                        )
+                    )
 
                 if slice_after_tensor_idx:
                     tensor_idx = 0

--- a/gpytorch/utils/linear_cg.py
+++ b/gpytorch/utils/linear_cg.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
-import torch
 import warnings
+
+import torch
+
 from .. import settings
 from .deprecation import bool_compat
 
@@ -12,8 +14,7 @@ def _default_preconditioner(x):
 
 @torch.jit.script
 def _jit_linear_cg_updates(
-    result, alpha, residual_inner_prod, eps, beta, residual, precond_residual,
-    mul_storage, is_zero, curr_conjugate_vec
+    result, alpha, residual_inner_prod, eps, beta, residual, precond_residual, mul_storage, is_zero, curr_conjugate_vec
 ):
     # # Update result
     # # result_{k} = result_{k-1} + alpha_{k} p_vec_{k-1}
@@ -37,8 +38,18 @@ def _jit_linear_cg_updates(
 
 @torch.jit.script
 def _jit_linear_cg_updates_no_precond(
-    mvms, result, has_converged, alpha, residual_inner_prod, eps, beta, residual, precond_residual,
-    mul_storage, is_zero, curr_conjugate_vec
+    mvms,
+    result,
+    has_converged,
+    alpha,
+    residual_inner_prod,
+    eps,
+    beta,
+    residual,
+    precond_residual,
+    mul_storage,
+    is_zero,
+    curr_conjugate_vec,
 ):
     torch.mul(curr_conjugate_vec, mvms, out=mul_storage)
     torch.sum(mul_storage, dim=-2, keepdim=True, out=alpha)
@@ -61,8 +72,16 @@ def _jit_linear_cg_updates_no_precond(
     precond_residual = residual.clone()
 
     _jit_linear_cg_updates(
-        result, alpha, residual_inner_prod, eps, beta, residual, precond_residual,
-        mul_storage, is_zero, curr_conjugate_vec
+        result,
+        alpha,
+        residual_inner_prod,
+        eps,
+        beta,
+        residual,
+        precond_residual,
+        mul_storage,
+        is_zero,
+        curr_conjugate_vec,
     )
 
 

--- a/gpytorch/utils/quadrature.py
+++ b/gpytorch/utils/quadrature.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import math
+
 import numpy as np
 import torch
 from torch.nn import Module
+
 from .. import settings
 from .broadcasting import _pad_with_singletons
 
@@ -17,9 +19,10 @@ class GaussHermiteQuadrature1D(Module):
     This is implemented as a Module because Gauss-Hermite quadrature has a set of locations and weights that it
     should initialize one time, but that should obey parent calls to .cuda(), .double() etc.
     """
+
     def __init__(self, num_locs=settings.num_gauss_hermite_locs.value()):
         super().__init__()
-        self .num_locs = num_locs
+        self.num_locs = num_locs
 
         locations, weights = self._locs_and_weights(num_locs)
 

--- a/gpytorch/utils/transforms.py
+++ b/gpytorch/utils/transforms.py
@@ -22,8 +22,4 @@ def _get_inv_param_transform(param_transform, inv_param_transform=None):
     return reg_inv_tf
 
 
-TRANSFORM_REGISTRY = {
-    torch.exp: torch.log,
-    torch.nn.functional.softplus: inv_softplus,
-    torch.sigmoid: inv_sigmoid,
-}
+TRANSFORM_REGISTRY = {torch.exp: torch.log, torch.nn.functional.softplus: inv_softplus, torch.sigmoid: inv_sigmoid}

--- a/gpytorch/utils/woodbury.py
+++ b/gpytorch/utils/woodbury.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import torch
+
 from .. import settings
 
 
@@ -60,7 +61,7 @@ def woodbury_factor(umat, vmat, diag, logdet=False):
         torch.eye(k, dtype=scaled_inv_diag.dtype, device=scaled_inv_diag.device),
         1,
         vmat.transpose(-1, -2),
-        umat * scaled_inv_diag
+        umat * scaled_inv_diag,
     )
 
     # Compute the cholesky factor of (1/s (I_k + V^T D^-1 U))

--- a/gpytorch/variational/_variational_distribution.py
+++ b/gpytorch/variational/_variational_distribution.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import warnings
-import torch
-from ..module import Module
 from abc import ABC, abstractmethod
+
+import torch
+
+from ..module import Module
 
 
 class _VariationalDistribution(Module, ABC):
@@ -43,7 +45,7 @@ class _VariationalDistribution(Module, ABC):
             warnings.warn(
                 "_VariationalDistribution.variational_distribution is deprecated. "
                 "Please implement a `forward` method instead.",
-                DeprecationWarning
+                DeprecationWarning,
             )
             return self.variational_distribution
 
@@ -53,7 +55,7 @@ class _VariationalDistribution(Module, ABC):
             warnings.warn(
                 "_VariationalDistribution.variational_distribution is deprecated. "
                 "To get q(u), call the _VariationalDistribution object instead.",
-                DeprecationWarning
+                DeprecationWarning,
             )
             return self.forward()
         else:

--- a/gpytorch/variational/_variational_strategy.py
+++ b/gpytorch/variational/_variational_strategy.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
 
+from abc import ABC, abstractproperty
+
 import torch
+
 from .. import settings
 from ..distributions import Delta, MultivariateNormal
 from ..module import Module
 from ..utils.broadcasting import _mul_broadcast_shape
 from ..utils.memoize import cached
-from abc import ABC, abstractproperty
 
 
 class _VariationalStrategy(Module, ABC):
     """
     Abstract base class for all Variational Strategies.
     """
+
     def __init__(self, model, inducing_points, variational_distribution, learn_inducing_locations=True):
         super().__init__()
 
@@ -79,10 +82,7 @@ class _VariationalStrategy(Module, ABC):
         :rtype: torch.Tensor
         """
         with settings.max_preconditioner_size(0):
-            kl_divergence = torch.distributions.kl.kl_divergence(
-                self.variational_distribution,
-                self.prior_distribution
-            )
+            kl_divergence = torch.distributions.kl.kl_divergence(self.variational_distribution, self.prior_distribution)
         return kl_divergence
 
     def train(self, mode=True):
@@ -121,15 +121,14 @@ class _VariationalStrategy(Module, ABC):
         # Get q(f)
         if isinstance(variational_dist_u, MultivariateNormal):
             return super().__call__(
-                x, inducing_points,
+                x,
+                inducing_points,
                 inducing_values=variational_dist_u.mean,
                 variational_inducing_covar=variational_dist_u.lazy_covariance_matrix,
             )
         elif isinstance(variational_dist_u, Delta):
             return super().__call__(
-                x, inducing_points,
-                inducing_values=variational_dist_u.mean,
-                variational_inducing_covar=None,
+                x, inducing_points, inducing_values=variational_dist_u.mean, variational_inducing_covar=None
             )
         else:
             raise RuntimeError(

--- a/gpytorch/variational/delta_variational_distribution.py
+++ b/gpytorch/variational/delta_variational_distribution.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import torch
+
 from ..distributions import Delta
 from ._variational_distribution import _VariationalDistribution
 
@@ -16,6 +17,7 @@ class DeltaVariationalDistribution(_VariationalDistribution):
         for the variational parameters. This is useful for example when doing additive variational inference.
     :param float mean_init_std: (default=1e-3) Standard deviation of gaussian noise to add to the mean initialization.
     """
+
     def __init__(self, num_inducing_points, batch_shape=torch.Size([]), mean_init_std=1e-3, **kwargs):
         super().__init__(num_inducing_points=num_inducing_points, batch_shape=batch_shape, mean_init_std=mean_init_std)
         mean_init = torch.zeros(num_inducing_points)

--- a/gpytorch/variational/grid_interpolation_variational_strategy.py
+++ b/gpytorch/variational/grid_interpolation_variational_strategy.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
 import torch
+
+from ..distributions import MultivariateNormal
+from ..lazy import InterpolatedLazyTensor
 from ..utils.broadcasting import _mul_broadcast_shape
 from ..utils.interpolation import Interpolation, left_interp
-from ..lazy import InterpolatedLazyTensor
-from ..distributions import MultivariateNormal
 from ..utils.memoize import cached
 from ._variational_strategy import _VariationalStrategy
 
@@ -30,6 +31,7 @@ class GridInterpolationVariationalStrategy(_VariationalStrategy):
     :param ~gpytorch.variational.VariationalDistribution variational_distribution: A
         VariationalDistribution object that represents the form of the variational distribution :math:`q(\mathbf u)`
     """
+
     def __init__(self, model, grid_size, grid_bounds, variational_distribution):
         grid = torch.zeros(grid_size, len(grid_bounds))
         for i in range(len(grid_bounds)):
@@ -71,9 +73,7 @@ class GridInterpolationVariationalStrategy(_VariationalStrategy):
     @cached(name="prior_distribution_memo")
     def prior_distribution(self):
         out = self.model.forward(self.inducing_points)
-        res = MultivariateNormal(
-            out.mean, out.lazy_covariance_matrix.add_jitter()
-        )
+        res = MultivariateNormal(out.mean, out.lazy_covariance_matrix.add_jitter())
         return res
 
     def forward(self, x, inducing_points, inducing_values, variational_inducing_covar=None):

--- a/gpytorch/variational/mean_field_variational_distribution.py
+++ b/gpytorch/variational/mean_field_variational_distribution.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import torch
-from ..lazy import DiagLazyTensor
+
 from ..distributions import MultivariateNormal
+from ..lazy import DiagLazyTensor
 from ._variational_distribution import _VariationalDistribution
 
 
@@ -18,6 +19,7 @@ class MeanFieldVariationalDistribution(_VariationalDistribution):
         for the variational parameters. This is useful for example when doing additive variational inference.
     :param float mean_init_std: (default=1e-3) Standard deviation of gaussian noise to add to the mean initialization.
     """
+
     def __init__(self, num_inducing_points, batch_shape=torch.Size([]), mean_init_std=1e-3, **kwargs):
         super().__init__(num_inducing_points=num_inducing_points, batch_shape=batch_shape, mean_init_std=mean_init_std)
         mean_init = torch.zeros(num_inducing_points)

--- a/gpytorch/variational/multitask_variational_strategy.py
+++ b/gpytorch/variational/multitask_variational_strategy.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
-from ._variational_strategy import _VariationalStrategy
+from ..distributions import MultitaskMultivariateNormal
 from ..module import Module
 from ..utils.memoize import cached
-from ..distributions import MultitaskMultivariateNormal
+from ._variational_strategy import _VariationalStrategy
 
 
 class MultitaskVariationalStrategy(_VariationalStrategy):
@@ -18,6 +18,7 @@ class MultitaskVariationalStrategy(_VariationalStrategy):
     :param ~gpytorch.variational.VariationalStrategy base_variational_strategy: Base variational strategy
     :param int task_dim: (default=-1) Which batch dimension is the task dimension
     """
+
     def __init__(self, base_variational_strategy, num_tasks, task_dim=-1):
         Module.__init__(self)
         self.base_variational_strategy = base_variational_strategy
@@ -44,8 +45,10 @@ class MultitaskVariationalStrategy(_VariationalStrategy):
     def __call__(self, x, prior=False):
         function_dist = self.base_variational_strategy(x, prior=prior)
         if (
-            self.task_dim > 0 and self.task_dim > len(function_dist.batch_shape)
-            or self.task_dim < 0 and self.task_dim + len(function_dist.batch_shape) < 0
+            self.task_dim > 0
+            and self.task_dim > len(function_dist.batch_shape)
+            or self.task_dim < 0
+            and self.task_dim + len(function_dist.batch_shape) < 0
         ):
             return MultitaskMultivariateNormal.from_repeated_mvn(function_dist, num_tasks=self.num_tasks)
         else:

--- a/gpytorch/variational/whitened_variational_strategy.py
+++ b/gpytorch/variational/whitened_variational_strategy.py
@@ -1,23 +1,31 @@
 #!/usr/bin/env python3
 
 import math
-import torch
 import warnings
-from ..module import Module
+
+import torch
+
 from .. import settings
-from .unwhitened_variational_strategy import UnwhitenedVariationalStrategy
-from ..utils.memoize import cached
-from ..lazy import RootLazyTensor, MatmulLazyTensor, CholLazyTensor, \
-    CachedCGLazyTensor, DiagLazyTensor, BatchRepeatLazyTensor, PsdSumLazyTensor
 from ..distributions import MultivariateNormal
+from ..lazy import (
+    BatchRepeatLazyTensor,
+    CachedCGLazyTensor,
+    CholLazyTensor,
+    DiagLazyTensor,
+    MatmulLazyTensor,
+    PsdSumLazyTensor,
+    RootLazyTensor,
+)
+from ..module import Module
+from ..utils.memoize import cached
+from .unwhitened_variational_strategy import UnwhitenedVariationalStrategy
 
 
 # Deprecated on 0.4 release
 class WhitenedVariationalStrategy(UnwhitenedVariationalStrategy):
     def __init__(self, model, inducing_points, variational_distribution, learn_inducing_locations=True):
         warnings.warn(
-            "WhitenedVariationalStrategy is deprecated. Please use VariationalStrategy instead.",
-            DeprecationWarning
+            "WhitenedVariationalStrategy is deprecated. Please use VariationalStrategy instead.", DeprecationWarning
         )
         super().__init__(model, inducing_points, variational_distribution, learn_inducing_locations)
 
@@ -200,8 +208,7 @@ class WhitenedVariationalStrategy(UnwhitenedVariationalStrategy):
                 data_covariance = DiagLazyTensor((data_data_covar.diag() - interp_data_data_var).clamp(0, math.inf))
             else:
                 neg_induc_data_data_covar = torch.matmul(
-                    induc_data_covar.transpose(-1, -2).mul(-1),
-                    induc_induc_covar.inv_matmul(induc_data_covar)
+                    induc_data_covar.transpose(-1, -2).mul(-1), induc_induc_covar.inv_matmul(induc_data_covar)
                 )
                 data_covariance = data_data_covar + neg_induc_data_data_covar
             predictive_covar = PsdSumLazyTensor(predictive_covar, data_covariance)

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,21 @@
 #!/usr/bin/env python3
 
-import re
-import os
 import io
-from setuptools import setup, find_packages
+import os
+import re
+
+from setuptools import find_packages, setup
 
 
 # Get version
 def read(*names, **kwargs):
-    with io.open(
-        os.path.join(os.path.dirname(__file__), *names),
-        encoding=kwargs.get("encoding", "utf8")
-    ) as fp:
+    with io.open(os.path.join(os.path.dirname(__file__), *names), encoding=kwargs.get("encoding", "utf8")) as fp:
         return fp.read()
 
 
 def find_version(*file_paths):
     version_file = read(*file_paths)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
@@ -33,6 +30,7 @@ install_requires = [">=".join(["torch", torch_min])]
 # if recent dev version of PyTorch is installed, no need to install stable
 try:
     import torch
+
     if torch.__version__ >= torch_min:
         install_requires = []
 except ImportError:
@@ -59,34 +57,11 @@ setup(
     python_requires=">=3.6",
     install_requires=install_requires,
     extras_require={
-        "dev": [
-            "black",
-            "twine",
-        ],
-        "docs": [
-            "ipython",
-            "ipykernel",
-            "sphinx",
-            "sphinx_rtd_theme",
-            "nbsphinx",
-            "m2r",
-        ],
-        "examples": [
-            "ipython",
-            "jupyter",
-            "matplotlib",
-            "scipy",
-            "torchvision",
-        ],
-        "pyro": [
-            "pyro-ppl>=1.0.0",
-        ],
-        "keops": [
-            "pykeops>=1.1.1",
-        ],
-        "test": [
-            "flake8",
-            "flake8-print",
-        ]
+        "dev": ["black", "twine"],
+        "docs": ["ipython", "ipykernel", "sphinx", "sphinx_rtd_theme", "nbsphinx", "m2r"],
+        "examples": ["ipython", "jupyter", "matplotlib", "scipy", "torchvision"],
+        "pyro": ["pyro-ppl>=1.0.0"],
+        "keops": ["pykeops>=1.1.1"],
+        "test": ["flake8", "flake8-print"],
     },
 )

--- a/test/distributions/test_delta.py
+++ b/test/distributions/test_delta.py
@@ -2,8 +2,10 @@
 # Mostly copied from https://raw.githubusercontent.com/pyro-ppl/pyro/dev/tests/distributions/test_delta.py
 
 import unittest
+
 import numpy as np
 import torch
+
 import gpytorch.distributions as dist
 from gpytorch.test.base_test_case import BaseTestCase
 
@@ -14,13 +16,13 @@ class TestDelta(BaseTestCase, unittest.TestCase):
         self.vs = torch.tensor([[0.0], [1.0], [2.0], [3.0]])
         self.vs_expanded = self.vs.expand(4, 3)
         self.test_data = torch.tensor([[3.0], [3.0], [3.0]])
-        self.batch_test_data_1 = torch.arange(0., 4.).unsqueeze(1).expand(4, 3)
-        self.batch_test_data_2 = torch.arange(4., 8.).unsqueeze(1).expand(4, 3)
-        self.batch_test_data_3 = torch.Tensor([[3.], [3.], [3.], [3.]])
-        self.expected_support = [[[0.], [1.], [2.], [3.]]]
-        self.expected_support_non_vec = [[3.]]
-        self.analytic_mean = 3.
-        self.analytic_var = 0.
+        self.batch_test_data_1 = torch.arange(0.0, 4.0).unsqueeze(1).expand(4, 3)
+        self.batch_test_data_2 = torch.arange(4.0, 8.0).unsqueeze(1).expand(4, 3)
+        self.batch_test_data_3 = torch.Tensor([[3.0], [3.0], [3.0], [3.0]])
+        self.expected_support = [[[0.0], [1.0], [2.0], [3.0]]]
+        self.expected_support_non_vec = [[3.0]]
+        self.analytic_mean = 3.0
+        self.analytic_var = 0.0
         self.n_samples = 10
 
     def test_log_prob_sum(self):
@@ -31,15 +33,14 @@ class TestDelta(BaseTestCase, unittest.TestCase):
         log_px_torch = dist.Delta(self.vs_expanded).log_prob(self.batch_test_data_1).data
         self.assertEqual(log_px_torch.sum().item(), 0)
         log_px_torch = dist.Delta(self.vs_expanded).log_prob(self.batch_test_data_2).data
-        self.assertEqual(log_px_torch.sum().item(), float('-inf'))
+        self.assertEqual(log_px_torch.sum().item(), float("-inf"))
 
     def test_batch_log_prob_shape(self):
         assert dist.Delta(self.vs).log_prob(self.batch_test_data_3).size() == (4, 1)
         assert dist.Delta(self.v).log_prob(self.batch_test_data_3).size() == (4, 1)
 
     def test_mean_and_var(self):
-        torch_samples = [dist.Delta(self.v).sample().detach().cpu().numpy()
-                         for _ in range(self.n_samples)]
+        torch_samples = [dist.Delta(self.v).sample().detach().cpu().numpy() for _ in range(self.n_samples)]
         torch_mean = np.mean(torch_samples)
         torch_var = np.var(torch_samples)
         self.assertEqual(torch_mean, self.analytic_mean)

--- a/test/examples/test_svgp_gp_regression.py
+++ b/test/examples/test_svgp_gp_regression.py
@@ -65,8 +65,10 @@ class TestSVGPRegression(BaseTestCase, unittest.TestCase):
             self.assertLess(mean_abs_error.item(), 1e-1)
 
     def test_regression_error(
-        self, cuda=False, mll_cls=gpytorch.mlls.VariationalELBO,
-        distribution_cls=gpytorch.variational.CholeskyVariationalDistribution
+        self,
+        cuda=False,
+        mll_cls=gpytorch.mlls.VariationalELBO,
+        distribution_cls=gpytorch.variational.CholeskyVariationalDistribution,
     ):
         train_x, train_y = train_data(cuda=cuda)
         likelihood = GaussianLikelihood()
@@ -121,9 +123,6 @@ class TestSVGPRegression(BaseTestCase, unittest.TestCase):
             mll_cls=gpytorch.mlls.PredictiveLogLikelihood,
             distribution_cls=gpytorch.variational.DeltaVariationalDistribution,
         )
-
-    def test_robust_regression_error(self):
-        return self.test_regression_error(mll_cls=gpytorch.mlls.GammaRobustVariationalELBO)
 
     def test_robust_regression_error(self):
         return self.test_regression_error(mll_cls=gpytorch.mlls.GammaRobustVariationalELBO)

--- a/test/examples/test_unwhitened_svgp_regression.py
+++ b/test/examples/test_unwhitened_svgp_regression.py
@@ -9,7 +9,6 @@ import torch
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.models import ApproximateGP
 from gpytorch.test.base_test_case import BaseTestCase
-from gpytorch.test.utils import least_used_cuda_device
 from gpytorch.lazy import ExtraComputationWarning
 from torch import optim
 
@@ -44,8 +43,10 @@ class TestSVGPRegression(BaseTestCase, unittest.TestCase):
     seed = 0
 
     def test_regression_error(
-        self, cuda=False, mll_cls=gpytorch.mlls.VariationalELBO,
-        distribution_cls=gpytorch.variational.CholeskyVariationalDistribution
+        self,
+        cuda=False,
+        mll_cls=gpytorch.mlls.VariationalELBO,
+        distribution_cls=gpytorch.variational.CholeskyVariationalDistribution,
     ):
         train_x, train_y = train_data(cuda=cuda)
         likelihood = GaussianLikelihood()

--- a/test/kernels/keops/test_matern_kernel.py
+++ b/test/kernels/keops/test_matern_kernel.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
-import torch
 import unittest
-from gpytorch.kernels.keops import MaternKernel
+
+import torch
+
 from gpytorch.kernels import MaternKernel as GMaternKernel
+from gpytorch.kernels.keops import MaternKernel
 from gpytorch.test.base_kernel_test_case import BaseKernelTestCase
 
 try:
@@ -77,6 +79,7 @@ try:
             res2 = kern2(x1, x1).matmul(rhs)
 
             self.assertLess(torch.norm(res1 - res2), 1e-4)
+
 
 except ImportError:
     pass

--- a/test/kernels/keops/test_rbf_kernel.py
+++ b/test/kernels/keops/test_rbf_kernel.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
-import torch
 import unittest
-from gpytorch.kernels.keops import RBFKernel
+
+import torch
+
 from gpytorch.kernels import RBFKernel as GRBFKernel
+from gpytorch.kernels.keops import RBFKernel
 from gpytorch.test.base_kernel_test_case import BaseKernelTestCase
 
 try:
@@ -59,6 +61,7 @@ try:
             res2 = kern2(x1, x1).matmul(rhs)
 
             self.assertLess(torch.norm(res1 - res2), 1e-4)
+
 
 except ImportError:
     pass

--- a/test/kernels/test_newton_girard_additive_kernel.py
+++ b/test/kernels/test_newton_girard_additive_kernel.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 
 from unittest import TestCase
-from gpytorch.test.base_kernel_test_case import BaseKernelTestCase
-from gpytorch.kernels import RBFKernel, ScaleKernel, AdditiveKernel, NewtonGirardAdditiveKernel
+
+import torch
+
+from gpytorch.distributions import MultivariateNormal
+from gpytorch.kernels import AdditiveKernel, NewtonGirardAdditiveKernel, RBFKernel, ScaleKernel
 from gpytorch.likelihoods import GaussianLikelihood
+from gpytorch.means import ConstantMean
 from gpytorch.mlls import ExactMarginalLogLikelihood
 from gpytorch.models import ExactGP
-from gpytorch.means import ConstantMean
-from gpytorch.distributions import MultivariateNormal
-import torch
+from gpytorch.test.base_kernel_test_case import BaseKernelTestCase
 
 
 class TestNewtonGirardAdditiveKernel(TestCase, BaseKernelTestCase):
@@ -26,10 +28,10 @@ class TestNewtonGirardAdditiveKernel(TestCase, BaseKernelTestCase):
         testvals = torch.tensor([[1, 2, 3], [7, 5, 2]], dtype=torch.float)
         add_k_val = AddK(testvals, testvals).evaluate()
 
-        manual_k = ScaleKernel(AdditiveKernel(RBFKernel(active_dims=0),
-                                              RBFKernel(active_dims=1),
-                                              RBFKernel(active_dims=2)))
-        manual_k.initialize(outputscale=1.)
+        manual_k = ScaleKernel(
+            AdditiveKernel(RBFKernel(active_dims=0), RBFKernel(active_dims=1), RBFKernel(active_dims=2))
+        )
+        manual_k.initialize(outputscale=1.0)
         manual_add_k_val = manual_k(testvals, testvals).evaluate()
 
         # np.testing.assert_allclose(add_k_val.detach().numpy(), manual_add_k_val.detach().numpy(), atol=1e-5)
@@ -43,13 +45,13 @@ class TestNewtonGirardAdditiveKernel(TestCase, BaseKernelTestCase):
         testvals = torch.tensor([[1, 2, 3], [7, 5, 2]], dtype=torch.float)
         add_k_val = AddK(testvals, testvals).evaluate()
 
-        manual_k1 = ScaleKernel(AdditiveKernel(RBFKernel(active_dims=0),
-                                               RBFKernel(active_dims=1),
-                                               RBFKernel(active_dims=2)))
+        manual_k1 = ScaleKernel(
+            AdditiveKernel(RBFKernel(active_dims=0), RBFKernel(active_dims=1), RBFKernel(active_dims=2))
+        )
         manual_k1.initialize(outputscale=1 / 2)
-        manual_k2 = ScaleKernel(AdditiveKernel(RBFKernel(active_dims=[0, 1]),
-                                               RBFKernel(active_dims=[1, 2]),
-                                               RBFKernel(active_dims=[0, 2])))
+        manual_k2 = ScaleKernel(
+            AdditiveKernel(RBFKernel(active_dims=[0, 1]), RBFKernel(active_dims=[1, 2]), RBFKernel(active_dims=[0, 2]))
+        )
         manual_k2.initialize(outputscale=1 / 2)
         manual_k = AdditiveKernel(manual_k1, manual_k2)
         manual_add_k_val = manual_k(testvals, testvals).evaluate()
@@ -66,13 +68,13 @@ class TestNewtonGirardAdditiveKernel(TestCase, BaseKernelTestCase):
         testvals = torch.tensor([[1, 2, 3], [7, 5, 2]], dtype=torch.float)
         add_k_val = AddK(testvals, testvals).evaluate()
 
-        manual_k1 = ScaleKernel(AdditiveKernel(RBFKernel(active_dims=0),
-                                               RBFKernel(active_dims=1),
-                                               RBFKernel(active_dims=2)))
+        manual_k1 = ScaleKernel(
+            AdditiveKernel(RBFKernel(active_dims=0), RBFKernel(active_dims=1), RBFKernel(active_dims=2))
+        )
         manual_k1.initialize(outputscale=1 / 3)
-        manual_k2 = ScaleKernel(AdditiveKernel(RBFKernel(active_dims=[0, 1]),
-                                               RBFKernel(active_dims=[1, 2]),
-                                               RBFKernel(active_dims=[0, 2])))
+        manual_k2 = ScaleKernel(
+            AdditiveKernel(RBFKernel(active_dims=[0, 1]), RBFKernel(active_dims=[1, 2]), RBFKernel(active_dims=[0, 2]))
+        )
         manual_k2.initialize(outputscale=1 / 3)
 
         manual_k3 = ScaleKernel(AdditiveKernel(RBFKernel()))
@@ -115,7 +117,7 @@ class TestNewtonGirardAdditiveKernel(TestCase, BaseKernelTestCase):
 
     def test_ard(self):
         base_k = RBFKernel(ard_num_dims=3)
-        base_k.initialize(lengthscale=[1., 2., 3.])
+        base_k.initialize(lengthscale=[1.0, 2.0, 3.0])
         AddK = NewtonGirardAdditiveKernel(base_k, 3, max_degree=1)
 
         testvals = torch.tensor([[1, 2, 3], [7, 5, 2]], dtype=torch.float)
@@ -127,7 +129,7 @@ class TestNewtonGirardAdditiveKernel(TestCase, BaseKernelTestCase):
             k.initialize(lengthscale=i + 1)
             ks.append(k)
         manual_k = ScaleKernel(AdditiveKernel(*ks))
-        manual_k.initialize(outputscale=1.)
+        manual_k.initialize(outputscale=1.0)
         manual_add_k_val = manual_k(testvals, testvals).evaluate()
 
         # np.testing.assert_allclose(add_k_val.detach().numpy(), manual_add_k_val.detach().numpy(), atol=1e-5)
@@ -141,13 +143,13 @@ class TestNewtonGirardAdditiveKernel(TestCase, BaseKernelTestCase):
         testvals = torch.tensor([[1, 2, 3], [7, 5, 2]], dtype=torch.float)
         add_k_val = AddK(testvals, testvals).diag()
 
-        manual_k1 = ScaleKernel(AdditiveKernel(RBFKernel(active_dims=0),
-                                               RBFKernel(active_dims=1),
-                                               RBFKernel(active_dims=2)))
+        manual_k1 = ScaleKernel(
+            AdditiveKernel(RBFKernel(active_dims=0), RBFKernel(active_dims=1), RBFKernel(active_dims=2))
+        )
         manual_k1.initialize(outputscale=1 / 2)
-        manual_k2 = ScaleKernel(AdditiveKernel(RBFKernel(active_dims=[0, 1]),
-                                               RBFKernel(active_dims=[1, 2]),
-                                               RBFKernel(active_dims=[0, 2])))
+        manual_k2 = ScaleKernel(
+            AdditiveKernel(RBFKernel(active_dims=[0, 1]), RBFKernel(active_dims=[1, 2]), RBFKernel(active_dims=[0, 2]))
+        )
         manual_k2.initialize(outputscale=1 / 2)
         manual_k = AdditiveKernel(manual_k1, manual_k2)
         manual_add_k_val = manual_k(testvals, testvals).diag()

--- a/test/lazy/test_added_diag_lazy_tensor.py
+++ b/test/lazy/test_added_diag_lazy_tensor.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
 
-import torch
 import unittest
-from gpytorch.lazy import (
-    NonLazyTensor,
-    DiagLazyTensor,
-    AddedDiagLazyTensor,
-    RootLazyTensor,
-)
+
+import torch
+
+from gpytorch.lazy import AddedDiagLazyTensor, DiagLazyTensor, NonLazyTensor, RootLazyTensor
 from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase
 
 
@@ -35,12 +32,7 @@ class TestAddedDiagLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
         tensor = torch.randn(3, 5, 5)
         tensor = tensor.transpose(-1, -2).matmul(tensor).detach()
         diag = torch.tensor(
-            [
-                [1.0, 2.0, 4.0, 2.0, 3.0],
-                [2.0, 1.0, 2.0, 1.0, 4.0],
-                [1.0, 2.0, 2.0, 3.0, 4.0],
-            ],
-            requires_grad=True,
+            [[1.0, 2.0, 4.0, 2.0, 3.0], [2.0, 1.0, 2.0, 1.0, 4.0], [1.0, 2.0, 2.0, 3.0, 4.0]], requires_grad=True
         )
         return AddedDiagLazyTensor(NonLazyTensor(tensor), DiagLazyTensor(diag))
 
@@ -61,12 +53,7 @@ class TestAddedDiagLazyTensorMultiBatch(LazyTensorTestCase, unittest.TestCase):
         tensor = tensor.transpose(-1, -2).matmul(tensor).detach()
         diag = (
             torch.tensor(
-                [
-                    [1.0, 2.0, 4.0, 2.0, 3.0],
-                    [2.0, 1.0, 2.0, 1.0, 4.0],
-                    [1.0, 2.0, 2.0, 3.0, 4.0],
-                ],
-                requires_grad=True,
+                [[1.0, 2.0, 4.0, 2.0, 3.0], [2.0, 1.0, 2.0, 1.0, 4.0], [1.0, 2.0, 2.0, 3.0, 4.0]], requires_grad=True
             )
             .repeat(4, 1, 1)
             .detach()
@@ -105,9 +92,7 @@ class TestAddedDiagLazyTensorPrecondOverride(unittest.TestCase):
             return precond_closure, precond_lt, logdet
 
         overrode_lt = AddedDiagLazyTensor(
-            RootLazyTensor(tensor),
-            DiagLazyTensor(diag),
-            preconditioner_override=nonstandard_preconditioner,
+            RootLazyTensor(tensor), DiagLazyTensor(diag), preconditioner_override=nonstandard_preconditioner
         )
 
         # compute a solve - mostly to make sure that we can actually perform the solve
@@ -117,9 +102,7 @@ class TestAddedDiagLazyTensorPrecondOverride(unittest.TestCase):
 
         # gut checking that our preconditioner is not breaking anything
         self.assertEqual(standard_solve.shape, overrode_solve.shape)
-        self.assertLess(
-            torch.norm(standard_solve - overrode_solve) / standard_solve.norm(), 1.0
-        )
+        self.assertLess(torch.norm(standard_solve - overrode_solve) / standard_solve.norm(), 1.0)
 
 
 if __name__ == "__main__":

--- a/test/variational/test_grid_interpolation_variational_strategy.py
+++ b/test/variational/test_grid_interpolation_variational_strategy.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 
 import unittest
-import gpytorch
+
 import torch
+
+import gpytorch
 from gpytorch.test.variational_test_case import VariationalTestCase
 
 
 class TestGridVariationalGP(VariationalTestCase, unittest.TestCase):
     def _make_model_and_likelihood(
-        self, num_inducing=8,
-        batch_shape=torch.Size([]), inducing_batch_shape=torch.Size([]),
+        self,
+        num_inducing=8,
+        batch_shape=torch.Size([]),
+        inducing_batch_shape=torch.Size([]),
         strategy_cls=gpytorch.variational.VariationalStrategy,
         distribution_cls=gpytorch.variational.CholeskyVariationalDistribution,
         constant_mean=True,
@@ -21,7 +25,7 @@ class TestGridVariationalGP(VariationalTestCase, unittest.TestCase):
                 super().__init__(variational_strategy)
                 if constant_mean:
                     self.mean_module = gpytorch.means.ConstantMean()
-                    self.mean_module.initialize(constant=1.)
+                    self.mean_module.initialize(constant=1.0)
                 else:
                     self.mean_module = gpytorch.means.ZeroMean()
                 self.covar_module = gpytorch.kernels.ScaleKernel(gpytorch.kernels.RBFKernel())

--- a/test/variational/test_multitask_variational_strategy.py
+++ b/test/variational/test_multitask_variational_strategy.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import unittest
-import gpytorch
+
 import torch
+
+import gpytorch
 from gpytorch.test.variational_test_case import VariationalTestCase
 
 
@@ -14,7 +16,8 @@ def strategy_cls(model, inducing_points, variational_distribution, learn_inducin
     return gpytorch.variational.MultitaskVariationalStrategy(
         gpytorch.variational.VariationalStrategy(
             model, inducing_points, variational_distribution, learn_inducing_locations
-        ), num_tasks=2
+        ),
+        num_tasks=2,
     )
 
 
@@ -55,9 +58,7 @@ class TestMultitaskVariationalGP(VariationalTestCase, unittest.TestCase):
     def test_eval_iteration(self, *args, expected_batch_shape=None, **kwargs):
         expected_batch_shape = expected_batch_shape or self.batch_shape
         expected_batch_shape = expected_batch_shape[:-1]
-        cg_mock, cholesky_mock = super().test_eval_iteration(
-            *args, expected_batch_shape=expected_batch_shape, **kwargs
-        )
+        cg_mock, cholesky_mock = super().test_eval_iteration(*args, expected_batch_shape=expected_batch_shape, **kwargs)
         self.assertFalse(cg_mock.called)
         self.assertEqual(cholesky_mock.call_count, 1)  # One to compute cache, that's it!
 

--- a/test/variational/test_whitened_variational_strategy.py
+++ b/test/variational/test_whitened_variational_strategy.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
-import warnings
 import unittest
-import gpytorch
-import torch
+import warnings
 from unittest.mock import MagicMock, patch
+
+import torch
+
+import gpytorch
 from gpytorch.lazy import ExtraComputationWarning
 from gpytorch.test.base_test_case import BaseTestCase
 
@@ -27,8 +29,10 @@ class TestVariationalGP(BaseTestCase, unittest.TestCase):
         return gpytorch.variational.WhitenedVariationalStrategy
 
     def _make_model_and_likelihood(
-        self, num_inducing=16,
-        batch_shape=torch.Size([]), inducing_batch_shape=torch.Size([]),
+        self,
+        num_inducing=16,
+        batch_shape=torch.Size([]),
+        inducing_batch_shape=torch.Size([]),
         strategy_cls=gpytorch.variational.VariationalStrategy,
         distribution_cls=gpytorch.variational.CholeskyVariationalDistribution,
         constant_mean=True,
@@ -37,12 +41,12 @@ class TestVariationalGP(BaseTestCase, unittest.TestCase):
             def __init__(self, inducing_points):
                 variational_distribution = distribution_cls(num_inducing, batch_shape=batch_shape)
                 variational_strategy = strategy_cls(
-                    self, inducing_points, variational_distribution, learn_inducing_locations=True,
+                    self, inducing_points, variational_distribution, learn_inducing_locations=True
                 )
                 super().__init__(variational_strategy)
                 if constant_mean:
                     self.mean_module = gpytorch.means.ConstantMean()
-                    self.mean_module.initialize(constant=1.)
+                    self.mean_module.initialize(constant=1.0)
                 else:
                     self.mean_module = gpytorch.means.ZeroMean()
                 self.covar_module = gpytorch.kernels.ScaleKernel(gpytorch.kernels.RBFKernel())
@@ -57,10 +61,7 @@ class TestVariationalGP(BaseTestCase, unittest.TestCase):
         with warnings.catch_warnings(record=True):
             return _SVGPRegressionModel(inducing_points), self.likelihood_cls()
 
-    def _training_iter(
-        self, model, likelihood, batch_shape=torch.Size([]),
-        mll_cls=gpytorch.mlls.VariationalELBO,
-    ):
+    def _training_iter(self, model, likelihood, batch_shape=torch.Size([]), mll_cls=gpytorch.mlls.VariationalELBO):
         train_x = torch.randn(*batch_shape, 32, 2).clamp(-2.5, 2.5)
         train_y = torch.linspace(-1, 1, self.event_shape[0])
         train_y = train_y.view(self.event_shape[0], *([1] * (len(self.event_shape) - 1)))
@@ -108,8 +109,12 @@ class TestVariationalGP(BaseTestCase, unittest.TestCase):
         return gpytorch.likelihoods.GaussianLikelihood
 
     def test_eval_iteration(
-        self, data_batch_shape=None, inducing_batch_shape=None, model_batch_shape=None,
-        eval_data_batch_shape=None, expected_batch_shape=None,
+        self,
+        data_batch_shape=None,
+        inducing_batch_shape=None,
+        model_batch_shape=None,
+        eval_data_batch_shape=None,
+        expected_batch_shape=None,
     ):
         # Batch shapes
         model_batch_shape = model_batch_shape if model_batch_shape is not None else self.batch_shape
@@ -126,15 +131,14 @@ class TestVariationalGP(BaseTestCase, unittest.TestCase):
 
         # Make model and likelihood
         model, likelihood = self._make_model_and_likelihood(
-            batch_shape=model_batch_shape, inducing_batch_shape=inducing_batch_shape,
-            distribution_cls=self.distribution_cls, strategy_cls=self.strategy_cls,
+            batch_shape=model_batch_shape,
+            inducing_batch_shape=inducing_batch_shape,
+            distribution_cls=self.distribution_cls,
+            strategy_cls=self.strategy_cls,
         )
 
         # Do one forward pass
-        self._training_iter(
-            model, likelihood, data_batch_shape,
-            mll_cls=self.mll_cls,
-        )
+        self._training_iter(model, likelihood, data_batch_shape, mll_cls=self.mll_cls)
 
         # Now do evaluatioj
         with _cholesky_mock as cholesky_mock, _cg_mock as cg_mock:
@@ -146,8 +150,12 @@ class TestVariationalGP(BaseTestCase, unittest.TestCase):
             return cg_mock, cholesky_mock
 
     def test_training_iteration(
-        self, data_batch_shape=None, inducing_batch_shape=None, model_batch_shape=None,
-        expected_batch_shape=None, constant_mean=True
+        self,
+        data_batch_shape=None,
+        inducing_batch_shape=None,
+        model_batch_shape=None,
+        expected_batch_shape=None,
+        constant_mean=True,
     ):
         # Batch shapes
         model_batch_shape = model_batch_shape if model_batch_shape is not None else self.batch_shape
@@ -163,8 +171,10 @@ class TestVariationalGP(BaseTestCase, unittest.TestCase):
 
         # Make model and likelihood
         model, likelihood = self._make_model_and_likelihood(
-            batch_shape=model_batch_shape, inducing_batch_shape=inducing_batch_shape,
-            distribution_cls=self.distribution_cls, strategy_cls=self.strategy_cls,
+            batch_shape=model_batch_shape,
+            inducing_batch_shape=inducing_batch_shape,
+            distribution_cls=self.distribution_cls,
+            strategy_cls=self.strategy_cls,
             constant_mean=constant_mean,
         )
 
@@ -172,16 +182,10 @@ class TestVariationalGP(BaseTestCase, unittest.TestCase):
         with _cholesky_mock as cholesky_mock, _cg_mock as cg_mock:
             # Iter 1
             self.assertEqual(model.variational_strategy.variational_params_initialized.item(), 0)
-            self._training_iter(
-                model, likelihood, data_batch_shape,
-                mll_cls=self.mll_cls
-            )
+            self._training_iter(model, likelihood, data_batch_shape, mll_cls=self.mll_cls)
             self.assertEqual(model.variational_strategy.variational_params_initialized.item(), 1)
             # Iter 2
-            output, loss = self._training_iter(
-                model, likelihood, data_batch_shape,
-                mll_cls=self.mll_cls
-            )
+            output, loss = self._training_iter(model, likelihood, data_batch_shape, mll_cls=self.mll_cls)
             self.assertEqual(output.batch_shape, expected_batch_shape)
             self.assertEqual(output.event_shape, self.event_shape)
             self.assertEqual(loss.shape, expected_batch_shape)


### PR DESCRIPTION
Now if you do:
```
$ pip install pre-commit
$ pre-commit install
```
Every time you commit it'll run flake8, isort, black, and a few other basic fixes (change `\r\n -> \n`, make sure end of file has a blank line, etc. You'll get output that looks like this:
```
(base) ➜  gpytorch git:(precommit_hooks) ✗ git commit -m "Run black"      
Flake8...................................................................Passed
Check for byte-order marker..............................................Passed
Check for case conflicts.................................................Passed
Check for merge conflicts................................................Passed
Fix End of Files.........................................................Passed
Forbid new submodules....................................................Passed
Mixed line ending........................................................Passed
Trim Trailing Whitespace.................................................Passed
Debug Statements (Python)................................................Passed
black....................................................................Passed
seed isort known_third_party.............................................Passed
isort....................................................................Passed
Check file encoding......................................................Passed
Non-executable shell script filename ends in .sh.....(no files to check)Skipped
Forbid binaries......................................(no files to check)Skipped
CRLF end-lines checker...................................................Passed
No-tabs checker..........................................................Passed
```

If we wanted to make this mandatory / strongly encouraged, we could add a section to the dev/contributors section of the README.

Before we merge this idea in, let's merge in #918 and #903 to avoid massive merge conflicts because those are relatively large PRs.
