### PR TITLE
Get variational batch shape from variational distribution

### DIFF
--- a/gpytorch/variational/_variational_strategy.py
+++ b/gpytorch/variational/_variational_strategy.py
@@ -7,7 +7,6 @@ import torch
 from .. import settings
 from ..distributions import Delta, MultivariateNormal
 from ..module import Module
-from ..utils.broadcasting import _mul_broadcast_shape
 from ..utils.memoize import cached
 
 
@@ -110,10 +109,10 @@ class _VariationalStrategy(Module, ABC):
 
         # Ensure inducing_points and x are the same size
         inducing_points = self.inducing_points
-        if inducing_points.shape[:-2] != x.shape[:-2]:
-            batch_shape = _mul_broadcast_shape(inducing_points.shape[:-2], x.shape[:-2])
-            inducing_points = inducing_points.expand(*batch_shape, *inducing_points.shape[-2:])
-            x = x.expand(*batch_shape, *x.shape[-2:])
+
+        batch_shape = self._variational_distribution.batch_shape
+        inducing_points = inducing_points.expand(*batch_shape, *inducing_points.shape[-2:])
+        x = x.expand(*batch_shape, *x.shape[-2:])
 
         # Get p(u)/q(u)
         variational_dist_u = self.variational_distribution


### PR DESCRIPTION
Alright, so if you have a batch variational GP that are sharing inducing points (so `inducing_points` are `m x d`, but the variational parameters are `b x m` and `b x m x m`) AND you pass a non batch input (e.g., `n x d` instead of explicitly `b x n x d`), the existing expands fail.

This is a bit of an edge case, but it did work before 1.0.0. To fix this on 1.0.0, this PR explicitly grabs the batch shape from the variational distribution object and explicitly expands inducing points and x (which is a no-op if they already match).

We might push out 1.0.1 with this + anything else we find in a week or so. For now, on 1.0.0, this (a) is a pretty rare edge case, and (b) can be worked around by explicitly giving `x` a batch shape (e.g., everything works as intended if you manually do `x.expand(*batch_shape, *x.shape[-2:])`

cc/ @samuelstanton who encountered this initially, and @gpleiss who'll have to review. I also have a quick smoke test I'll add for this to the unit tests, since this is clearly untested currently.