### PR TITLE
Add preconditioner override option for AddedDiagLazyTensor

### DIFF
--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -97,14 +97,18 @@ class AddedDiagLazyTensor(SumLazyTensor):
                     )
 
                     eye = torch.eye(
-                        k, dtype=self._piv_chol_self.dtype, device=self._piv_chol_self.device
+                        k,
+                        dtype=self._piv_chol_self.dtype,
+                        device=self._piv_chol_self.device,
                     )
 
                     if self.constant_diag:
                         # We can factor out the noise for for both QR and solves.
                         self.noise_constant = self._noise[0].squeeze()
                         self._q_cache, self._r_cache = torch.qr(
-                            torch.cat((self._piv_chol_self, self.noise_constant.sqrt() * eye))
+                            torch.cat(
+                                (self._piv_chol_self, self.noise_constant.sqrt() * eye)
+                            )
                         )
                         self._q_cache = self._q_cache[:n, :]
 
@@ -164,7 +168,8 @@ class AddedDiagLazyTensor(SumLazyTensor):
                 if hasattr(self, "_q_cache"):
                     if self.constant_diag:
                         return (1 / self.noise_constant) * (
-                            tensor - self._q_cache.matmul(self._q_cache.t().matmul(tensor))
+                            tensor
+                            - self._q_cache.matmul(self._q_cache.t().matmul(tensor))
                         )
 
                     else:
@@ -182,4 +187,8 @@ class AddedDiagLazyTensor(SumLazyTensor):
                     )
                     return res
 
-            return precondition_closure, self.preconditioner_lt, self._precond_logdet_cache
+            return (
+                precondition_closure,
+                self.preconditioner_lt,
+                self._precond_logdet_cache,
+            )

--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -68,127 +68,118 @@ class AddedDiagLazyTensor(SumLazyTensor):
     def _preconditioner(self):
         if self.preconditioner_override is not None:
             return self.preconditioner_override(self)
-        else:
-            if (
-                settings.max_preconditioner_size.value() == 0
-                or self.size(-1) < settings.min_preconditioning_size.value()
-            ):
+
+        if (
+            settings.max_preconditioner_size.value() == 0
+            or self.size(-1) < settings.min_preconditioning_size.value()
+        ):
+            return None, None, None
+
+        if not (hasattr(self, "_woodbury_cache") or hasattr(self, "self._q_cache")):
+            max_iter = settings.max_preconditioner_size.value()
+            self._piv_chol_self = pivoted_cholesky.pivoted_cholesky(
+                self._lazy_tensor, max_iter
+            )
+            if torch.any(torch.isnan(self._piv_chol_self)).item():
+                warnings.warn(
+                    "NaNs encountered in preconditioner computation. Attempting to continue without preconditioning."
+                )
                 return None, None, None
 
-            if not (hasattr(self, "_woodbury_cache") or hasattr(self, "self._q_cache")):
-                max_iter = settings.max_preconditioner_size.value()
-                self._piv_chol_self = pivoted_cholesky.pivoted_cholesky(
-                    self._lazy_tensor, max_iter
+            if (
+                self._piv_chol_self.dim() == 2
+            ):  # TODO: Whenever PyTorch supports batch mode
+                *batch_shape, n, k = self._piv_chol_self.shape
+                self._noise = self._diag_tensor.diag().unsqueeze(-1)
+
+                self.constant_diag = torch.equal(
+                    self._noise, self._noise[0] * torch.ones_like(self._noise)
                 )
-                if torch.any(torch.isnan(self._piv_chol_self)).item():
-                    warnings.warn(
-                        "NaNs encountered in preconditioner computation. Attempting to continue without preconditioning."
+
+                eye = torch.eye(
+                    k, dtype=self._piv_chol_self.dtype, device=self._piv_chol_self.device
+                )
+
+                if self.constant_diag:
+                    # We can factor out the noise for for both QR and solves.
+                    self.noise_constant = self._noise[0].squeeze()
+                    self._q_cache, self._r_cache = torch.qr(
+                        torch.cat((self._piv_chol_self, self.noise_constant.sqrt() * eye))
                     )
-                    return None, None, None
+                    self._q_cache = self._q_cache[:n, :]
 
-                if (
-                    self._piv_chol_self.dim() == 2
-                ):  # TODO: Whenever PyTorch supports batch mode
-                    *batch_shape, n, k = self._piv_chol_self.shape
-                    self._noise = self._diag_tensor.diag().unsqueeze(-1)
-
-                    self.constant_diag = torch.equal(
-                        self._noise, self._noise[0] * torch.ones_like(self._noise)
+                    # Use the matrix determinant lemma for the logdet, using the fact that R'R = L_k'L_k + s*I
+                    logdet = (
+                        self._r_cache.diagonal(dim1=-1, dim2=-2)
+                        .abs()
+                        .log()
+                        .sum(-1)
+                        .mul(2)
                     )
-
-                    eye = torch.eye(
-                        k,
-                        dtype=self._piv_chol_self.dtype,
-                        device=self._piv_chol_self.device,
+                    logdet = logdet + (n - k) * self.noise_constant.log()
+                    self._precond_logdet_cache = (
+                        logdet.view(*batch_shape)
+                        if len(batch_shape)
+                        else logdet.squeeze()
                     )
-
-                    if self.constant_diag:
-                        # We can factor out the noise for for both QR and solves.
-                        self.noise_constant = self._noise[0].squeeze()
-                        self._q_cache, self._r_cache = torch.qr(
-                            torch.cat(
-                                (self._piv_chol_self, self.noise_constant.sqrt() * eye)
-                            )
-                        )
-                        self._q_cache = self._q_cache[:n, :]
-
-                        # Use the matrix determinant lemma for the logdet, using the fact that R'R = L_k'L_k + s*I
-                        logdet = (
-                            self._r_cache.diagonal(dim1=-1, dim2=-2)
-                            .abs()
-                            .log()
-                            .sum(-1)
-                            .mul(2)
-                        )
-                        logdet = logdet + (n - k) * self.noise_constant.log()
-                        self._precond_logdet_cache = (
-                            logdet.view(*batch_shape)
-                            if len(batch_shape)
-                            else logdet.squeeze()
-                        )
-
-                    else:
-                        # With non-constant diagonals, we cant factor out the noise as easily
-                        self._q_cache, self._r_cache = torch.qr(
-                            torch.cat((self._piv_chol_self / self._noise.sqrt(), eye))
-                        )
-                        self._q_cache = self._q_cache[:n, :] / self._noise.sqrt()
-
-                        logdet = self._r_cache.diagonal(dim1=-1, dim2=-2).abs().log().sum(
-                            -1
-                        ).mul(2) - (1.0 / self._noise).log().sum([-1, -2])
-                        self._precond_logdet_cache = (
-                            logdet.view(*batch_shape)
-                            if len(batch_shape)
-                            else logdet.squeeze()
-                        )
 
                 else:
-                    self._woodbury_cache, self._inv_scale, self._precond_logdet_cache = woodbury.woodbury_factor(
-                        self._piv_chol_self,
-                        self._piv_chol_self,
-                        self._diag_tensor.diag(),
-                        logdet=True,
+                    # With non-constant diagonals, we cant factor out the noise as easily
+                    self._q_cache, self._r_cache = torch.qr(
+                        torch.cat((self._piv_chol_self / self._noise.sqrt(), eye))
                     )
-                    self._scaled_inv_diag = self._inv_scale / self._diag_tensor.diag().unsqueeze(
+                    self._q_cache = self._q_cache[:n, :] / self._noise.sqrt()
+
+                    logdet = self._r_cache.diagonal(dim1=-1, dim2=-2).abs().log().sum(
                         -1
-                    )
-                    self._scaled_inv_diag_piv_chol_self = (
-                        self._piv_chol_self * self._scaled_inv_diag
+                    ).mul(2) - (1.0 / self._noise).log().sum([-1, -2])
+                    self._precond_logdet_cache = (
+                        logdet.view(*batch_shape)
+                        if len(batch_shape)
+                        else logdet.squeeze()
                     )
 
-                self.preconditioner_lt = PsdSumLazyTensor(
-                    RootLazyTensor(self._piv_chol_self), self._diag_tensor
+            else:
+                self._woodbury_cache, self._inv_scale, self._precond_logdet_cache = woodbury.woodbury_factor(
+                    self._piv_chol_self,
+                    self._piv_chol_self,
+                    self._diag_tensor.diag(),
+                    logdet=True,
+                )
+                self._scaled_inv_diag = self._inv_scale / self._diag_tensor.diag().unsqueeze(
+                    -1
+                )
+                self._scaled_inv_diag_piv_chol_self = (
+                    self._piv_chol_self * self._scaled_inv_diag
                 )
 
-            # NOTE to future self:
-            # We cannot memoize this precondition closure
-            # It causes a memory leak otherwise
-            def precondition_closure(tensor):
-                if hasattr(self, "_q_cache"):
-                    if self.constant_diag:
-                        return (1 / self.noise_constant) * (
-                            tensor
-                            - self._q_cache.matmul(self._q_cache.t().matmul(tensor))
-                        )
+            self.preconditioner_lt = PsdSumLazyTensor(
+                RootLazyTensor(self._piv_chol_self), self._diag_tensor
+            )
 
-                    else:
-                        return (tensor / self._noise) - self._q_cache.matmul(
-                            self._q_cache.t().matmul(tensor)
-                        )
+        # NOTE to future self:
+        # We cannot memoize this precondition closure
+        # It causes a memory leak otherwise
+        def precondition_closure(tensor):
+            if hasattr(self, "_q_cache"):
+                if self.constant_diag:
+                    return (1 / self.noise_constant) * (
+                        tensor - self._q_cache.matmul(self._q_cache.t().matmul(tensor))
+                    )
 
                 else:
-                    res = woodbury.woodbury_solve(
-                        tensor,
-                        self._scaled_inv_diag_piv_chol_self,
-                        self._woodbury_cache,
-                        self._scaled_inv_diag,
-                        self._inv_scale,
+                    return (tensor / self._noise) - self._q_cache.matmul(
+                        self._q_cache.t().matmul(tensor)
                     )
-                    return res
 
-            return (
-                precondition_closure,
-                self.preconditioner_lt,
-                self._precond_logdet_cache,
-            )
+            else:
+                res = woodbury.woodbury_solve(
+                    tensor,
+                    self._scaled_inv_diag_piv_chol_self,
+                    self._woodbury_cache,
+                    self._scaled_inv_diag,
+                    self._inv_scale,
+                )
+                return res
+
+        return (precondition_closure, self.preconditioner_lt, self._precond_logdet_cache)

--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -17,16 +17,23 @@ class AddedDiagLazyTensor(SumLazyTensor):
     a DiagLazyTensor.
     """
 
-    def __init__(self, *lazy_tensors):
+    def __init__(self, *lazy_tensors, preconditioner_override=None):
         lazy_tensors = list(lazy_tensors)
-        super(AddedDiagLazyTensor, self).__init__(*lazy_tensors)
+        super(AddedDiagLazyTensor, self).__init__(
+            *lazy_tensors, preconditioner_override=preconditioner_override
+        )
         if len(lazy_tensors) > 2:
             raise RuntimeError("An AddedDiagLazyTensor can only have two components")
 
         broadcasting._mul_broadcast_shape(lazy_tensors[0].shape, lazy_tensors[1].shape)
 
-        if isinstance(lazy_tensors[0], DiagLazyTensor) and isinstance(lazy_tensors[1], DiagLazyTensor):
-            raise RuntimeError("Trying to lazily add two DiagLazyTensors. " "Create a single DiagLazyTensor instead.")
+        if isinstance(lazy_tensors[0], DiagLazyTensor) and isinstance(
+            lazy_tensors[1], DiagLazyTensor
+        ):
+            raise RuntimeError(
+                "Trying to lazily add two DiagLazyTensors. "
+                "Create a single DiagLazyTensor instead."
+            )
         elif isinstance(lazy_tensors[0], DiagLazyTensor):
             self._diag_tensor = lazy_tensors[0]
             self._lazy_tensor = lazy_tensors[1]
@@ -34,13 +41,21 @@ class AddedDiagLazyTensor(SumLazyTensor):
             self._diag_tensor = lazy_tensors[1]
             self._lazy_tensor = lazy_tensors[0]
         else:
-            raise RuntimeError("One of the LazyTensors input to AddedDiagLazyTensor must be a DiagLazyTensor!")
+            raise RuntimeError(
+                "One of the LazyTensors input to AddedDiagLazyTensor must be a DiagLazyTensor!"
+            )
+
+        self.preconditioner_override = preconditioner_override
 
     def _matmul(self, rhs):
-        return torch.addcmul(self._lazy_tensor._matmul(rhs), self._diag_tensor._diag.unsqueeze(-1), rhs)
+        return torch.addcmul(
+            self._lazy_tensor._matmul(rhs), self._diag_tensor._diag.unsqueeze(-1), rhs
+        )
 
     def add_diag(self, added_diag):
-        return AddedDiagLazyTensor(self._lazy_tensor, self._diag_tensor.add_diag(added_diag))
+        return AddedDiagLazyTensor(
+            self._lazy_tensor, self._diag_tensor.add_diag(added_diag)
+        )
 
     def __add__(self, other):
         from .diag_lazy_tensor import DiagLazyTensor
@@ -51,25 +66,42 @@ class AddedDiagLazyTensor(SumLazyTensor):
             return AddedDiagLazyTensor(self._lazy_tensor + other, self._diag_tensor)
 
     def _preconditioner(self):
-        if settings.max_preconditioner_size.value() == 0 or self.size(-1) < settings.min_preconditioning_size.value():
+        if self.preconditioner_override is not None:
+            return self.preconditioner_override(self)
+        else:
+            return self._default_preconditioner()
+
+    def _default_preconditioner(self):
+        if (
+            settings.max_preconditioner_size.value() == 0
+            or self.size(-1) < settings.min_preconditioning_size.value()
+        ):
             return None, None, None
 
         if not (hasattr(self, "_woodbury_cache") or hasattr(self, "self._q_cache")):
             max_iter = settings.max_preconditioner_size.value()
-            self._piv_chol_self = pivoted_cholesky.pivoted_cholesky(self._lazy_tensor, max_iter)
+            self._piv_chol_self = pivoted_cholesky.pivoted_cholesky(
+                self._lazy_tensor, max_iter
+            )
             if torch.any(torch.isnan(self._piv_chol_self)).item():
                 warnings.warn(
                     "NaNs encountered in preconditioner computation. Attempting to continue without preconditioning."
                 )
                 return None, None, None
 
-            if self._piv_chol_self.dim() == 2:  # TODO: Whenever PyTorch supports batch mode
+            if (
+                self._piv_chol_self.dim() == 2
+            ):  # TODO: Whenever PyTorch supports batch mode
                 *batch_shape, n, k = self._piv_chol_self.shape
                 self._noise = self._diag_tensor.diag().unsqueeze(-1)
 
-                self.constant_diag = torch.equal(self._noise, self._noise[0] * torch.ones_like(self._noise))
+                self.constant_diag = torch.equal(
+                    self._noise, self._noise[0] * torch.ones_like(self._noise)
+                )
 
-                eye = torch.eye(k, dtype=self._piv_chol_self.dtype, device=self._piv_chol_self.device)
+                eye = torch.eye(
+                    k, dtype=self._piv_chol_self.dtype, device=self._piv_chol_self.device
+                )
 
                 if self.constant_diag:
                     # We can factor out the noise for for both QR and solves.
@@ -80,28 +112,53 @@ class AddedDiagLazyTensor(SumLazyTensor):
                     self._q_cache = self._q_cache[:n, :]
 
                     # Use the matrix determinant lemma for the logdet, using the fact that R'R = L_k'L_k + s*I
-                    logdet = self._r_cache.diagonal(dim1=-1, dim2=-2).abs().log().sum(-1).mul(2)
+                    logdet = (
+                        self._r_cache.diagonal(dim1=-1, dim2=-2)
+                        .abs()
+                        .log()
+                        .sum(-1)
+                        .mul(2)
+                    )
                     logdet = logdet + (n - k) * self.noise_constant.log()
-                    self._precond_logdet_cache = logdet.view(*batch_shape) if len(batch_shape) else logdet.squeeze()
+                    self._precond_logdet_cache = (
+                        logdet.view(*batch_shape)
+                        if len(batch_shape)
+                        else logdet.squeeze()
+                    )
 
                 else:
                     # With non-constant diagonals, we cant factor out the noise as easily
-                    self._q_cache, self._r_cache = torch.qr(torch.cat((self._piv_chol_self / self._noise.sqrt(), eye)))
+                    self._q_cache, self._r_cache = torch.qr(
+                        torch.cat((self._piv_chol_self / self._noise.sqrt(), eye))
+                    )
                     self._q_cache = self._q_cache[:n, :] / self._noise.sqrt()
 
-                    logdet = self._r_cache.diagonal(dim1=-1, dim2=-2).abs().log().sum(-1).mul(2) - (
-                        1.0 / self._noise
-                    ).log().sum([-1, -2])
-                    self._precond_logdet_cache = logdet.view(*batch_shape) if len(batch_shape) else logdet.squeeze()
+                    logdet = self._r_cache.diagonal(dim1=-1, dim2=-2).abs().log().sum(
+                        -1
+                    ).mul(2) - (1.0 / self._noise).log().sum([-1, -2])
+                    self._precond_logdet_cache = (
+                        logdet.view(*batch_shape)
+                        if len(batch_shape)
+                        else logdet.squeeze()
+                    )
 
             else:
                 self._woodbury_cache, self._inv_scale, self._precond_logdet_cache = woodbury.woodbury_factor(
-                    self._piv_chol_self, self._piv_chol_self, self._diag_tensor.diag(), logdet=True
+                    self._piv_chol_self,
+                    self._piv_chol_self,
+                    self._diag_tensor.diag(),
+                    logdet=True,
                 )
-                self._scaled_inv_diag = self._inv_scale / self._diag_tensor.diag().unsqueeze(-1)
-                self._scaled_inv_diag_piv_chol_self = self._piv_chol_self * self._scaled_inv_diag
+                self._scaled_inv_diag = self._inv_scale / self._diag_tensor.diag().unsqueeze(
+                    -1
+                )
+                self._scaled_inv_diag_piv_chol_self = (
+                    self._piv_chol_self * self._scaled_inv_diag
+                )
 
-            self.preconditioner_lt = PsdSumLazyTensor(RootLazyTensor(self._piv_chol_self), self._diag_tensor)
+            self.preconditioner_lt = PsdSumLazyTensor(
+                RootLazyTensor(self._piv_chol_self), self._diag_tensor
+            )
 
         # NOTE to future self:
         # We cannot memoize this precondition closure
@@ -109,10 +166,14 @@ class AddedDiagLazyTensor(SumLazyTensor):
         def precondition_closure(tensor):
             if hasattr(self, "_q_cache"):
                 if self.constant_diag:
-                    return (1 / self.noise_constant) * (tensor - self._q_cache.matmul(self._q_cache.t().matmul(tensor)))
+                    return (1 / self.noise_constant) * (
+                        tensor - self._q_cache.matmul(self._q_cache.t().matmul(tensor))
+                    )
 
                 else:
-                    return (tensor / self._noise) - self._q_cache.matmul(self._q_cache.t().matmul(tensor))
+                    return (tensor / self._noise) - self._q_cache.matmul(
+                        self._q_cache.t().matmul(tensor)
+                    )
 
             else:
                 res = woodbury.woodbury_solve(

--- a/gpytorch/lazy/sum_lazy_tensor.py
+++ b/gpytorch/lazy/sum_lazy_tensor.py
@@ -7,14 +7,14 @@ from .zero_lazy_tensor import ZeroLazyTensor
 
 
 class SumLazyTensor(LazyTensor):
-    def __init__(self, *lazy_tensors):
+    def __init__(self, *lazy_tensors, **kwargs):
         lazy_tensors = list(lazy_tensors)
         for i, lazy_tensor in enumerate(lazy_tensors):
             try:
                 lazy_tensors[i] = lazify(lazy_tensor)
             except TypeError:
                 raise TypeError("All arguments of a SumLazyTensor should be LazyTensors or Tensors")
-        super(SumLazyTensor, self).__init__(*lazy_tensors)
+        super(SumLazyTensor, self).__init__(*lazy_tensors, **kwargs)
 
         self.lazy_tensors = lazy_tensors
 


### PR DESCRIPTION
Adding a `preconditioner_override` option that allows specification of arbitrary preconditioners for `AddedDiagLazyTensor`. Example usage is given in the associated unit test but broadly looks like:

```
 overrode_lt = AddedDiagLazyTensor(
       RootLazyTensor(tensor),
       DiagLazyTensor(diag),
       preconditioner_override=nonstandard_preconditioner,
 )
```

The original preconditioner is still left in the class, but renamed as `_default_preconditioner`

Potential use cases include easier testing of new preconditioners as well as data driven preconditioners such as recycled subspaces from old solves.