### PR TITLE
Remove old deprecations

### DIFF
--- a/gpytorch/__init__.py
+++ b/gpytorch/__init__.py
@@ -19,9 +19,7 @@ from .functions import (  # Deprecated
     dsmm,
     inv_matmul,
     inv_quad,
-    inv_quad_log_det,
     inv_quad_logdet,
-    log_det,
     log_normal_cdf,
     logdet,
     matmul,
@@ -69,7 +67,4 @@ __all__ = [
     "settings",
     # Other
     "__version__",
-    # Deprecated
-    "inv_quad_log_det",
-    "log_det",
 ]

--- a/gpytorch/functions/__init__.py
+++ b/gpytorch/functions/__init__.py
@@ -2,7 +2,6 @@
 
 import torch
 
-from ..utils.deprecation import _deprecated_function_for
 from ._dsmm import DSMM
 from ._log_normal_cdf import LogNormalCDF
 from .matern_covariance import MaternCovariance
@@ -188,10 +187,6 @@ def root_inv_decomposition(mat, initial_vectors=None, test_vectors=None):
     from ..lazy import lazify
 
     return lazify(mat).root_inv_decomposition(initial_vectors, test_vectors)
-
-
-log_det = _deprecated_function_for("log_det", logdet)
-inv_quad_log_det = _deprecated_function_for("inv_quad_log_det", inv_quad_logdet)
 
 
 __all__ = [

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -13,7 +13,6 @@ from ..lazy import LazyEvaluatedKernelTensor, ZeroLazyTensor, delazify, lazify
 from ..models.exact_prediction_strategies import DefaultPredictionStrategy, SumPredictionStrategy
 from ..module import Module
 from ..utils.broadcasting import _mul_broadcast_shape
-from ..utils.deprecation import _ClassWithDeprecatedBatchSize, _deprecate_kwarg_with_transform
 
 
 def default_postprocess_script(x):
@@ -57,7 +56,7 @@ class Distance(torch.nn.Module):
         return self._postprocess(res) if postprocess else res
 
 
-class Kernel(Module, _ClassWithDeprecatedBatchSize):
+class Kernel(Module):
     r"""
     Kernels in GPyTorch are implemented as a :class:`gpytorch.Module` that, when called on two :obj:`torch.tensor`
     objects `x1` and `x2` returns either a :obj:`torch.tensor` or a :obj:`gpytorch.lazy.LazyTensor` that represents
@@ -141,16 +140,11 @@ class Kernel(Module, _ClassWithDeprecatedBatchSize):
         **kwargs,
     ):
         super(Kernel, self).__init__()
-        self._register_load_state_dict_pre_hook(self._batch_shape_state_dict_hook)
-
+        self._batch_shape = batch_shape
         if active_dims is not None and not torch.is_tensor(active_dims):
             active_dims = torch.tensor(active_dims, dtype=torch.long)
         self.register_buffer("active_dims", active_dims)
         self.ard_num_dims = ard_num_dims
-
-        self._batch_shape = _deprecate_kwarg_with_transform(
-            kwargs, "batch_size", "batch_shape", batch_shape, lambda n: torch.Size([n])
-        )
 
         self.eps = eps
 

--- a/gpytorch/kernels/linear_kernel.py
+++ b/gpytorch/kernels/linear_kernel.py
@@ -50,9 +50,11 @@ class LinearKernel(Kernel):
             variance_constraint = Positive()
 
         if num_dimensions is not None:
+            # Remove after 1.0
             warnings.warn("The `num_dimensions` argument is deprecated and no longer used.", DeprecationWarning)
             self.register_parameter(name="offset", parameter=torch.nn.Parameter(torch.zeros(1, 1, num_dimensions)))
         if offset_prior is not None:
+            # Remove after 1.0
             warnings.warn("The `offset_prior` argument is deprecated and no longer used.", DeprecationWarning)
         self.register_parameter(name="raw_variance", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, 1)))
         if variance_prior is not None:

--- a/gpytorch/likelihoods/bernoulli_likelihood.py
+++ b/gpytorch/likelihoods/bernoulli_likelihood.py
@@ -39,6 +39,7 @@ class BernoulliLikelihood(_OneDimensionalLikelihood):
 
     def expected_log_prob(self, observations, function_dist, *params, **kwargs):
         if torch.any(observations.eq(-1)):
+            # Remove after 1.0
             warnings.warn(
                 "BernoulliLikelihood.expected_log_prob expects observations with labels in {0, 1}. "
                 "Observations with labels in {-1, 1} are deprecated.",

--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -10,7 +10,6 @@ from torch import Tensor
 
 from ..distributions import MultivariateNormal, base_distributions
 from ..lazy import ZeroLazyTensor
-from ..utils.deprecation import _deprecate_kwarg_with_transform
 from .likelihood import Likelihood
 from .noise_models import FixedGaussianNoise, HomoskedasticNoise, Noise
 
@@ -80,9 +79,6 @@ class _GaussianLikelihoodBase(Likelihood):
 
 class GaussianLikelihood(_GaussianLikelihoodBase):
     def __init__(self, noise_prior=None, noise_constraint=None, batch_shape=torch.Size(), **kwargs):
-        batch_shape = _deprecate_kwarg_with_transform(
-            kwargs, "batch_size", "batch_shape", batch_shape, lambda n: torch.Size([n])
-        )
         noise_covar = HomoskedasticNoise(
             noise_prior=noise_prior, noise_constraint=noise_constraint, batch_shape=batch_shape
         )
@@ -139,9 +135,6 @@ class FixedNoiseGaussianLikelihood(_GaussianLikelihoodBase):
     ) -> None:
         super().__init__(noise_covar=FixedGaussianNoise(noise=noise))
 
-        batch_shape = _deprecate_kwarg_with_transform(
-            kwargs, "batch_size", "batch_shape", batch_shape, lambda n: torch.Size([n])
-        )
         if learn_additional_noise:
             noise_prior = kwargs.get("noise_prior", None)
             noise_constraint = kwargs.get("noise_constraint", None)

--- a/gpytorch/likelihoods/likelihood.py
+++ b/gpytorch/likelihoods/likelihood.py
@@ -10,14 +10,12 @@ import torch
 from .. import settings
 from ..distributions import MultivariateNormal, base_distributions
 from ..module import Module
-from ..utils.deprecation import _ClassWithDeprecatedBatchSize
 from ..utils.quadrature import GaussHermiteQuadrature1D
 
 
-class _Likelihood(Module, ABC, _ClassWithDeprecatedBatchSize):
+class _Likelihood(Module, ABC):
     def __init__(self, max_plate_nesting=1):
         super().__init__()
-        self._register_load_state_dict_pre_hook(self._batch_shape_state_dict_hook)
         self.max_plate_nesting = max_plate_nesting
 
     def _draw_likelihood_samples(self, function_dist, *args, sample_shape=None, **kwargs):

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -288,6 +288,7 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
 
 def deprecate_task_noise_corr(state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):
     if prefix + "task_noise_corr_factor" in state_dict:
+        # Remove after 1.0
         warnings.warn(
             "Loading a deprecated parameterization of _MultitaskGaussianLikelihoodBase. Consider re-saving your model.",
             DeprecationWarning,

--- a/gpytorch/likelihoods/softmax_likelihood.py
+++ b/gpytorch/likelihoods/softmax_likelihood.py
@@ -5,7 +5,6 @@ import warnings
 import torch
 
 from ..distributions import Distribution, MultitaskMultivariateNormal, base_distributions
-from ..utils.deprecation import _deprecate_kwarg_with_transform
 from .likelihood import Likelihood
 
 
@@ -15,7 +14,6 @@ class SoftmaxLikelihood(Likelihood):
     """
 
     def __init__(self, num_features=None, num_classes=None, mixing_weights=True, mixing_weights_prior=None, **kwargs):
-        num_classes = _deprecate_kwarg_with_transform(kwargs, "n_classes", "num_classes", num_classes, lambda n: n)
         super().__init__()
         if num_classes is None:
             raise ValueError("num_classes is required")

--- a/gpytorch/means/constant_mean.py
+++ b/gpytorch/means/constant_mean.py
@@ -3,15 +3,11 @@
 import torch
 
 from ..utils.broadcasting import _mul_broadcast_shape
-from ..utils.deprecation import _deprecate_kwarg_with_transform
 from .mean import Mean
 
 
 class ConstantMean(Mean):
     def __init__(self, prior=None, batch_shape=torch.Size(), **kwargs):
-        batch_shape = _deprecate_kwarg_with_transform(
-            kwargs, "batch_size", "batch_shape", batch_shape, lambda n: torch.Size([n])
-        )
         super(ConstantMean, self).__init__()
         self.batch_shape = batch_shape
         self.register_parameter(name="constant", parameter=torch.nn.Parameter(torch.zeros(*batch_shape, 1)))

--- a/gpytorch/means/constant_mean_grad.py
+++ b/gpytorch/means/constant_mean_grad.py
@@ -3,15 +3,11 @@
 import torch
 
 from ..utils.broadcasting import _mul_broadcast_shape
-from ..utils.deprecation import _deprecate_kwarg_with_transform
 from .mean import Mean
 
 
 class ConstantMeanGrad(Mean):
     def __init__(self, prior=None, batch_shape=torch.Size(), **kwargs):
-        batch_shape = _deprecate_kwarg_with_transform(
-            kwargs, "batch_size", "batch_shape", batch_shape, lambda n: torch.Size([n])
-        )
         super(ConstantMeanGrad, self).__init__()
         self.batch_shape = batch_shape
         self.register_parameter(name="constant", parameter=torch.nn.Parameter(torch.zeros(*batch_shape, 1)))

--- a/gpytorch/means/mean.py
+++ b/gpytorch/means/mean.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python3
 
 from ..module import Module
-from ..utils.deprecation import _ClassWithDeprecatedBatchSize
 
 
-class Mean(Module, _ClassWithDeprecatedBatchSize):
+class Mean(Module):
     """
     Mean function.
     """
 
     def __init__(self):
         super().__init__()
-        self._register_load_state_dict_pre_hook(self._batch_shape_state_dict_hook)
 
     def forward(self, x):
         raise NotImplementedError()

--- a/gpytorch/mlls/__init__.py
+++ b/gpytorch/mlls/__init__.py
@@ -16,6 +16,7 @@ from .variational_elbo import VariationalELBO
 # Deprecated for 0.4 release
 class VariationalMarginalLogLikelihood(VariationalELBO):
     def __init__(self, *args, **kwargs):
+        # Remove after 1.0
         warnings.warn(
             "VariationalMarginalLogLikelihood is deprecated. Please use VariationalELBO instead.", DeprecationWarning
         )
@@ -24,6 +25,7 @@ class VariationalMarginalLogLikelihood(VariationalELBO):
 
 class VariationalELBOEmpirical(VariationalELBO):
     def __init__(self, *args, **kwargs):
+        # Remove after 1.0
         warnings.warn("VariationalELBOEmpirical is deprecated. Please use VariationalELBO instead.", DeprecationWarning)
         super().__init__(*args, **kwargs)
 

--- a/gpytorch/models/__init__.py
+++ b/gpytorch/models/__init__.py
@@ -15,6 +15,7 @@ VariationalGP = ApproximateGP
 
 # Deprecated for 0.4 release
 class AbstractVariationalGP(ApproximateGP):
+    # Remove after 1.0
     def __init__(self, *args, **kwargs):
         warnings.warn("AbstractVariationalGP has been renamed to ApproximateGP.", DeprecationWarning)
         super().__init__(*args, **kwargs)
@@ -22,6 +23,7 @@ class AbstractVariationalGP(ApproximateGP):
 
 # Deprecated for 0.4 release
 class PyroVariationalGP(ApproximateGP):
+    # Remove after 1.0
     def __init__(self, *args, **kwargs):
         warnings.warn("PyroVariationalGP has been renamed to PyroGP.", DeprecationWarning)
         super().__init__(*args, **kwargs)

--- a/gpytorch/utils/deprecation.py
+++ b/gpytorch/utils/deprecation.py
@@ -17,26 +17,6 @@ class DeprecationError(Exception):
     pass
 
 
-class _ClassWithDeprecatedBatchSize(object):
-    def _batch_shape_state_dict_hook(
-        self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
-    ):
-        try:
-            current_state_dict = self.state_dict()
-            for name, param in current_state_dict.items():
-                load_param = state_dict[prefix + name]
-                if load_param.dim() == param.dim() + 1:
-                    warnings.warn(
-                        f"The supplied state_dict contains a parameter ({prefix + name}) with an extra batch "
-                        f"dimension ({load_param.shape} vs {param.shape}).\nDefault batch shapes are now "
-                        "deprecated in GPyTorch. You may wish to re-save your model.",
-                        DeprecationWarning,
-                    )
-                    load_param.squeeze_(0)
-        except Exception:
-            pass
-
-
 def _deprecated_function_for(old_function_name, function):
     @functools.wraps(function)
     def _deprecated_function(*args, **kwargs):

--- a/gpytorch/variational/_variational_distribution.py
+++ b/gpytorch/variational/_variational_distribution.py
@@ -40,7 +40,7 @@ class _VariationalDistribution(Module, ABC):
     def __call__(self):
         try:
             return self.forward()
-        # Deprecation added for 0.4 release
+        # Remove after 1.0
         except NotImplementedError:
             warnings.warn(
                 "_VariationalDistribution.variational_distribution is deprecated. "
@@ -49,8 +49,8 @@ class _VariationalDistribution(Module, ABC):
             )
             return self.variational_distribution
 
-    # Deprecation added for 0.4 release
     def __getattr__(self, attr):
+        # Remove after 1.0
         if attr == "variational_distribution":
             warnings.warn(
                 "_VariationalDistribution.variational_distribution is deprecated. "

--- a/gpytorch/variational/whitened_variational_strategy.py
+++ b/gpytorch/variational/whitened_variational_strategy.py
@@ -21,7 +21,7 @@ from ..utils.memoize import cached
 from .unwhitened_variational_strategy import UnwhitenedVariationalStrategy
 
 
-# Deprecated on 0.4 release
+# Remove after 1.0
 class WhitenedVariationalStrategy(UnwhitenedVariationalStrategy):
     def __init__(self, model, inducing_points, variational_distribution, learn_inducing_locations=True):
         warnings.warn(

--- a/test/examples/test_spectral_mixture_gp_regression.py
+++ b/test/examples/test_spectral_mixture_gp_regression.py
@@ -28,8 +28,8 @@ test_y = torch.sin(test_x * (2 * pi))
 
 good_state_dict = OrderedDict(
     [
-        ("likelihood.log_noise", torch.tensor([[-5.0]])),
-        ("mean_module.constant", torch.tensor([[0.4615]])),
+        ("likelihood.log_noise", torch.tensor([-5.0])),
+        ("mean_module.constant", torch.tensor([0.4615])),
         ("covar_module.log_mixture_weights", torch.tensor([-0.7277, -15.1212, -0.5511, -6.3787]).unsqueeze(0)),
         (
             "covar_module.log_mixture_means",


### PR DESCRIPTION
Removes:
- `batch_size`
- `*log_det`

Marks all other deprecation as "Remove after 1.0" to remind us!