### PR TITLE
upgrade to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ To use packages globally but install GPyTorch as a user-only package, use `pip i
 
 #### Latest (unstable) version
 
-To get the latest (unstable) version, run
+To upgrade to the latest (unstable) version, run
 
 ```bash
-pip install git+https://github.com/cornellius-gp/gpytorch.git
+pip install --upgrade git+https://github.com/cornellius-gp/gpytorch.git
 ```
 
 ## Citing Us


### PR DESCRIPTION
I tried to use `pip install git+https://github.com/cornellius-gp/gpytorch.git` to install the latest version. However, under the circumstance of already installed `gpytorch-0.3.6`, the provided installation command will not upgrade to the latest version. In order to install the latest version, `--upgrade` command should be explicitly added.  