### PR TITLE
Handle non-gpytorch submodules in constraint_for_parameter_name

### DIFF
--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -262,8 +262,11 @@ class Module(nn.Module):
             base_module = submodule
             base_name = ".".join(components[1:])
 
-        constraint_name = base_name + "_constraint"
-        return base_module._constraints.get(constraint_name)
+        try:
+            constraint_name = base_name + "_constraint"
+            return base_module._constraints.get(constraint_name)
+        except AttributeError:  # submodule may not always be a gpytorch module
+            return None
 
     def named_parameters_and_constraints(self):
         for name, param in self.named_parameters():


### PR DESCRIPTION
Currently, attaching non-gpytorch torch modules as submodules to gpytorch modules causes issues with the constraint functionality. Specifically, `constraint_for_parameter_name ` assumes that all the submodules are GPyTorch modules and have a `_constraints` dictionary (as initialized here: https://github.com/cornellius-gp/gpytorch/blob/master/gpytorch/module.py#L19). 

This catches the `AttributeError` that is raised if that is not the case and returns `None`.