### PR TITLE
Dont squeeze kernel vector outputs in PeriodicKernel

### DIFF
--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -111,6 +111,6 @@ class PeriodicKernel(Kernel):
         x2_ = x2.div(self.period_length)
         diff = self.covar_dist(x1_, x2_, diag=diag, **params)
         res = torch.sin(diff.mul(math.pi)).pow(2).mul(-2 / self.lengthscale).exp_()
-        if diff.ndimension() == 2 or diag:
+        if diag:
             res = res.squeeze(0)
         return res


### PR DESCRIPTION
On master, the following breaks:
```python
from gpytorch.kernels import PeriodicKernel
kern = PeriodicKernel()
x1 = torch.randn(1, 1)  # Code works if x1 is any n x d other than 1 x d
x2 = torch.randn(5, 1)
K = kern(x1, x2).evaluate()
```
Clearly, this should not break :-). In our defense, GPyTorch returns exactly the error you'd hope:
```python
RuntimeError: The expected shape of the kernel was torch.Size([1, 5]), but got torch.Size([5]). This is likely a bug in GPyTorch.
```
but clearly we should add some unit tests for edge cases like this. 

Fixes #1011 