### PR TITLE
Add custom cholesky method to KroneckerProductLazyTensor

### DIFF
--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -112,3 +112,7 @@ class KroneckerProductLazyTensor(LazyTensor):
 
     def _transpose_nonbatch(self):
         return self.__class__(*(lazy_tensor._transpose_nonbatch() for lazy_tensor in self.lazy_tensors), **self._kwargs)
+
+    @cached(name="cholesky")
+    def _cholesky(self):
+        return KroneckerProductLazyTensor(*[lt._cholesky() for lt in self.lazy_tensors])

--- a/gpytorch/test/lazy_tensor_test_case.py
+++ b/gpytorch/test/lazy_tensor_test_case.py
@@ -356,6 +356,14 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
                 actual[..., i, i] = actual[..., i, i] + other_diag[..., i]
             self.assertAllClose(res, actual, rtol=1e-2, atol=1e-5)
 
+    def test_cholesky(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        res = lazy_tensor.cholesky().evaluate()
+        actual = torch.cholesky(evaluated)
+        self.assertAllClose(res, actual, rtol=1e-3, atol=1e-5)
+
     def test_diag(self):
         lazy_tensor = self.create_lazy_tensor()
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)

--- a/test/lazy/test_interpolated_lazy_tensor.py
+++ b/test/lazy/test_interpolated_lazy_tensor.py
@@ -5,7 +5,7 @@ import unittest
 import torch
 
 from gpytorch.lazy import InterpolatedLazyTensor, NonLazyTensor
-from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase
+from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase, RectangularLazyTensorTestCase
 
 
 class TestInterpolatedLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -145,7 +145,7 @@ def empty_method(self):
     pass
 
 
-class TestInterpolatedLazyTensorRectangular(LazyTensorTestCase, unittest.TestCase):
+class TestInterpolatedLazyTensorRectangular(RectangularLazyTensorTestCase, unittest.TestCase):
     def create_lazy_tensor(self):
         itplzt = InterpolatedLazyTensor(NonLazyTensor(torch.rand(3, 4)))
         return itplzt


### PR DESCRIPTION
`chol(A \kron B) = chol(A) \kron chol(B)`

I don't think this is actually used very often (typically there is a `+ sigma^2 I` in there), but if we need it this should be way faster (`O(max(n,m)^3)` vs. `O((nm)^3)`). 

More generally, we can probably speed up other things if we want. e.g. `logdet(A \kron B) = logdet(A) logdet(B)`...