### PR TITLE
Fix docstring for SpectralMixtureKernel and CylindricalKernel: mathbf -> \mathbf

### DIFF
--- a/gpytorch/kernels/cylindrical_kernel.py
+++ b/gpytorch/kernels/cylindrical_kernel.py
@@ -13,7 +13,7 @@ from .kernel import Kernel
 class CylindricalKernel(Kernel):
     r"""
     Computes a covariance matrix based on the Cylindrical Kernel between
-    inputs :math:`mathbf{x_1}` and :math:`mathbf{x_2}`.
+    inputs :math:`\mathbf{x_1}` and :math:`\mathbf{x_2}`.
     It was proposed in `BOCK: Bayesian Optimization with Cylindrical Kernels`.
     See http://proceedings.mlr.press/v80/oh18a.html for more details
 

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -14,7 +14,7 @@ logger = logging.getLogger()
 class SpectralMixtureKernel(Kernel):
     r"""
     Computes a covariance matrix based on the Spectral Mixture Kernel
-    between inputs :math:`mathbf{x_1}` and :math:`mathbf{x_2}`:
+    between inputs :math:`\mathbf{x_1}` and :math:`\mathbf{x_2}`:
     It was proposed in `Gaussian Process Kernels for Pattern Discovery and Extrapolation`_.
 
     .. note::


### PR DESCRIPTION
Fixes two small math render errors due to missing '\' for SpectralMixtureKernel and CylindricalKernel at
https://gpytorch.readthedocs.io/en/latest/kernels.html