### PR TITLE
Add support to BatchRepeatLazyTensorfor nonsquare Matrices

### DIFF
--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -179,7 +179,6 @@ class BatchRepeatLazyTensor(LazyTensor):
         return res
 
     def _quad_form_derivative(self, left_vectors, right_vectors):
-        print("qf shapes", self.shape, left_vectors.shape, right_vectors.shape)
         if self.is_square:
             left_output_shape = _matmul_broadcast_shape(self.shape, left_vectors.shape)
             if left_output_shape != left_vectors.shape:

--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -95,13 +95,23 @@ class BatchRepeatLazyTensor(LazyTensor):
 
     def _matmul(self, rhs):
         output_shape = _matmul_broadcast_shape(self.shape, rhs.shape)
-        if rhs.shape != output_shape:
-            rhs = rhs.expand(*output_shape)
 
-        rhs = self._move_repeat_batches_to_columns(rhs, output_shape)
-        res = self.base_lazy_tensor._matmul(rhs)
-        res = self._move_repeat_batches_back(res, output_shape)
-        return res
+        # only attempt broadcasting if the non-batch dimensions are the same
+        if self.is_square:
+            if rhs.shape != output_shape:
+                rhs = rhs.expand(*output_shape)
+
+            rhs = self._move_repeat_batches_to_columns(rhs, output_shape)
+            res = self.base_lazy_tensor._matmul(rhs)
+            res = self._move_repeat_batches_back(res, output_shape)
+            return res
+        else:
+            # otherwise, we will rely on base tensor broadcasting
+            res = self.base_lazy_tensor._matmul(rhs)
+            if res.shape != output_shape:
+                res = res.expand(*output_shape)
+
+            return res
 
     def _move_repeat_batches_back(self, batch_matrix, output_shape):
         """
@@ -169,15 +179,22 @@ class BatchRepeatLazyTensor(LazyTensor):
         return res
 
     def _quad_form_derivative(self, left_vectors, right_vectors):
-        left_output_shape = _matmul_broadcast_shape(self.shape, left_vectors.shape)
-        if left_output_shape != left_vectors.shape:
-            left_vectors = left_vectors.expand(left_output_shape)
-        right_output_shape = _matmul_broadcast_shape(self.shape, right_vectors.shape)
-        if right_output_shape != right_vectors.shape:
-            right_vectors = right_vectors.expand(right_output_shape)
-        left_vectors = self._move_repeat_batches_to_columns(left_vectors, left_output_shape)
-        right_vectors = self._move_repeat_batches_to_columns(right_vectors, right_output_shape)
-        return self.base_lazy_tensor._quad_form_derivative(left_vectors, right_vectors)
+        print("qf shapes", self.shape, left_vectors.shape, right_vectors.shape)
+        if self.is_square:
+            left_output_shape = _matmul_broadcast_shape(self.shape, left_vectors.shape)
+            if left_output_shape != left_vectors.shape:
+                left_vectors = left_vectors.expand(left_output_shape)
+
+            right_output_shape = _matmul_broadcast_shape(self.shape, right_vectors.shape)
+            if right_output_shape != right_vectors.shape:
+                right_vectors = right_vectors.expand(right_output_shape)
+
+            left_vectors = self._move_repeat_batches_to_columns(left_vectors, left_output_shape)
+            right_vectors = self._move_repeat_batches_to_columns(right_vectors, right_output_shape)
+
+            return self.base_lazy_tensor._quad_form_derivative(left_vectors, right_vectors)
+        else:
+            return super()._quad_form_derivative(left_vectors, right_vectors)
 
     def _root_decomposition(self):
         return self.base_lazy_tensor._root_decomposition().repeat(*self.batch_repeat, 1, 1)

--- a/test/lazy/test_batch_repeat_lazy_tensor.py
+++ b/test/lazy/test_batch_repeat_lazy_tensor.py
@@ -4,8 +4,9 @@ import unittest
 
 import torch
 
+from gpytorch import lazify
 from gpytorch.lazy import BatchRepeatLazyTensor, ToeplitzLazyTensor
-from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase
+from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase, RectangularLazyTensorTestCase
 
 
 class TestBatchRepeatLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -15,6 +16,19 @@ class TestBatchRepeatLazyTensor(LazyTensorTestCase, unittest.TestCase):
         toeplitz_column = torch.tensor([4, 0.1, 0.05, 0.01, 0.0], dtype=torch.float)
         toeplitz_column.detach_()
         return BatchRepeatLazyTensor(ToeplitzLazyTensor(toeplitz_column), torch.Size((3,)))
+
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        evaluated = lazy_tensor.base_lazy_tensor.evaluate()
+        return evaluated.repeat(*lazy_tensor.batch_repeat, 1, 1)
+
+
+class TestBatchRepeatLazyTensorNonSquare(RectangularLazyTensorTestCase, unittest.TestCase):
+    seed = 0
+
+    def create_lazy_tensor(self):
+        rand_mat = torch.randn(25, 12, dtype=torch.float)
+        rand_mat.detach_()
+        return BatchRepeatLazyTensor(lazify(rand_mat), torch.Size((10,)))
 
     def evaluate_lazy_tensor(self, lazy_tensor):
         evaluated = lazy_tensor.base_lazy_tensor.evaluate()


### PR DESCRIPTION
Provides a fix to https://github.com/cornellius-gp/gpytorch/issues/1064 by adding in flags to the `_matmul` and `_quad_form_derivative` methods of `BatchRepeatLazyTensor` when the repeated lazy tensor is not square (as happens when trying to batch expand prediction strategy covariance matrices).

I also added a unit test for the non-square case in the test file for `BatchRepeatLazyTensor`.