### PR TITLE
[Examples] Fix Simple GP function noise

### DIFF
--- a/examples/01_Exact_GPs/Simple_GP_Regression.ipynb
+++ b/examples/01_Exact_GPs/Simple_GP_Regression.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "\\begin{align}\n",
     "y &= \\sin(2\\pi x) + \\epsilon \\\\\n",
-    "  \\epsilon &\\sim \\mathcal{N}(0, 0.2) \n",
+    "  \\epsilon &\\sim \\mathcal{N}(0, 0.04) \n",
     "\\end{align}\n",
     "\n",
     "with 100 training examples, and testing on 51 test examples.\n",
@@ -63,7 +63,7 @@
     "# Training data is 100 points in [0,1] inclusive regularly spaced\n",
     "train_x = torch.linspace(0, 1, 100)\n",
     "# True function is sin(2*pi*x) with Gaussian noise\n",
-    "train_y = torch.sin(train_x * (2 * math.pi)) + torch.randn(train_x.size()) * 0.2"
+    "train_y = torch.sin(train_x * (2 * math.pi)) + torch.randn(train_x.size()) * math.sqrt(0.04)"
    ]
   },
   {


### PR DESCRIPTION
The function stated in the Simple GP example (https://gpytorch.readthedocs.io/en/latest/examples/01_Exact_GPs/Simple_GP_Regression.html#Introduction)
 has noise from a Gaussian with variance 0.2. 

However, the following code block samples from a Gaussian with _standard deviation_ 0.2. This makes the code snippet/sample consistent with the definition stated in the introduction.  