### PR TITLE
Raise error if Cholesky is used with KeOps.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = gpytorch,matplotlib,numpy,pyro,setuptools,sphinx_rtd_theme,torch
+known_third_party = matplotlib,numpy,pyro,setuptools,sphinx_rtd_theme,torch

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -397,8 +397,14 @@ class LazyTensor(ABC):
             (LazyTensor) Cholesky factor
         """
         from .non_lazy_tensor import NonLazyTensor
+        from .keops_lazy_tensor import KeOpsLazyTensor
 
-        evaluated_mat = self.evaluate()
+        evaluated_kern_mat = self.evaluate_kernel()
+
+        if any(isinstance(sub_mat, KeOpsLazyTensor) for sub_mat in evaluated_kern_mat._args):
+            raise RuntimeError("Cannot run Cholesky with KeOps: it will either be really slow or not work.")
+
+        evaluated_mat = evaluated_kern_mat.evaluate()
 
         # if the tensor is a scalar, we can just take the square root
         if evaluated_mat.size(-1) == 1:


### PR DESCRIPTION
Pretty sure this is the right way to handle this check and error.