### PR TITLE
Always use output shape instead of input shape for noise shape

### DIFF
--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -30,13 +30,7 @@ class _GaussianLikelihoodBase(Likelihood):
         self.noise_covar = noise_covar
 
     def _shaped_noise_covar(self, base_shape: torch.Size, *params: Any, **kwargs: Any):
-        if len(params) > 0:
-            # we can infer the shape from the params
-            shape = None
-        else:
-            # here shape[:-1] is the batch shape requested, and shape[-1] is `n`, the number of points
-            shape = base_shape
-        return self.noise_covar(*params, shape=shape, **kwargs)
+        return self.noise_covar(*params, shape=base_shape, **kwargs)
 
     def expected_log_prob(self, target: Tensor, input: MultivariateNormal, *params: Any, **kwargs: Any) -> Tensor:
         mean, variance = input.mean, input.variance


### PR DESCRIPTION
In Gaussian likelihoods, I can't see any reason why we would ever not want the noise diagonal we add to be equivalent to the shape we can resolve from the input distribution's mean. In particular, if `p(f | D)` has a mean of size ` b1 x ... x bk x n`, then shouldn't our noise be `b1 x ... x bk x n x n` always?

Right now, we try to get the shape from the input data if we have it available, but that is definitely wrong because the raw input data might not have been passed through a feature extractor that impacts the shape.

Fixes #1084  (hopefully)