### PR TITLE
Add deterministic_probes setting to improve L-BFGS convergence

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = gpytorch,matplotlib,numpy,pyro,setuptools,sphinx_rtd_theme,torch
+known_third_party = matplotlib,numpy,pyro,setuptools,sphinx_rtd_theme,torch

--- a/gpytorch/functions/_inv_quad_log_det.py
+++ b/gpytorch/functions/_inv_quad_log_det.py
@@ -69,15 +69,48 @@ class InvQuadLogDet(Function):
         if (probe_vectors is None or probe_vector_norms is None) and logdet:
             num_random_probes = settings.num_trace_samples.value()
             if preconditioner is None:
-                probe_vectors = torch.empty(matrix_shape[-1], num_random_probes, dtype=dtype, device=device)
-                probe_vectors.bernoulli_().mul_(2).add_(-1)
+                if settings.deterministic_probes.on():
+                    if settings.deterministic_probes.probe_vectors is None:
+                        probe_vectors = torch.empty(matrix_shape[-1], num_random_probes, dtype=dtype, device=device)
+                        probe_vectors.bernoulli_().mul_(2).add_(-1)
+                        settings.deterministic_probes.probe_vectors = probe_vectors
+                    else:
+                        probe_vectors = settings.deterministic_probes.probe_vectors
+                else:
+                    probe_vectors = torch.empty(matrix_shape[-1], num_random_probes, dtype=dtype, device=device)
+                    probe_vectors.bernoulli_().mul_(2).add_(-1)
+
                 probe_vector_norms = torch.norm(probe_vectors, 2, dim=-2, keepdim=True)
                 if batch_shape is not None:
                     probe_vectors = probe_vectors.expand(*batch_shape, matrix_shape[-1], num_random_probes)
                     probe_vector_norms = probe_vector_norms.expand(*batch_shape, 1, num_random_probes)
-            else:
-                probe_vectors = precond_lt.zero_mean_mvn_samples(num_random_probes)
-                probe_vectors = probe_vectors.unsqueeze(-2).transpose(0, -2).squeeze(0).transpose(-2, -1)
+            else:  # When preconditioning, probe vectors must be drawn from N(0, P)
+                if precond_lt.size()[-2:] == torch.Size([1, 1]):
+                    covar_root = precond_lt.evaluate().sqrt()
+                else:
+                    covar_root = precond_lt.root_decomposition().root
+
+                if settings.deterministic_probes.on():
+                    base_samples = settings.deterministic_probes.probe_vectors
+                    if base_samples is None or covar_root.size(-1) != base_samples.size(-2):
+                        base_samples = torch.randn(
+                            *precond_lt.batch_shape, covar_root.size(-1),
+                            num_random_probes,
+                            dtype=precond_lt.dtype,
+                            device=precond_lt.device,
+                        )
+                        settings.deterministic_probes.probe_vectors = base_samples
+
+                    probe_vectors = covar_root.matmul(base_samples).permute(-1, *range(precond_lt.dim() - 1))
+                else:
+                    base_samples = torch.randn(
+                        *precond_lt.batch_shape, covar_root.size(-1),
+                        num_random_probes,
+                        dtype=precond_lt.dtype,
+                        device=precond_lt.device,
+                    )
+                    probe_vectors = precond_lt.zero_mean_mvn_samples(num_random_probes)
+                probe_vectors = probe_vectors.unsqueeze(-2).transpose(0, -2).squeeze(0).transpose(-2, -1).contiguous()
                 probe_vector_norms = torch.norm(probe_vectors, p=2, dim=-2, keepdim=True)
             probe_vectors = probe_vectors.div(probe_vector_norms)
 

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -143,6 +143,9 @@ class deterministic_probes(_feature_flag):
     Whether or not to resample probe vectors every iteration of training. If True, we use the same set of probe vectors
     for computing log determinants each iteration. This introduces small amounts of bias in to the MLL, but allows us
     to compute a deterministic estimate of it which makes optimizers like L-BFGS more viable choices.
+
+    NOTE: Currently, probe vectors are cached in a global scope. Therefore, this setting cannot be used
+    if multiple independent GP models are being trained in the same context (i.e., it works fine with a single GP model)
     """
 
     _state = False

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -138,6 +138,22 @@ class detach_test_caches(_feature_flag):
     _state = True
 
 
+class deterministic_probes(_feature_flag):
+    """
+    Whether or not to resample probe vectors every iteration of training. If True, we use the same set of probe vectors
+    for computing log determinants each iteration. This introduces small amounts of bias in to the MLL, but allows us
+    to compute a deterministic estimate of it which makes optimizers like L-BFGS more viable choices.
+    """
+
+    _state = False
+    probe_vectors = None
+
+    @classmethod
+    def _set_state(cls, state):
+        cls._state = state
+        cls.probe_vectors = None
+
+
 class debug(_feature_flag):
     """
     Whether or not to perform "safety" checks on the supplied data.


### PR DESCRIPTION
This adds a flag that causes us to not resample probe vectors for our log det estimates each iterations. This will result in some mild bias in our derivatives, but reduced stochasticity in the MLL value. Using this flag should improve the convergence of methods like L-BFGS that don't deal well with even mild amounts of stochasticity in a loss function.