### PR TITLE
max_cholesky_size -> 800

### DIFF
--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -360,7 +360,7 @@ class max_cholesky_size(_value_context):
     Default: 128
     """
 
-    _global_value = 128
+    _global_value = 800
 
 
 class max_root_decomposition_size(_value_context):


### PR DESCRIPTION
Current benchmarking against our new default tolerances + various code changes suggests that CG overtakes Cholesky around n=800-n=1000. Therefore, we should not use CG until then.