### PR TITLE
Validation code for MultivariateNormal

### DIFF
--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -77,16 +77,13 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
             variable. The first (second) Tensor is the lower (upper) end of
             the confidence region.
         """
-        std2 = self.stddev.mul(2)
+        std2 = self.stddev.mul_(2)
         mean = self.mean
         return mean.sub(std2), mean.add(std2)
 
     @staticmethod
     def _repr_sizes(mean, covariance_matrix):
         return f"MultivariateNormal(loc: {mean.size()}, scale: {covariance_matrix.size()})"
-
-    def __repr__(self):
-        return self._repr_sizes(self.mean, self.lazy_covariance_matrix)
 
     @lazy_property
     def covariance_matrix(self):


### PR DESCRIPTION
I've resolved the TODO item to add validation for the sizes of the mean and variance.

I had also implemented a `__repr__` method that would show you the shape of the MultivariateNormal instead of the values of the tensors. But I think it's best not to upstream that. The `__repr_sizes` method was sharing code with it.