### PR TITLE
add instructions for archlinux package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ pip install --upgrade git+https://github.com/cornellius-gp/gpytorch.git
 ```
 
 ### ArchLinux Package
+Note: The ArchLinux package is not tested by the GPyTorch developers.
+
 GPyTorch is also available on the [ArchLinux User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository) (AUR).
 You can install it with an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers), like [`yay`](https://aur.archlinux.org/packages/yay/), as follows:
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ To upgrade to the latest (unstable) version, run
 pip install --upgrade git+https://github.com/cornellius-gp/gpytorch.git
 ```
 
+### ArchLinux Package
+GPyTorch is also available on the [ArchLinux User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository) (AUR).
+You can install it with an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers), like [`yay`](https://aur.archlinux.org/packages/yay/), as follows:
+
+```bash
+yay -S python-gpytorch
+```
+To discuss any issues related to this package refer to the comments section of
+[`python-gpytorch`](https://aur.archlinux.org/packages/python-gpytorch/).
+
 ## Citing Us
 
 If you use GPyTorch, please cite the following papers:

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ To upgrade to the latest (unstable) version, run
 pip install --upgrade git+https://github.com/cornellius-gp/gpytorch.git
 ```
 
-### ArchLinux Package
-Note: The ArchLinux package is not tested by the GPyTorch developers.
+#### ArchLinux Package
+Note: Experimental AUR package. For most users, we recommend installation by conda or pip.
 
 GPyTorch is also available on the [ArchLinux User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository) (AUR).
 You can install it with an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers), like [`yay`](https://aur.archlinux.org/packages/yay/), as follows:
@@ -52,7 +52,7 @@ You can install it with an [AUR helper](https://wiki.archlinux.org/index.php/AUR
 ```bash
 yay -S python-gpytorch
 ```
-To discuss any issues related to this package refer to the comments section of
+To discuss any issues related to this AUR package refer to the comments section of
 [`python-gpytorch`](https://aur.archlinux.org/packages/python-gpytorch/).
 
 ## Citing Us


### PR DESCRIPTION
Hey guys, thank you for your work on this amazing project. I use GPyTorch on ArchLinux and thought I would create a package for this so users can easily install it. With the advent of the first stable version, this would be the perfect time to include it with the installation instructions.