### PR TITLE
[RFC] "Unrolled" representation of multi-task MVN

### DIFF
--- a/examples/03_Multitask_Exact_GPs/demo_alternative_mtmvn_rep.ipynb
+++ b/examples/03_Multitask_Exact_GPs/demo_alternative_mtmvn_rep.ipynb
@@ -1,0 +1,921 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Alternative representation of MultitaskMultivariateNormal\n",
+    "\n",
+    "## Issue:\n",
+    "Currently, the interleaved/non-interleaved representation of MTMVN creates a bunch of headaches. It would be nice to have a higher-level API that abstracts away from these details. \n",
+    "\n",
+    "\n",
+    "## Suggestion:\n",
+    "Represent the covariance matrix as an \"unrolled\" tensor (e.g. `n x n x m x m`), instead of a `nm x nm` covariance matrix. That way things like scalarizations are easily done, and reshaping/viewing/getting items can be done more straightforwardly. \n",
+    "\n",
+    "\n",
+    "## Challenge:\n",
+    "In order to sample from this MVN, we need to compute the full `nm x nm` covariance matrix (to either compute the cholesky decomposition or apply iterative approximate root decomposition methods. We need to make sure this is transparent, fast, and happens without much overhead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 3  # number of points\n",
+    "m = 2  # number of outputs\n",
+    "\n",
+    "# create some full covar\n",
+    "\n",
+    "def make_rand_covar(k):\n",
+    "    a = torch.rand(k, k)\n",
+    "    return a @ a.t() + torch.diag_embed(torch.rand(k))\n",
+    "    \n",
+    "A = make_rand_covar(n * m)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### interleaved: block matrix where each block is an intra-point, cross-task covariance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "C_inter = torch.zeros(n, n, m, m)\n",
+    "\n",
+    "# this is obviously super inefficient, but it makes clear what we want\n",
+    "for i in range(n):\n",
+    "    for i_ in range(n):\n",
+    "        for j in range(m):\n",
+    "            for j_ in range(m):\n",
+    "                C_inter[i, i_, j, j_] = A[i*m+j, i_*m+j_]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[2.7159, 1.0785, 1.1687, 1.3138, 1.2568, 1.6569],\n",
+       "        [1.0785, 1.1027, 0.7116, 0.5418, 0.7340, 1.2092],\n",
+       "        [1.1687, 0.7116, 1.1992, 0.5868, 0.7759, 1.0248],\n",
+       "        [1.3138, 0.5418, 0.5868, 2.1368, 1.1354, 1.3857],\n",
+       "        [1.2568, 0.7340, 0.7759, 1.1354, 2.5999, 1.7795],\n",
+       "        [1.6569, 1.2092, 1.0248, 1.3857, 1.7795, 2.8634]])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[2.7159, 1.0785, 1.1687, 1.3138, 1.2568, 1.6569],\n",
+       "        [1.0785, 1.1027, 0.7116, 0.5418, 0.7340, 1.2092],\n",
+       "        [1.1687, 0.7116, 1.1992, 0.5868, 0.7759, 1.0248],\n",
+       "        [1.3138, 0.5418, 0.5868, 2.1368, 1.1354, 1.3857],\n",
+       "        [1.2568, 0.7340, 0.7759, 1.1354, 2.5999, 1.7795],\n",
+       "        [1.6569, 1.2092, 1.0248, 1.3857, 1.7795, 2.8634]])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# we can construct the full matrix as follows:\n",
+    "C_inter.permute(0, 2, 1, 3).reshape(m*n, m*n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[2.7159, 1.0785, 1.1687, 1.3138, 1.2568, 1.6569],\n",
+       "         [1.0785, 1.1027, 0.7116, 0.5418, 0.7340, 1.2092],\n",
+       "         [1.1687, 0.7116, 1.1992, 0.5868, 0.7759, 1.0248],\n",
+       "         [1.3138, 0.5418, 0.5868, 2.1368, 1.1354, 1.3857],\n",
+       "         [1.2568, 0.7340, 0.7759, 1.1354, 2.5999, 1.7795],\n",
+       "         [1.6569, 1.2092, 1.0248, 1.3857, 1.7795, 2.8634]],\n",
+       "\n",
+       "        [[3.7159, 2.0785, 2.1687, 2.3138, 2.2568, 2.6569],\n",
+       "         [2.0785, 2.1027, 1.7116, 1.5418, 1.7340, 2.2092],\n",
+       "         [2.1687, 1.7116, 2.1992, 1.5868, 1.7759, 2.0248],\n",
+       "         [2.3138, 1.5418, 1.5868, 3.1368, 2.1354, 2.3857],\n",
+       "         [2.2568, 1.7340, 1.7759, 2.1354, 3.5999, 2.7795],\n",
+       "         [2.6569, 2.2092, 2.0248, 2.3857, 2.7795, 3.8634]]])"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# batched version\n",
+    "b = 2\n",
+    "A_b = torch.stack([A, A + 1])\n",
+    "C_inter_b = torch.zeros(b, n, n, m, m)\n",
+    "\n",
+    "# this is obviously super inefficient, but it makes clear what we want\n",
+    "for b_ in range(b):\n",
+    "    for i in range(n):\n",
+    "        for i_ in range(n):\n",
+    "            for j in range(m):\n",
+    "                for j_ in range(m):\n",
+    "                    C_inter_b[b_, i, i_, j, j_] = A_b[b_, i*m+j, i_*m+j_]\n",
+    "                    \n",
+    "C_inter_b.permute(0, 1, 3, 2, 4).reshape(b, m*n, m*n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[2.7159, 1.0785, 1.1687, 1.3138, 1.2568, 1.6569],\n",
+       "         [1.0785, 1.1027, 0.7116, 0.5418, 0.7340, 1.2092],\n",
+       "         [1.1687, 0.7116, 1.1992, 0.5868, 0.7759, 1.0248],\n",
+       "         [1.3138, 0.5418, 0.5868, 2.1368, 1.1354, 1.3857],\n",
+       "         [1.2568, 0.7340, 0.7759, 1.1354, 2.5999, 1.7795],\n",
+       "         [1.6569, 1.2092, 1.0248, 1.3857, 1.7795, 2.8634]],\n",
+       "\n",
+       "        [[3.7159, 2.0785, 2.1687, 2.3138, 2.2568, 2.6569],\n",
+       "         [2.0785, 2.1027, 1.7116, 1.5418, 1.7340, 2.2092],\n",
+       "         [2.1687, 1.7116, 2.1992, 1.5868, 1.7759, 2.0248],\n",
+       "         [2.3138, 1.5418, 1.5868, 3.1368, 2.1354, 2.3857],\n",
+       "         [2.2568, 1.7340, 1.7759, 2.1354, 3.5999, 2.7795],\n",
+       "         [2.6569, 2.2092, 2.0248, 2.3857, 2.7795, 3.8634]]])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# the general formulation:\n",
+    "batch_shape = C_inter_b.shape[:-4]\n",
+    "C_inter_b.permute(*range(len(batch_shape)), -4, -2, -3, -1).reshape(*batch_shape, m*n, m*n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# how do we go back? I.e. construct C_inter efficiently form the full matrix? Just do the same thing in reverse\n",
+    "\n",
+    "batch_shape = A_b.shape[:-2]\n",
+    "C_inter_b_recov = A_b.reshape(*batch_shape, n, m, n, m).permute(*range(len(batch_shape)), -4, -2, -3, -1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.allclose(C_inter_b, C_inter_b_recov)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### non-interleaved: block matrix where each block is an intra-task, cross-point covariance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "C_noninter = torch.zeros(m, m, n, n)\n",
+    "\n",
+    "# this is obviously super inefficient, but it makes clear what we want\n",
+    "for i in range(m):\n",
+    "    for i_ in range(m):\n",
+    "        for j in range(n):\n",
+    "            for j_ in range(n):\n",
+    "                C_noninter[i, i_, j, j_] = A[i*n+j, i_*n+j_]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[2.7159, 1.0785, 1.1687, 1.3138, 1.2568, 1.6569],\n",
+       "        [1.0785, 1.1027, 0.7116, 0.5418, 0.7340, 1.2092],\n",
+       "        [1.1687, 0.7116, 1.1992, 0.5868, 0.7759, 1.0248],\n",
+       "        [1.3138, 0.5418, 0.5868, 2.1368, 1.1354, 1.3857],\n",
+       "        [1.2568, 0.7340, 0.7759, 1.1354, 2.5999, 1.7795],\n",
+       "        [1.6569, 1.2092, 1.0248, 1.3857, 1.7795, 2.8634]])"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[2.7159, 1.0785, 1.1687, 1.3138, 1.2568, 1.6569],\n",
+       "        [1.0785, 1.1027, 0.7116, 0.5418, 0.7340, 1.2092],\n",
+       "        [1.1687, 0.7116, 1.1992, 0.5868, 0.7759, 1.0248],\n",
+       "        [1.3138, 0.5418, 0.5868, 2.1368, 1.1354, 1.3857],\n",
+       "        [1.2568, 0.7340, 0.7759, 1.1354, 2.5999, 1.7795],\n",
+       "        [1.6569, 1.2092, 1.0248, 1.3857, 1.7795, 2.8634]])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# again we can construct the matrix as follows:\n",
+    "C_noninter.permute(0, 2, 1, 3).reshape(m*n, m*n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# batched version\n",
+    "C_noninter_b = torch.zeros(b, m, m, n, n)\n",
+    "\n",
+    "# this is obviously super inefficient, but it makes clear what we want\n",
+    "for b_ in range(b):\n",
+    "    for i in range(m):\n",
+    "        for i_ in range(m):\n",
+    "            for j in range(n):\n",
+    "                for j_ in range(n):\n",
+    "                    C_noninter_b[b_, i, i_, j, j_] = A_b[b_, i*n+j, i_*n+j_]\n",
+    "                    \n",
+    "torch.allclose(\n",
+    "    C_noninter_b.permute(0, 1, 3, 2, 4).reshape(b, m*n, m*n),\n",
+    "    A_b,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# and again we can go back the same way\n",
+    "\n",
+    "batch_shape = A_b.shape[:-2]\n",
+    "C_noninter_b_recov = A_b.reshape(*batch_shape, m, n, m, n).permute(*range(len(batch_shape)), -4, -2, -3, -1)\n",
+    "torch.allclose(C_noninter_b, C_noninter_b_recov)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### alternate mixed-interleaved: block matrix where each block is an intra-point, cross-task covariance\n",
+    "\n",
+    "This seems to be the most useful internal representation, as this means we don't have to do any permuting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# alternate representation\n",
+    "C_alt = torch.zeros(n, m, n, m)\n",
+    "\n",
+    "# this is (obciously) super inefficient, but it makes clear what we want\n",
+    "for i in range(n):\n",
+    "    for j in range(m):\n",
+    "        for i_ in range(n):    \n",
+    "            for j_ in range(m):\n",
+    "                C_alt[i, j, i_, j_] = A[i*m+j, i_*m+j_]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[2.7159, 1.0785, 1.1687, 1.3138, 1.2568, 1.6569],\n",
+       "        [1.0785, 1.1027, 0.7116, 0.5418, 0.7340, 1.2092],\n",
+       "        [1.1687, 0.7116, 1.1992, 0.5868, 0.7759, 1.0248],\n",
+       "        [1.3138, 0.5418, 0.5868, 2.1368, 1.1354, 1.3857],\n",
+       "        [1.2568, 0.7340, 0.7759, 1.1354, 2.5999, 1.7795],\n",
+       "        [1.6569, 1.2092, 1.0248, 1.3857, 1.7795, 2.8634]])"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[2.7159, 1.0785, 1.1687, 1.3138, 1.2568, 1.6569],\n",
+       "        [1.0785, 1.1027, 0.7116, 0.5418, 0.7340, 1.2092],\n",
+       "        [1.1687, 0.7116, 1.1992, 0.5868, 0.7759, 1.0248],\n",
+       "        [1.3138, 0.5418, 0.5868, 2.1368, 1.1354, 1.3857],\n",
+       "        [1.2568, 0.7340, 0.7759, 1.1354, 2.5999, 1.7795],\n",
+       "        [1.6569, 1.2092, 1.0248, 1.3857, 1.7795, 2.8634]])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# this is super straightforward\n",
+    "C_alt.view(n*m, n*m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# alternate representation\n",
+    "C_alt_b = torch.zeros(b, n, m, n, m)\n",
+    "\n",
+    "# this is (obciously) super inefficient, but it makes clear what we want\n",
+    "for b_ in range(b):\n",
+    "    for i in range(n):\n",
+    "        for j in range(m):\n",
+    "            for i_ in range(n):    \n",
+    "                for j_ in range(m):\n",
+    "                    C_alt_b[b_, i, j, i_, j_] = A_b[b_, i*m+j, i_*m+j_]\n",
+    "\n",
+    "batch_shape = C_alt_b.shape[:-4]\n",
+    "torch.allclose(\n",
+    "    C_alt_b.view(*batch_shape, n*m, n*m),\n",
+    "    A_b,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# ....and going back\n",
+    "\n",
+    "batch_shape = A_b.shape[:-2]\n",
+    "C_alt_b_recov = A_b.reshape(*batch_shape, n, m, n, m) #.permute(*range(len(batch_shape)), -4, -2, -3, -1)\n",
+    "torch.allclose(C_alt_b, C_alt_b_recov)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Question: What if the tensor memory layout is different? Do we need to handle that?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Scalarizing\n",
+    "\n",
+    "This representation makes scalarizing across the outputs trivial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[1.1511, 0.6632, 0.7950],\n",
+       "        [0.6632, 0.6734, 0.6435],\n",
+       "        [0.7950, 0.6435, 1.4682]])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "weights = torch.rand(m)\n",
+    "(C_alt @ weights).transpose(-1, -2) @ weights"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Representing independet outputs\n",
+    "\n",
+    "Here we can just store the `m` individual `n x n` blocks as a `m x n x n` tensor, no need to store the cross covariances.\n",
+    "\n",
+    "We could also think of the case where we have independence across points, and only inter-task correlation. This will typically not be the case though, so we can punt on this for now."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[1.4507, 0.7111, 0.4856, 0.0000, 0.0000, 0.0000],\n",
+       "        [0.7111, 1.3544, 0.1176, 0.0000, 0.0000, 0.0000],\n",
+       "        [0.4856, 0.1176, 1.4699, 0.0000, 0.0000, 0.0000],\n",
+       "        [0.0000, 0.0000, 0.0000, 2.0618, 0.7923, 0.7034],\n",
+       "        [0.0000, 0.0000, 0.0000, 0.7923, 1.4361, 0.1751],\n",
+       "        [0.0000, 0.0000, 0.0000, 0.7034, 0.1751, 1.9329]])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from gpytorch.lazy import BlockDiagLazyTensor\n",
+    "\n",
+    "C_indep = torch.stack([make_rand_covar(n) for _ in range(m)])\n",
+    "\n",
+    "# using the lazy here will speed up matrix operations\n",
+    "BlockDiagLazyTensor(C_indep).evaluate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[1.4507, 0.7111, 0.4856],\n",
+       "         [0.7111, 1.3544, 0.1176],\n",
+       "         [0.4856, 0.1176, 1.4699]],\n",
+       "\n",
+       "        [[2.0618, 0.7923, 0.7034],\n",
+       "         [0.7923, 1.4361, 0.1751],\n",
+       "         [0.7034, 0.1751, 1.9329]]])"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "C_indep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[1.4507, 0.7111, 0.4856, 0.0000, 0.0000, 0.0000],\n",
+       "        [0.7111, 1.3544, 0.1176, 0.0000, 0.0000, 0.0000],\n",
+       "        [0.4856, 0.1176, 1.4699, 0.0000, 0.0000, 0.0000],\n",
+       "        [0.0000, 0.0000, 0.0000, 2.0618, 0.7923, 0.7034],\n",
+       "        [0.0000, 0.0000, 0.0000, 0.7923, 1.4361, 0.1751],\n",
+       "        [0.0000, 0.0000, 0.0000, 0.7034, 0.1751, 1.9329]])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# how do we construct the full matrix (we don't want to do this in general, but maybe sometimes)\n",
+    "# Once https://github.com/pytorch/pytorch/issues/31932 goes in, we can just use that instead\n",
+    "\n",
+    "batch_shape = C_indep.shape[:-3]\n",
+    "out = torch.zeros(*batch_shape, m*n, m*n, device=C_indep.device, dtype=C_indep.dtype)\n",
+    "for i, vals in enumerate(C_indep):\n",
+    "    start = i*n\n",
+    "    end = start + n\n",
+    "    out[..., start:end, start:end].copy_(vals)\n",
+    "    \n",
+    "out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# We can also allow arbitrary order in the construction...\n",
+    "\n",
+    "### ... so long as we have a consistent internal representation\n",
+    "\n",
+    "The following orders are admissible (`n` is the number of points, `t` is the number tasks):\n",
+    "\n",
+    "```\n",
+    "nntt\n",
+    "ntnt\n",
+    "nttn\n",
+    "ttnn\n",
+    "tntn\n",
+    "tnnt\n",
+    "\n",
+    "nnt\n",
+    "ntt\n",
+    "ntn\n",
+    "ttn\n",
+    "tnt\n",
+    "tnn\n",
+    "```\n",
+    "\n",
+    "So basically we have the set \n",
+    "```\n",
+    "nnt\n",
+    "ntt\n",
+    "ntn\n",
+    "ttn\n",
+    "tnt\n",
+    "tnn\n",
+    "```\n",
+    "\n",
+    "and then the whole set of admissible combinations we get by combining this wiht the set we get by post-pending with the single letter (we could pre-pend too but that would just generate duplicates"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we know this is admissible. We'd like to store things consistently internally. There are four options:\n",
+    "\n",
+    "- no independence -> can standardize to `n x t x n x t`\n",
+    "- cross-task independence only -> can standardize to `t x n x n`\n",
+    "- cross-point independence only -> can standardize to `n x t x t`\n",
+    "- cross-task AND cross-point independence: This is trivial -> can standardize to `n x t` (just marginal variances)\n",
+    "\n",
+    "**For now we focus on the first two cases**, we can deal with the other ones later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gpytorch.distributions.new_multitask_multivariate_normal import MultitaskMultivariateNormal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_b = torch.randn(b, n, m)\n",
+    "\n",
+    "mtmvn = MultitaskMultivariateNormal(mean=mean_b, covariance=C_alt_b, order=\"ntnt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([2, 3, 2])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mtmvn.mean.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([2, 3, 2])"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mtmvn.variance.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([4, 2, 3, 2])"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mtmvn.rsample(torch.Size([4])).shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([-7.0052, -8.6431])"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mtmvn.log_prob(mtmvn.mean + torch.randn_like(mtmvn.mean))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Independent tasks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "C_indep_b = torch.stack([C_indep, C_indep + 1])\n",
+    "\n",
+    "mtmvn_indep = MultitaskMultivariateNormal(mean=mean_b, covariance=C_indep_b, order=\"tnn\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([2, 3, 2])"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mtmvn_indep.mean.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([2, 3, 2])"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mtmvn_indep.variance.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([4, 2, 3, 2])"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mtmvn_indep.rsample(torch.Size([4])).shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([-10.5470, -12.9468])"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mtmvn_indep.log_prob(mtmvn_indep.mean + torch.randn_like(mtmvn_indep.mean))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/gpytorch/distributions/new_multitask_multivariate_normal.py
+++ b/gpytorch/distributions/new_multitask_multivariate_normal.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Iterable, Optional, Tuple
+
+import torch
+from torch import Tensor
+from torch.distributions.multivariate_normal import _batch_mahalanobis
+
+from gpytorch.distributions import MultivariateNormal
+
+ADMISSIBLE_ORDERS = {"nnt", "ntt", "ntn", "ttn", "tnt", "tnn"}
+
+
+class MultitaskMultivariateNormal(MultivariateNormal):
+    def __init__(self, mean: Tensor, covariance: Tensor, order: str = "ntnt") -> MultitaskMultivariateNormal:
+        """Construct a MultitaskMultivariateNormal from a stacked representation of its covariance matrix.
+
+        :param torch.tensor mean: A `batch_shape x n x t` tensor of means
+        :param torch.tensor covariance: A `batch_shape x shape`-dim tensor, where `shape` has either three
+            or four elements and can be any combination of "n" and "t" with at least one and at most two
+            occurrences of both "n" and "t" (currently only n==2 is supported)
+
+        Internally, the covariance is represented consistently as `n x t n x t` or `t x n x n` (case of
+        cross-task independence) in order to simplify indexing / scalarization operations.
+
+        """
+        # TODO: Clean this up
+        if len(order) not in {3, 4}:
+            raise ValueError
+        if order[:3] not in ADMISSIBLE_ORDERS:
+            raise ValueError
+        cnt = Counter(order)
+        if len(cnt) > 2:
+            raise ValueError
+        elif max(cnt.values()) > 2:
+            raise ValueError
+        self._task_indep = cnt["t"] == 1
+        self._point_indep = cnt["n"] == 1
+        if self._point_indep:
+            raise NotImplementedError("Independent points currently unsupported")
+
+        self._mean = mean
+        self._batch_shape = mean.shape[:-2]
+        b = len(self._batch_shape)
+        # TODO: Clean this up, avoid enumerating everything
+        if order == "ntnt":
+            self._covar = covariance
+        elif order == "nntt":
+            self._covar = covariance.permute(*range(b), -2, -3, -4, -1)
+        elif order == "nttn":
+            self._covar = covariance.transpose(-1, -2)
+        elif order == "ttnn":
+            self._covar = covariance.permute(*range(b), -4, -2, -3, -1)
+        elif order == "tntn":
+            self._covar = covariance.permute(*range(b), -3, -4, -1, -2)
+        elif order == "tnnt":
+            self._covar = covariance.transpose(-4, -3)
+        # cross-task independency
+        elif order == "tnn":
+            self._covar = covariance
+        elif order == "nnt":
+            self._covar = covariance.transpose(-3, -1)
+        elif order == "ntn":
+            self._covar = covariance.transpose(-3, -2)
+        else:
+            raise ValueError(f"Unsuported order '{order}'")
+
+    @classmethod
+    def from_independent_mvns(cls, mvns: Iterable[MultivariateNormal]) -> MultitaskMultivariateNormal:
+        mean = torch.stack([mvn.mean for mvn in mvns], dim=-1)
+        covariance = torch.cat([mvn.covariance_matrix.unsqueeze(-3) for mvn in mvns], dim=-3)
+        return cls(mean=mean, covariance=covariance, order="tnn")
+
+    @classmethod
+    def from_batch_mvn(cls, batch_mvn: MultivariateNormal, task_dim: int = -1) -> MultitaskMultivariateNormal:
+        mean = batch_mvn.mean
+        batch_shape = mean.shape[:-1]
+        if task_dim < 0:
+            task_dim += len(batch_shape)
+        mean = mean.permute(*range(0, task_dim), *range(task_dim + 1, mean.ndim), task_dim)
+        cov = batch_mvn.covariance_matrix
+        covariance = cov.permute(*range(0, task_dim), *range(task_dim + 1, cov.ndim - 2), task_dim, -2, -1)
+        return cls(mean=mean, covariance=covariance, order="tnn")
+
+    @property
+    def event_shape(self) -> torch.Size:
+        return self._mean.shape[-2:]
+
+    @property
+    def num_tasks(self) -> int:
+        return self.event_shape[-1]
+
+    @property
+    def mean(self) -> Tensor:
+        return self._mean
+
+    @property
+    def variance(self) -> Tensor:
+        if self._task_indep:
+            # _covar is t x n x n
+            return torch.diagonal(self._covar, dim1=-1, dim2=-2).transpose(-1, -2)
+        # _covar is n x t x n x t
+        C = torch.diagonal(self._covar, dim1=-1, dim2=-3)
+        return torch.diagonal(C, dim1=-3, dim2=-2).transpose(-1, -2)
+
+    def expand(self, batch_size: Tuple[int, ...]) -> MultitaskMultivariateNormal:
+        mean = self.mean.expand(torch.Size(batch_size) + self.mean.shape[-2:])
+        k = 3 if self._task_indep else 4
+        order = "tnn" if self._task_indep else "ntnt"
+        covariance = self._covar.expand(torch.Size(batch_size) + self._covar.shape[-k:])
+        return self.__class__(mean=mean, covariance=covariance, order=order)
+
+    def rsample(self, sample_shape: torch.Size = torch.Size(), base_samples: Optional[Tensor] = None) -> Tensor:
+        if base_samples is not None:
+            raise NotImplementedError
+        if self._task_indep:
+            # TODO: Use lazies + caching!
+            L = torch.cholesky(self._covar)
+            eps = torch.randn(*sample_shape, *L.shape[:-1], 1)
+            zero_mean_samples = (L @ eps).squeeze(-1).transpose(-1, -2)
+        else:
+            n, t = self._covar.shape[-2:]
+            covar = self._covar.view(*self._batch_shape, n * t, n * t)
+            # TODO: Use lazies + caching!
+            L = torch.cholesky(covar)
+            eps = torch.randn(*sample_shape, *L.shape[:-1], 1)
+            s = (L @ eps).squeeze(-1)
+            zero_mean_samples = s.reshape(*sample_shape, *self._batch_shape, n, t)
+
+        return self.mean + zero_mean_samples
+
+    def log_prob(self, value: Tensor) -> Tensor:
+        if self._task_indep:
+            # TODO: Use lazies and caching
+            ust = torch.cholesky(self._covar)
+            loc = self.mean.transpose(-1, -2)
+            logprobs = mvn_log_prob(loc, ust, value.transpose(-1, -2))
+            return logprobs.sum(-1)
+        else:
+            n, t = self.event_shape
+            covariance = self._covar.reshape(*self.batch_shape, n * t, n * t)
+            # TODO: Use lazies and caching
+            ust = torch.cholesky(covariance)
+            loc = self.mean.reshape(-1, n * t)
+            return mvn_log_prob(loc, ust, value.view(*value.shape[:-2], -1))
+
+
+def mvn_log_prob(loc: Tensor, unbroadcasted_scale_tril: Tensor, value: Tensor) -> Tensor:
+    diff = value - loc
+    M = _batch_mahalanobis(unbroadcasted_scale_tril, diff)
+    half_log_det = unbroadcasted_scale_tril.diagonal(dim1=-2, dim2=-1).log().sum(-1)
+    return -0.5 * (loc.size(-1) * math.log(2 * math.pi) + M) - half_log_det


### PR DESCRIPTION
Currently, the interleaved/non-interleaved representation of MTMVN creates a bunch of headaches (in particular regarding indexing, scalarization, and performance). It would be nice to have a higher-level API that abstracts away from these details (see #1055).

In this RFC, the covariance matrix is represented as an "unrolled" tensor (e.g. `n x t x n x t`), instead of a `nt x nt` covariance matrix. The constructor accepts a covariance matrix of shape `batch_shape x shape`-dim tensor, where `shape` has either three or four elements, and can be any combination of "n" and "t" with at least one and at most two occurrences of both "n" and "t" (currently only n==2 is supported). Internally, the covariance is represented consistently as `n x t n x t` or `t x n x n` (case of cross-task independence) in order to simplify indexing / scalarization operations.

The main benefits here are: 
1) It makes indexing much easier (e.g. if we want the cross-point covariance at some task `j`, we can just index the internal covariance as `_covar[..., :, j, :, j]` and we are done. With the current representation (especially considering the interleaving option) this is a huge headache. Note that this RFC does not include any indexing functions)
2) We can represent MTMVNs with independent outputs much more efficiently, without necessarily having to do a ton of `LazyTensor` acrobatics. Importantly, this should mean that in this case sampling and computing log probs should be much faster. 
3) We can easily scalarize multi-output posteriors (in fact, this is related to indexing)

Currently, this is very early work, and so there are major limitations with this:
1) This PR assumes proper tensors throughout (no support for `LazyTensor` yet)
2) No caching of matrix decompositions (yet)
3) The class subclasses `MultivariateNormal` (and hence the torch  `MultivariateNormal`), but it doesn't make sure that it implements the full interface, probably a lot of stuff will just break.
4) No support for `covariance_matrix` and `lazy_covariance_matrix` interface. I am actually not sure that we'll need this though.


The notebook included in this PR demos the basic usage of this.