### PR TITLE
Fix constraint handling for PyTorch modules

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = gpytorch,matplotlib,numpy,pyro,setuptools,sphinx_rtd_theme,torch
+known_third_party = matplotlib,numpy,pyro,setuptools,sphinx_rtd_theme,torch

--- a/gpytorch/__init__.py
+++ b/gpytorch/__init__.py
@@ -30,7 +30,7 @@ from .lazy import cat, delazify, lazify
 from .mlls import ExactMarginalLogLikelihood
 from .module import Module
 
-__version__ = "0.3.6"
+__version__ = "1.0.0"
 
 __all__ = [
     # Submodules

--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -263,7 +263,11 @@ class Module(nn.Module):
             base_name = ".".join(components[1:])
 
         constraint_name = base_name + "_constraint"
-        return base_module._constraints.get(constraint_name)
+
+        if hasattr(base_module, "_constraints"):
+            return base_module._constraints.get(constraint_name)
+        else:
+            return None
 
     def named_parameters_and_constraints(self):
         for name, param in self.named_parameters():


### PR DESCRIPTION
If you have a GPyTorch module that incorporates vanila PyTorch modules, then `model.named_parameters_and_constraints()` will fail trying to access `submodule._constraints` where `submodule` is a PyTorch module instead of a GPyTorch one.

This makes us return `None` for parameters on PyTorch modules.