### PR TITLE
fix some math/latex typos in doc strings

### DIFF
--- a/gpytorch/mlls/gamma_robust_variational_elbo.py
+++ b/gpytorch/mlls/gamma_robust_variational_elbo.py
@@ -21,16 +21,16 @@ class GammaRobustVariationalELBO(_ApproximateMarginalLogLikelihood):
           \sum_{i=1}^N \mathbb{E}_{q( \mathbf u)} \left[
             -\frac{\gamma}{\gamma - 1}
             \frac{
-                p( y_i \! \mid \! \mathbf u)^{\gamma - 1}
+                p( y_i \! \mid \! \mathbf u, x_i)^{\gamma - 1}
             }{
-                \int p(\mathbf y \mid \mathbf u) \: d \mathbf y
+                \int p(y \mid \mathbf u, x_i)^{\gamma} \: dy
             }
           \right] - \beta \: \text{KL} \left[ q( \mathbf u) \Vert p( \mathbf u) \right]
        \end{align*}
 
     where :math:`N` is the number of datapoints, :math:`\gamma` is a hyperparameter,
     :math:`q(\mathbf u)` is the variational distribution for
-    the inducing function values, and `p(\mathbf u)` is the prior distribution for the inducing function
+    the inducing function values, and :math:`p(\mathbf u)` is the prior distribution for the inducing function
     values.
 
     :math:`\beta` is a scaling constant for the KL divergence.

--- a/gpytorch/mlls/predictive_log_likelihood.py
+++ b/gpytorch/mlls/predictive_log_likelihood.py
@@ -31,7 +31,7 @@ class PredictiveLogLikelihood(_ApproximateMarginalLogLikelihood):
 
     .. note::
         This objective is very similar to the variational ELBO.
-        The only difference is that the :math:`log` occurs *outside* the expectation :math:`\mathbb E_{q(\mathbf u}}`.
+        The only difference is that the :math:`log` occurs *outside* the expectation :math:`\mathbb{E}_{q(\mathbf u)}`.
         This difference results in very different predictive performance (see `Jankowiak et al., 2019`_).
 
     :param ~gpytorch.likelihoods.Likelihood likelihood: The likelihood for the model

--- a/gpytorch/mlls/predictive_log_likelihood.py
+++ b/gpytorch/mlls/predictive_log_likelihood.py
@@ -17,7 +17,7 @@ class PredictiveLogLikelihood(_ApproximateMarginalLogLikelihood):
           \right] - \beta \: \text{KL} \left[ q( \mathbf u) \Vert p( \mathbf u) \right]
           \\
           &\approx \sum_{i=1}^N \log \mathbb{E}_{q(\mathbf u)} \left[
-            \int p( y_i \! \mid \! f_i) p(f_i \! \mid \! \mathbf u) \: d f_i
+            \int p( y_i \! \mid \! f_i) p(f_i \! \mid \! \mathbf u, \mathbf x_i) \: d f_i
           \right] - \beta \: \text{KL} \left[ q( \mathbf u) \Vert p( \mathbf u) \right]
        \end{align*}
 
@@ -31,7 +31,7 @@ class PredictiveLogLikelihood(_ApproximateMarginalLogLikelihood):
 
     .. note::
         This objective is very similar to the variational ELBO.
-        The only difference is that the :math:`log` occurs *outside* the expectation :math:`\mathbb E_{q(\mathbf u}`.
+        The only difference is that the :math:`log` occurs *outside* the expectation :math:`\mathbb E_{q(\mathbf u}}`.
         This difference results in very different predictive performance (see `Jankowiak et al., 2019`_).
 
     :param ~gpytorch.likelihoods.Likelihood likelihood: The likelihood for the model
@@ -61,7 +61,7 @@ class PredictiveLogLikelihood(_ApproximateMarginalLogLikelihood):
 
     def forward(self, approximate_dist_f, target, **kwargs):
         r"""
-        Computes the predictive cross entropy given :math:`q(\mathbf f)` and `\mathbf y`.
+        Computes the predictive cross entropy given :math:`q(\mathbf f)` and :math:`\mathbf y`.
         Calling this function will call the likelihood's
         :meth:`~gpytorch.likelihoods.Likelihood.forward` function.
 

--- a/gpytorch/mlls/predictive_log_likelihood.py
+++ b/gpytorch/mlls/predictive_log_likelihood.py
@@ -22,7 +22,7 @@ class PredictiveLogLikelihood(_ApproximateMarginalLogLikelihood):
        \end{align*}
 
     where :math:`N` is the total number of datapoints, :math:`q(\mathbf u)` is the variational distribution for
-    the inducing function values, and `p(\mathbf u)` is the prior distribution for the inducing function
+    the inducing function values, and :math:`p(\mathbf u)` is the prior distribution for the inducing function
     values.
 
     :math:`\beta` is a scaling constant that reduces the regularization effect of the KL

--- a/gpytorch/mlls/variational_elbo.py
+++ b/gpytorch/mlls/variational_elbo.py
@@ -13,16 +13,16 @@ class VariationalELBO(_ApproximateMarginalLogLikelihood):
        \begin{align*}
           \mathcal{L}_\text{ELBO} &=
           \mathbb{E}_{p_\text{data}( y, \mathbf x )} \left[
-            \log \mathbb{E}_{p(\mathbf f \mid \mathbf u, \mathbf x) q(\mathbf u)} \left[  \log p( y \! \mid \! \mathbf f) \right]
+            \mathbb{E}_{p(f \mid \mathbf u, \mathbf x) q(\mathbf u)} \left[  \log p( y \! \mid \! f) \right]
           \right] - \beta \: \text{KL} \left[ q( \mathbf u) \Vert p( \mathbf u) \right]
           \\
-          &\approx \sum_{i=1}^N \mathbb{E}_{q( \mathbf f_i)} \left[
+          &\approx \sum_{i=1}^N \mathbb{E}_{q( f_i)} \left[
             \log \int p( y_i \! \mid \! f_i) \right] - \beta \: \text{KL} \left[ q( \mathbf u) \Vert p( \mathbf u) \right]
        \end{align*}
 
     where :math:`N` is the number of datapoints, :math:`q(\mathbf u)` is the variational distribution for
-    the inducing function values and :math:`q(\mathbf f_i)` is the marginal of
-    :math:`p(\mathbf f_i \mid \mathbf u, \mathbf x_i) q(\mathbf u)`,
+    the inducing function values, :math:`q(f_i)` is the marginal of
+    :math:`p(f_i \mid \mathbf u, \mathbf x_i) q(\mathbf u)`,
     and :math:`p(\mathbf u)` is the prior distribution for the inducing function values.
 
     :math:`\beta` is a scaling constant that reduces the regularization effect of the KL

--- a/gpytorch/mlls/variational_elbo.py
+++ b/gpytorch/mlls/variational_elbo.py
@@ -13,17 +13,17 @@ class VariationalELBO(_ApproximateMarginalLogLikelihood):
        \begin{align*}
           \mathcal{L}_\text{ELBO} &=
           \mathbb{E}_{p_\text{data}( y, \mathbf x )} \left[
-            \log \mathbb{E}_{q(\mathbf u)} \left[  p( y \! \mid \! \mathbf u) \right]
+            \log \mathbb{E}_{p(\mathbf f \mid \mathbf u, \mathbf x) q(\mathbf u)} \left[  \log p( y \! \mid \! \mathbf f) \right]
           \right] - \beta \: \text{KL} \left[ q( \mathbf u) \Vert p( \mathbf u) \right]
           \\
-          &\approx \sum_{i=1}^N \mathbb{E}_{q( \mathbf u)} \left[
-            \log \int p( y_i \! \mid \! f_i) p(f_i \! \mid \! \mathbf u) \: d \mathbf f_i
-          \right] - \beta \: \text{KL} \left[ q( \mathbf u) \Vert p( \mathbf u) \right]
+          &\approx \sum_{i=1}^N \mathbb{E}_{q( \mathbf f_i)} \left[
+            \log \int p( y_i \! \mid \! f_i) \right] - \beta \: \text{KL} \left[ q( \mathbf u) \Vert p( \mathbf u) \right]
        \end{align*}
 
     where :math:`N` is the number of datapoints, :math:`q(\mathbf u)` is the variational distribution for
-    the inducing function values, and :math:`p(\mathbf u)` is the prior distribution for the inducing function
-    values.
+    the inducing function values and :math:`q(\mathbf f_i)` is the marginal of
+    :math:`p(\mathbf f_i \mid \mathbf u, \mathbf x_i) q(\mathbf u)`,
+    and :math:`p(\mathbf u)` is the prior distribution for the inducing function values.
 
     :math:`\beta` is a scaling constant that reduces the regularization effect of the KL
     divergence. Setting :math:`\beta=1` (default) results in the true variational ELBO.

--- a/gpytorch/mlls/variational_elbo.py
+++ b/gpytorch/mlls/variational_elbo.py
@@ -17,7 +17,7 @@ class VariationalELBO(_ApproximateMarginalLogLikelihood):
           \right] - \beta \: \text{KL} \left[ q( \mathbf u) \Vert p( \mathbf u) \right]
           \\
           &\approx \sum_{i=1}^N \mathbb{E}_{q( f_i)} \left[
-            \log \int p( y_i \! \mid \! f_i) \right] - \beta \: \text{KL} \left[ q( \mathbf u) \Vert p( \mathbf u) \right]
+            \log p( y_i \! \mid \! f_i) \right] - \beta \: \text{KL} \left[ q( \mathbf u) \Vert p( \mathbf u) \right]
        \end{align*}
 
     where :math:`N` is the number of datapoints, :math:`q(\mathbf u)` is the variational distribution for

--- a/gpytorch/mlls/variational_elbo.py
+++ b/gpytorch/mlls/variational_elbo.py
@@ -22,7 +22,7 @@ class VariationalELBO(_ApproximateMarginalLogLikelihood):
        \end{align*}
 
     where :math:`N` is the number of datapoints, :math:`q(\mathbf u)` is the variational distribution for
-    the inducing function values, and `p(\mathbf u)` is the prior distribution for the inducing function
+    the inducing function values, and :math:`p(\mathbf u)` is the prior distribution for the inducing function
     values.
 
     :math:`\beta` is a scaling constant that reduces the regularization effect of the KL


### PR DESCRIPTION
diffs limited to /mlls/ => rendered [here](https://gpytorch.readthedocs.io/en/docfix/marginal_log_likelihoods.html)