### PR TITLE
Custom expand methods for priors

### DIFF
--- a/gpytorch/priors/horseshoe_prior.py
+++ b/gpytorch/priors/horseshoe_prior.py
@@ -7,7 +7,6 @@ import torch
 from torch.distributions import HalfCauchy, Normal, constraints
 from torch.nn import Module as TModule
 
-from gpytorch.distributions import Distribution
 from gpytorch.priors.prior import Prior
 
 
@@ -56,9 +55,5 @@ class HorseshoePrior(Prior):
         return param_sample
 
     def expand(self, expand_shape, _instance=None):
-        new = self._get_checked_instance(HorseshoePrior)
         batch_shape = torch.Size(expand_shape)
-        new.scale = self.scale.expand(batch_shape)
-        super(Distribution, new).__init__(batch_shape)
-        new._validate_args = self._validate_args
-        return new
+        return HorseshoePrior(self.scale.expand(batch_shape))

--- a/gpytorch/priors/torch_priors.py
+++ b/gpytorch/priors/torch_priors.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import torch
 from torch.distributions import Gamma, LogNormal, MultivariateNormal, Normal, Uniform
 from torch.nn import Module as TModule
 
@@ -25,7 +26,8 @@ class NormalPrior(Prior, Normal):
         self._transform = transform
 
     def expand(self, batch_shape):
-        return Normal.expand(self, batch_shape, _instance=self)
+        batch_shape = torch.Size(batch_shape)
+        return NormalPrior(self.loc.expand(batch_shape), self.scale.expand(batch_shape))
 
 
 class LogNormalPrior(Prior, LogNormal):
@@ -39,7 +41,8 @@ class LogNormalPrior(Prior, LogNormal):
         self._transform = transform
 
     def expand(self, batch_shape):
-        return LogNormal.expand(self, batch_shape, _instance=self)
+        batch_shape = torch.Size(batch_shape)
+        return LogNormalPrior(self.loc.expand(batch_shape), self.scale.expand(batch_shape))
 
 
 class UniformPrior(Prior, Uniform):
@@ -53,7 +56,8 @@ class UniformPrior(Prior, Uniform):
         self._transform = transform
 
     def expand(self, batch_shape):
-        return Uniform.expand(self, batch_shape, _instance=self)
+        batch_shape = torch.Size(batch_shape)
+        return UniformPrior(self.low.expand(batch_shape), self.high.expand(batch_shape))
 
 
 class GammaPrior(Prior, Gamma):
@@ -71,7 +75,11 @@ class GammaPrior(Prior, Gamma):
         self._transform = transform
 
     def expand(self, batch_shape):
-        return Gamma.expand(self, batch_shape, _instance=self)
+        batch_shape = torch.Size(batch_shape)
+        return GammaPrior(self.concentration.expand(batch_shape), self.rate.expand(batch_shape))
+
+    def __call__(self, *args, **kwargs):
+        return super(Gamma, self).__call__(*args, **kwargs)
 
 
 class MultivariateNormalPrior(Prior, MultivariateNormal):


### PR DESCRIPTION
Inheriting the behavior of `expand` from the base torch distributions was causing really strange behavior, I think because our priors also inherit from Module. In addition to the bug in #976, calling `prior.expand(some_torch_size)` was actually modifying `prior` in place in addition to returning a new Module with the correct size.

These issues were easily fixed by just defining our own `expand` methods for the various priors. I also think that this is a rare setting where overriding and defining our own expand behavior will actually make things easier to debug, because the upstream behavior is extremely weird: https://github.com/pytorch/pytorch/blob/dd52f50fc85e6710f020936c1fc5f14673508350/torch/distributions/gamma.py#L50-L57

Fixes #976 