### PR TITLE
Make grid kernel work better with ARD

### DIFF
--- a/gpytorch/kernels/grid_interpolation_kernel.py
+++ b/gpytorch/kernels/grid_interpolation_kernel.py
@@ -175,7 +175,7 @@ class GridInterpolationKernel(GridKernel):
                 self.update_grid(grid)
 
         base_lazy_tsr = lazify(self._inducing_forward(last_dim_is_batch=last_dim_is_batch, **params))
-        if last_dim_is_batch:
+        if last_dim_is_batch and base_lazy_tsr.size(-3) == 1:
             base_lazy_tsr = base_lazy_tsr.repeat(*x1.shape[:-2], x1.size(-1), 1, 1)
 
         left_interp_indices, left_interp_values = self._compute_grid(x1, last_dim_is_batch)

--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -6,7 +6,7 @@ import torch
 from torch import Tensor
 
 from .. import settings
-from ..lazy import KroneckerProductLazyTensor, ToeplitzLazyTensor, cat, delazify
+from ..lazy import KroneckerProductLazyTensor, ToeplitzLazyTensor, delazify
 from ..utils.grid import convert_legacy_grid, create_data_from_grid
 from .kernel import Kernel
 
@@ -100,9 +100,26 @@ class GridKernel(Kernel):
         return not all(self.grid[0].size() == proj.size() for proj in self.grid)
 
     def forward(self, x1, x2, diag=False, last_dim_is_batch=False, **params):
+        if last_dim_is_batch and not self.interpolation_mode:
+            raise ValueError("last_dim_is_batch is only valid with interpolation model")
+
         grid = self.grid
-        if last_dim_is_batch and self.is_ragged:
-            raise ValueError("last_dim_is_batch requires all dimensions to have same number of grid points")
+        if self.is_ragged:
+            # Pad the grid - so that grid is the same size for each dimension
+            max_grid_size = max(proj.size(-1) for proj in grid)
+            padded_grid = []
+            for proj in grid:
+                padding_size = max_grid_size - proj.size(-1)
+                if padding_size > 0:
+                    dtype = proj.dtype
+                    device = proj.device
+                    padded_grid.append(
+                        torch.cat([proj, torch.zeros(*proj.shape[:-1], padding_size, dtype=dtype, device=device)])
+                    )
+                else:
+                    padded_grid.append(proj)
+        else:
+            padded_grid = grid
 
         if not self.interpolation_mode:
             if len(x1.shape[:-2]):
@@ -116,31 +133,31 @@ class GridKernel(Kernel):
             # Can exploit Toeplitz structure if grid points in each dimension are equally
             # spaced and using a translation-invariant kernel
             if settings.use_toeplitz.on():
-                first_grid_point = [proj[0].unsqueeze(0) for proj in grid]
-                covars = [
-                    self.base_kernel(first, proj, last_dim_is_batch=False, **params)
-                    for first, proj in zip(first_grid_point, grid)
-                ]  # Each entry i contains a 1 x grid_size[i] covariance matrix
-                covars = [delazify(c) for c in covars]
+                # Use padded grid for batch mode
+                first_grid_point = torch.stack([proj[0].unsqueeze(0) for proj in grid], dim=-1)
+                full_grid = torch.stack(padded_grid, dim=-1)
+                covars = delazify(self.base_kernel(first_grid_point, full_grid, last_dim_is_batch=True, **params))
 
                 if last_dim_is_batch:
                     # Toeplitz expects batches of columns so we concatenate the
                     # 1 x grid_size[i] tensors together
                     # Note that this requires all the dimensions to have the same number of grid points
-                    covar = ToeplitzLazyTensor(torch.cat(covars, dim=-2))
+                    covar = ToeplitzLazyTensor(covars.squeeze(-2))
                 else:
                     # Non-batched ToeplitzLazyTensor expects a 1D tensor, so we squeeze out the row dimension
-                    covars = [ToeplitzLazyTensor(c.squeeze(-2)) for c in covars]
+                    covars = covars.squeeze(-2)  # Get rid of the dimension corresponding to the first point
+                    # Un-pad the grid
+                    covars = [ToeplitzLazyTensor(covars[..., i, : proj.size(-1)]) for i, proj in enumerate(grid)]
                     # Due to legacy reasons, KroneckerProductLazyTensor(A, B, C) is actually (C Kron B Kron A)
                     covar = KroneckerProductLazyTensor(*covars[::-1])
             else:
-                covars = [
-                    self.base_kernel(proj, proj, last_dim_is_batch=False, **params) for proj in grid
-                ]  # Each entry i contains a grid_size[i] x grid_size[i] covariance matrix
+                full_grid = torch.stack(padded_grid, dim=-1)
+                covars = delazify(self.base_kernel(full_grid, full_grid, last_dim_is_batch=True, **params))
                 if last_dim_is_batch:
                     # Note that this requires all the dimensions to have the same number of grid points
-                    covar = cat([c.unsqueeze(-3) for c in covars], dim=-3)
+                    covar = covars
                 else:
+                    covars = [covars[..., i, : proj.size(-1), : proj.size(-1)] for i, proj in enumerate(self.grid)]
                     covar = KroneckerProductLazyTensor(*covars[::-1])
 
             if not self.training:

--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -92,6 +92,7 @@ class MaternKernel(Kernel):
             or x2.requires_grad
             or (self.ard_num_dims is not None and self.ard_num_dims > 1)
             or diag
+            or params.get("last_dim_is_batch", False)
             or trace_mode.on()
         ):
             mean = x1.reshape(-1, x1.size(-1)).mean(0)[(None,) * (x1.dim() - 1)]

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -75,6 +75,7 @@ class RBFKernel(Kernel):
             or x2.requires_grad
             or (self.ard_num_dims is not None and self.ard_num_dims > 1)
             or diag
+            or params.get("last_dim_is_batch", False)
             or trace_mode.on()
         ):
             x1_ = x1.div(self.lengthscale)

--- a/test/examples/test_simple_gp_regression.py
+++ b/test/examples/test_simple_gp_regression.py
@@ -9,7 +9,7 @@ from gpytorch.distributions import MultivariateNormal
 from gpytorch.kernels import RBFKernel, ScaleKernel
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.means import ConstantMean
-from gpytorch.priors import SmoothedBoxPrior, LogNormalPrior, UniformPrior
+from gpytorch.priors import SmoothedBoxPrior, UniformPrior
 from gpytorch.constraints import Positive
 from gpytorch.test.base_test_case import BaseTestCase
 from gpytorch.test.utils import least_used_cuda_device
@@ -465,9 +465,9 @@ class TestSimpleGPRegression(BaseTestCase, unittest.TestCase):
 
         # Register normal GPyTorch priors
         gp_model.mean_module.register_prior("mean_prior", UniformPrior(-1, 1), "constant")
-        gp_model.covar_module.base_kernel.register_prior("lengthscale_prior", UniformPrior(0.01, 0.2), "lengthscale")
+        gp_model.covar_module.base_kernel.register_prior("lengthscale_prior", UniformPrior(0.01, 0.5), "lengthscale")
         gp_model.covar_module.register_prior("outputscale_prior", UniformPrior(1, 2), "outputscale")
-        likelihood.register_prior("noise_prior", LogNormalPrior(-1.5, 0.1), "noise")
+        likelihood.register_prior("noise_prior", UniformPrior(0.05, 0.3), "noise")
 
         mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, gp_model)
 

--- a/test/kernels/test_grid_interpolation_kernel.py
+++ b/test/kernels/test_grid_interpolation_kernel.py
@@ -10,7 +10,7 @@ from gpytorch.lazy import InterpolatedLazyTensor
 
 class TestGridInterpolationKernel(unittest.TestCase):
     def test_standard(self):
-        base_kernel = RBFKernel()
+        base_kernel = RBFKernel(ard_num_dims=2)
         kernel = GridInterpolationKernel(base_kernel, num_dims=2, grid_size=128, grid_bounds=[(-1.2, 1.2)] * 2)
 
         xs = torch.randn(5, 2).clamp(-1, 1)
@@ -28,7 +28,7 @@ class TestGridInterpolationKernel(unittest.TestCase):
         self.assertLess(torch.norm(grid_eval - actual_eval), 2e-5)
 
     def test_batch_base_kernel(self):
-        base_kernel = RBFKernel(batch_shape=torch.Size([3]))
+        base_kernel = RBFKernel(batch_shape=torch.Size([3]), ard_num_dims=2)
         kernel = GridInterpolationKernel(base_kernel, num_dims=2, grid_size=128, grid_bounds=[(-1.2, 1.2)] * 2)
 
         xs = torch.randn(5, 2).clamp(-1, 1)

--- a/test/kernels/test_grid_kernel.py
+++ b/test/kernels/test_grid_kernel.py
@@ -4,6 +4,7 @@ import unittest
 
 import torch
 
+import gpytorch
 from gpytorch.kernels import GridKernel, LinearKernel, RBFKernel
 from gpytorch.lazy import KroneckerProductLazyTensor
 from gpytorch.utils.grid import create_data_from_grid
@@ -14,30 +15,42 @@ grid_data = create_data_from_grid(grid)
 
 
 class TestGridKernel(unittest.TestCase):
-    def test_grid_grid(self):
-        base_kernel = RBFKernel()
-        kernel = GridKernel(base_kernel, grid)
-        grid_covar = kernel(grid_data, grid_data).evaluate_kernel()
-        self.assertIsInstance(grid_covar, KroneckerProductLazyTensor)
-        grid_eval = kernel(grid_data, grid_data).evaluate()
-        actual_eval = base_kernel(grid_data, grid_data).evaluate()
-        self.assertLess(torch.norm(grid_eval - actual_eval), 2e-5)
+    def test_grid_grid(self, toeplitz=True):
+        with gpytorch.settings.use_toeplitz(toeplitz):
+            base_kernel = RBFKernel(ard_num_dims=2)
+            kernel = GridKernel(base_kernel, grid)
+            grid_covar = kernel(grid_data, grid_data).evaluate_kernel()
+            self.assertIsInstance(grid_covar, KroneckerProductLazyTensor)
+            grid_eval = kernel(grid_data, grid_data).evaluate()
+            actual_eval = base_kernel(grid_data, grid_data).evaluate()
+            self.assertLess(torch.norm(grid_eval - actual_eval), 2e-5)
 
-    def test_nongrid_grid(self):
-        base_kernel = RBFKernel()
-        data = torch.randn(5, d)
-        kernel = GridKernel(base_kernel, grid)
-        grid_eval = kernel(grid_data, data).evaluate()
-        actual_eval = base_kernel(grid_data, data).evaluate()
-        self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
+    def test_grid_grid_nontoeplitz(self):
+        return self.test_grid_grid(toeplitz=False)
 
-    def test_nongrid_nongrid(self):
-        base_kernel = RBFKernel()
-        data = torch.randn(5, d)
-        kernel = GridKernel(base_kernel, grid)
-        grid_eval = kernel(data, data).evaluate()
-        actual_eval = base_kernel(data, data).evaluate()
-        self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
+    def test_nongrid_grid(self, toeplitz=True):
+        with gpytorch.settings.use_toeplitz(toeplitz):
+            base_kernel = RBFKernel(ard_num_dims=2)
+            data = torch.randn(5, d)
+            kernel = GridKernel(base_kernel, grid)
+            grid_eval = kernel(grid_data, data).evaluate()
+            actual_eval = base_kernel(grid_data, data).evaluate()
+            self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
+
+    def test_nongrid_grid_nontoeplitz(self):
+        return self.test_nongrid_grid(toeplitz=False)
+
+    def test_nongrid_nongrid(self, toeplitz=True):
+        with gpytorch.settings.use_toeplitz(toeplitz):
+            base_kernel = RBFKernel(ard_num_dims=2)
+            data = torch.randn(5, d)
+            kernel = GridKernel(base_kernel, grid)
+            grid_eval = kernel(data, data).evaluate()
+            actual_eval = base_kernel(data, data).evaluate()
+            self.assertLess(torch.norm(grid_eval - actual_eval), 1e-5)
+
+    def test_nongrid_nongrid_nontoeplitz(self):
+        return self.test_nongrid_nongrid(toeplitz=False)
 
     def test_non_stationary_base(self):
         base_kernel = LinearKernel()


### PR DESCRIPTION
Closes #1054 

GridKernel and GridInterpKernel sometimes worked with ard (depending on the scale kernel ordering). This change makes GridKernel much more stable (and parallel) - and makes it so that ARD works with or without a scale kernel.