### PR TITLE
Custom expand method for MultivariateNormalPrior

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = gpytorch,matplotlib,numpy,pyro,setuptools,sphinx_rtd_theme,torch
+known_third_party = matplotlib,numpy,pyro,setuptools,sphinx_rtd_theme,torch

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = matplotlib,numpy,pyro,setuptools,sphinx_rtd_theme,torch
+known_third_party = matplotlib,numpy,setuptools,sphinx_rtd_theme,torch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,6 @@ repos:
     -   id: black
         exclude: ^(build/*)|(docs/*)|(examples/*)
         args: [-l 120, --target-version=py36]
-# -   repo: https://github.com/asottile/seed-isort-config
-#     rev: v1.9.3
-#     hooks:
-#     -   id: seed-isort-config
-#         args: [--application-directories=comparison]
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,11 @@ repos:
     -   id: black
         exclude: ^(build/*)|(docs/*)|(examples/*)
         args: [-l 120, --target-version=py36]
--   repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.3
-    hooks:
-    -   id: seed-isort-config
-        args: [--application-directories=comparison]
+# -   repo: https://github.com/asottile/seed-isort-config
+#     rev: v1.9.3
+#     hooks:
+#     -   id: seed-isort-config
+#         args: [--application-directories=comparison]
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:

--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -83,7 +83,7 @@ class Module(nn.Module):
                 setattr(self, name, val)
             elif torch.is_tensor(val):
                 constraint = self.constraint_for_parameter_name(name)
-                if constraint is not None and not constraint.check_raw(val):
+                if constraint is not None and constraint.enforced and not constraint.check_raw(val):
                     raise RuntimeError(
                         "Attempting to manually set a parameter value that is out of bounds of "
                         f"its current constraints, {constraint}. "

--- a/gpytorch/priors/torch_priors.py
+++ b/gpytorch/priors/torch_priors.py
@@ -118,4 +118,12 @@ class MultivariateNormalPrior(Prior, MultivariateNormal):
         return module
 
     def expand(self, batch_shape):
-        return MultivariateNormal.expand(self, batch_shape, _instance=self)
+        from IPython.core.debugger import set_trace
+
+        set_trace()
+        batch_shape = torch.Size(batch_shape)
+        cov_shape = batch_shape + self.event_shape
+        new_loc = self.loc.expand(batch_shape)
+        new_scale_tril = self.scale_tril.expand(cov_shape)
+
+        return MultivariateNormalPrior(loc=new_loc, scale_tril=new_scale_tril)

--- a/gpytorch/priors/torch_priors.py
+++ b/gpytorch/priors/torch_priors.py
@@ -118,9 +118,6 @@ class MultivariateNormalPrior(Prior, MultivariateNormal):
         return module
 
     def expand(self, batch_shape):
-        from IPython.core.debugger import set_trace
-
-        set_trace()
         batch_shape = torch.Size(batch_shape)
         cov_shape = batch_shape + self.event_shape
         new_loc = self.loc.expand(batch_shape)


### PR DESCRIPTION
Fixes an issue where the built in expand method was deleting our prior buffers (see #977).

cc/ @idelbrid