### PR TITLE
Add TriangularLazyTensor

### DIFF
--- a/gpytorch/functions/_inv_matmul.py
+++ b/gpytorch/functions/_inv_matmul.py
@@ -12,7 +12,7 @@ def _solve(lazy_tsr, rhs):
     if isinstance(lazy_tsr, (CholLazyTensor, TriangularLazyTensor)):
         return lazy_tsr.inv_matmul(rhs)
     if settings.fast_computations.solves.off() or lazy_tsr.size(-1) <= settings.max_cholesky_size.value():
-        return lazy_tsr._cholesky()._cholesky_solve(rhs)
+        return lazy_tsr.cholesky()._cholesky_solve(rhs)
     else:
         with torch.no_grad():
             preconditioner = lazy_tsr.detach()._inv_matmul_preconditioner()

--- a/gpytorch/functions/_inv_matmul.py
+++ b/gpytorch/functions/_inv_matmul.py
@@ -7,6 +7,10 @@ from .. import settings
 
 
 def _solve(lazy_tsr, rhs):
+    from ..lazy import CholLazyTensor, TriangularLazyTensor
+
+    if isinstance(lazy_tsr, (CholLazyTensor, TriangularLazyTensor)):
+        return lazy_tsr.inv_matmul(rhs)
     if settings.fast_computations.solves.off() or lazy_tsr.size(-1) <= settings.max_cholesky_size.value():
         return lazy_tsr._cholesky()._cholesky_solve(rhs)
     else:

--- a/gpytorch/functions/_inv_quad.py
+++ b/gpytorch/functions/_inv_quad.py
@@ -12,7 +12,7 @@ def _solve(lazy_tsr, rhs):
         or settings.fast_computations.log_prob.off()
         or lazy_tsr.size(-1) <= settings.max_cholesky_size.value()
     ):
-        return lazy_tsr._cholesky()._cholesky_solve(rhs)
+        return lazy_tsr.cholesky()._cholesky_solve(rhs)
     else:
         with torch.no_grad():
             preconditioner = lazy_tsr.detach()._inv_matmul_preconditioner()

--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -24,6 +24,7 @@ from .root_lazy_tensor import RootLazyTensor
 from .sum_batch_lazy_tensor import SumBatchLazyTensor
 from .sum_lazy_tensor import SumLazyTensor
 from .toeplitz_lazy_tensor import ToeplitzLazyTensor
+from .triangular_lazy_tensor import TriangularLazyTensor
 from .zero_lazy_tensor import ZeroLazyTensor
 
 __all__ = [
@@ -54,5 +55,6 @@ __all__ = [
     "SumLazyTensor",
     "SumBatchLazyTensor",
     "ToeplitzLazyTensor",
+    "TriangularLazyTensor",
     "ZeroLazyTensor",
 ]

--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -13,7 +13,7 @@ from .diag_lazy_tensor import DiagLazyTensor
 from .interpolated_lazy_tensor import InterpolatedLazyTensor
 from .keops_lazy_tensor import KeOpsLazyTensor
 from .kronecker_product_added_diag_lazy_tensor import KroneckerProductAddedDiagLazyTensor
-from .kronecker_product_lazy_tensor import KroneckerProductLazyTensor
+from .kronecker_product_lazy_tensor import KroneckerProductLazyTensor, KroneckerProductTriangularLazyTensor
 from .lazy_evaluated_kernel_tensor import LazyEvaluatedKernelTensor
 from .lazy_tensor import LazyTensor, delazify
 from .matmul_lazy_tensor import MatmulLazyTensor
@@ -47,6 +47,7 @@ __all__ = [
     "KeOpsLazyTensor",
     "KroneckerProductLazyTensor",
     "KroneckerProductAddedDiagLazyTensor",
+    "KroneckerProductTriangularLazyTensor",
     "MatmulLazyTensor",
     "MulLazyTensor",
     "NonLazyTensor",

--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -35,18 +35,18 @@ class BatchRepeatLazyTensor(LazyTensor):
         self.batch_repeat = batch_repeat
 
     @cached(name="cholesky")
-    def _cholesky(self):
-        res = self.base_lazy_tensor._cholesky()
+    def _cholesky(self, upper=False):
+        res = self.base_lazy_tensor._cholesky(upper=upper)
         res = res.repeat(*self.batch_repeat, 1, 1)
         return res
 
-    def _cholesky_solve(self, rhs):
+    def _cholesky_solve(self, rhs, upper: bool = False):
         output_shape = _matmul_broadcast_shape(self.shape, rhs.shape)
         if rhs.shape != output_shape:
             rhs = rhs.expand(*output_shape)
 
         rhs = self._move_repeat_batches_to_columns(rhs, output_shape)
-        res = self.base_lazy_tensor._cholesky_solve(rhs)
+        res = self.base_lazy_tensor._cholesky_solve(rhs, upper=upper)
         res = self._move_repeat_batches_back(res, output_shape)
         return res
 

--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -38,7 +38,7 @@ class BatchRepeatLazyTensor(LazyTensor):
     def _cholesky(self, upper=False):
         from .triangular_lazy_tensor import TriangularLazyTensor
 
-        res = self.base_lazy_tensor._cholesky(upper=upper)._tensor
+        res = self.base_lazy_tensor.cholesky(upper=upper)._tensor
         res = res.repeat(*self.batch_repeat, 1, 1)
         return TriangularLazyTensor(res, upper=upper)
 

--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -38,11 +38,12 @@ class BatchRepeatLazyTensor(LazyTensor):
     def _cholesky(self, upper=False):
         from .triangular_lazy_tensor import TriangularLazyTensor
 
-        res = self.base_lazy_tensor._cholesky(upper=upper)
+        res = self.base_lazy_tensor._cholesky(upper=upper)._tensor
         res = res.repeat(*self.batch_repeat, 1, 1)
         return TriangularLazyTensor(res, upper=upper)
 
     def _cholesky_solve(self, rhs, upper: bool = False):
+        # TODO: Figure out how to deal with this with TriangularLazyTensor if returned by _cholesky
         output_shape = _matmul_broadcast_shape(self.shape, rhs.shape)
         if rhs.shape != output_shape:
             rhs = rhs.expand(*output_shape)

--- a/gpytorch/lazy/batch_repeat_lazy_tensor.py
+++ b/gpytorch/lazy/batch_repeat_lazy_tensor.py
@@ -36,9 +36,11 @@ class BatchRepeatLazyTensor(LazyTensor):
 
     @cached(name="cholesky")
     def _cholesky(self, upper=False):
+        from .triangular_lazy_tensor import TriangularLazyTensor
+
         res = self.base_lazy_tensor._cholesky(upper=upper)
         res = res.repeat(*self.batch_repeat, 1, 1)
-        return res
+        return TriangularLazyTensor(res, upper=upper)
 
     def _cholesky_solve(self, rhs, upper: bool = False):
         output_shape = _matmul_broadcast_shape(self.shape, rhs.shape)

--- a/gpytorch/lazy/block_diag_lazy_tensor.py
+++ b/gpytorch/lazy/block_diag_lazy_tensor.py
@@ -37,7 +37,7 @@ class BlockDiagLazyTensor(BlockLazyTensor):
     def _cholesky(self, upper=False):
         from .triangular_lazy_tensor import TriangularLazyTensor
 
-        chol = self.__class__(self.base_lazy_tensor._cholesky(upper=upper))
+        chol = self.__class__(self.base_lazy_tensor.cholesky(upper=upper))
         return TriangularLazyTensor(chol, upper=upper)
 
     def _cholesky_solve(self, rhs, upper: bool = False):

--- a/gpytorch/lazy/block_diag_lazy_tensor.py
+++ b/gpytorch/lazy/block_diag_lazy_tensor.py
@@ -35,7 +35,9 @@ class BlockDiagLazyTensor(BlockLazyTensor):
 
     @cached(name="cholesky")
     def _cholesky(self, upper=False):
-        return self.__class__(self.base_lazy_tensor._cholesky(upper=upper))
+        from .triangular_lazy_tensor import TriangularLazyTensor
+
+        return TriangularLazyTensor(self.__class__(self.base_lazy_tensor._cholesky(upper=upper)), upper=upper)
 
     def _cholesky_solve(self, rhs, upper: bool = False):
         rhs = self._add_batch_dim(rhs)

--- a/gpytorch/lazy/block_diag_lazy_tensor.py
+++ b/gpytorch/lazy/block_diag_lazy_tensor.py
@@ -34,12 +34,12 @@ class BlockDiagLazyTensor(BlockLazyTensor):
         return other
 
     @cached(name="cholesky")
-    def _cholesky(self):
-        return self.__class__(self.base_lazy_tensor._cholesky())
+    def _cholesky(self, upper=False):
+        return self.__class__(self.base_lazy_tensor._cholesky(upper=upper))
 
-    def _cholesky_solve(self, rhs):
+    def _cholesky_solve(self, rhs, upper: bool = False):
         rhs = self._add_batch_dim(rhs)
-        res = self.base_lazy_tensor._cholesky_solve(rhs)
+        res = self.base_lazy_tensor._cholesky_solve(rhs, upper=upper)
         res = self._remove_batch_dim(res)
         return res
 

--- a/gpytorch/lazy/block_diag_lazy_tensor.py
+++ b/gpytorch/lazy/block_diag_lazy_tensor.py
@@ -37,7 +37,8 @@ class BlockDiagLazyTensor(BlockLazyTensor):
     def _cholesky(self, upper=False):
         from .triangular_lazy_tensor import TriangularLazyTensor
 
-        return TriangularLazyTensor(self.__class__(self.base_lazy_tensor._cholesky(upper=upper)), upper=upper)
+        chol = self.__class__(self.base_lazy_tensor._cholesky(upper=upper))
+        return TriangularLazyTensor(chol, upper=upper)
 
     def _cholesky_solve(self, rhs, upper: bool = False):
         rhs = self._add_batch_dim(rhs)

--- a/gpytorch/lazy/block_interleaved_lazy_tensor.py
+++ b/gpytorch/lazy/block_interleaved_lazy_tensor.py
@@ -38,7 +38,8 @@ class BlockInterleavedLazyTensor(BlockLazyTensor):
     def _cholesky(self, upper=False):
         from .triangular_lazy_tensor import TriangularLazyTensor
 
-        return TriangularLazyTensor(self.__class__(self.base_lazy_tensor._cholesky(upper=upper)), upper=upper)
+        chol = self.__class__(self.base_lazy_tensor._cholesky(upper=upper))
+        return TriangularLazyTensor(chol, upper=upper)
 
     def _cholesky_solve(self, rhs, upper: bool = False):
         rhs = self._add_batch_dim(rhs)

--- a/gpytorch/lazy/block_interleaved_lazy_tensor.py
+++ b/gpytorch/lazy/block_interleaved_lazy_tensor.py
@@ -36,7 +36,9 @@ class BlockInterleavedLazyTensor(BlockLazyTensor):
 
     @cached(name="cholesky")
     def _cholesky(self, upper=False):
-        return self.__class__(self.base_lazy_tensor._cholesky(upper=upper))
+        from .triangular_lazy_tensor import TriangularLazyTensor
+
+        return TriangularLazyTensor(self.__class__(self.base_lazy_tensor._cholesky(upper=upper)), upper=upper)
 
     def _cholesky_solve(self, rhs, upper: bool = False):
         rhs = self._add_batch_dim(rhs)

--- a/gpytorch/lazy/block_interleaved_lazy_tensor.py
+++ b/gpytorch/lazy/block_interleaved_lazy_tensor.py
@@ -38,7 +38,7 @@ class BlockInterleavedLazyTensor(BlockLazyTensor):
     def _cholesky(self, upper=False):
         from .triangular_lazy_tensor import TriangularLazyTensor
 
-        chol = self.__class__(self.base_lazy_tensor._cholesky(upper=upper))
+        chol = self.__class__(self.base_lazy_tensor.cholesky(upper=upper))
         return TriangularLazyTensor(chol, upper=upper)
 
     def _cholesky_solve(self, rhs, upper: bool = False):

--- a/gpytorch/lazy/block_interleaved_lazy_tensor.py
+++ b/gpytorch/lazy/block_interleaved_lazy_tensor.py
@@ -35,12 +35,12 @@ class BlockInterleavedLazyTensor(BlockLazyTensor):
         return other
 
     @cached(name="cholesky")
-    def _cholesky(self):
-        return self.__class__(self.base_lazy_tensor._cholesky())
+    def _cholesky(self, upper=False):
+        return self.__class__(self.base_lazy_tensor._cholesky(upper=upper))
 
-    def _cholesky_solve(self, rhs):
+    def _cholesky_solve(self, rhs, upper: bool = False):
         rhs = self._add_batch_dim(rhs)
-        res = self.base_lazy_tensor._cholesky_solve(rhs)
+        res = self.base_lazy_tensor._cholesky_solve(rhs, upper=upper)
         res = self._remove_batch_dim(res)
         return res
 

--- a/gpytorch/lazy/cached_cg_lazy_tensor.py
+++ b/gpytorch/lazy/cached_cg_lazy_tensor.py
@@ -135,6 +135,8 @@ class CachedCGLazyTensor(LazyTensor):
         self.base_lazy_tensor.requires_grad = val
 
     def _cholesky(self, upper=False):
+        from .triangular_lazy_tensor import TriangularLazyTensor
+
         res = self.__class__(
             self.base_lazy_tensor._cholesky(upper=upper),
             eager_rhss=self.eager_rhss,
@@ -144,7 +146,7 @@ class CachedCGLazyTensor(LazyTensor):
             probe_vector_solves=self.probe_vector_solves,
             probe_vector_tmats=self.probe_vector_tmats,
         )
-        return res
+        return TriangularLazyTensor(res, upper=upper)
 
     def _cholesky_solve(self, rhs, upper: bool = False):
         # Here we check to see what solves we've already performed

--- a/gpytorch/lazy/cached_cg_lazy_tensor.py
+++ b/gpytorch/lazy/cached_cg_lazy_tensor.py
@@ -8,6 +8,7 @@ from .. import settings
 from ..utils.warnings import ExtraComputationWarning
 from .chol_lazy_tensor import CholLazyTensor
 from .lazy_tensor import LazyTensor
+from .triangular_lazy_tensor import TriangularLazyTensor
 
 
 class CachedCGLazyTensor(LazyTensor):
@@ -109,7 +110,7 @@ class CachedCGLazyTensor(LazyTensor):
         probe_vector_solves=torch.tensor([]),
         probe_vector_tmats=torch.tensor([]),
     ):
-        super(CachedCGLazyTensor, self).__init__(
+        super().__init__(
             base_lazy_tensor,
             eager_rhss=eager_rhss,
             solves=solves,
@@ -160,7 +161,7 @@ class CachedCGLazyTensor(LazyTensor):
                 "LazyTensor should pre-register all vectors to run CG against.".format(rhs.shape),
                 ExtraComputationWarning,
             )
-        return super()._cholesky_solve(rhs, upper=upper)
+        return torch.cholesky_solve(rhs, self.evaluate(), upper=upper)
 
     def _expand_batch(self, batch_shape):
         return self.base_lazy_tensor._expand_batch(batch_shape)
@@ -192,7 +193,7 @@ class CachedCGLazyTensor(LazyTensor):
                         "CachedCGLazyTensor did not recognize the supplied probe vectors for tridiagonalization.",
                         ExtraComputationWarning,
                     )
-                return super(CachedCGLazyTensor, self)._solve(rhs, preconditioner, num_tridiag=num_tridiag)
+                return super()._solve(rhs, preconditioner, num_tridiag=num_tridiag)
 
         # Here we check to see what solves we've already performed
         truncated_rhs = rhs[..., (num_tridiag or 0) :]
@@ -209,7 +210,7 @@ class CachedCGLazyTensor(LazyTensor):
                 "LazyTensor should pre-register all vectors to run CG against.".format(rhs.shape),
                 ExtraComputationWarning,
             )
-        return super(CachedCGLazyTensor, self)._solve(rhs, preconditioner, num_tridiag=num_tridiag)
+        return super()._solve(rhs, preconditioner, num_tridiag=num_tridiag)
 
     def _size(self):
         return self.base_lazy_tensor._size()
@@ -225,6 +226,9 @@ class CachedCGLazyTensor(LazyTensor):
         return self
 
     def inv_matmul(self, right_tensor, left_tensor=None):
+        if isinstance(self.base_lazy_tensor, TriangularLazyTensor):
+            return self.base_lazy_tensor.inv_matmul(right_tensor, left_tensor=left_tensor)
+
         if not isinstance(self.base_lazy_tensor, CholLazyTensor):
             return super().inv_matmul(right_tensor, left_tensor=left_tensor)
 

--- a/gpytorch/lazy/cached_cg_lazy_tensor.py
+++ b/gpytorch/lazy/cached_cg_lazy_tensor.py
@@ -89,7 +89,7 @@ class CachedCGLazyTensor(LazyTensor):
                 if settings.fast_computations.log_prob.on():
                     solves = base_lazy_tensor._solve(eager_rhs, preconditioner=base_lazy_tensor._preconditioner()[0])
                 else:
-                    solves = base_lazy_tensor._cholesky()._cholesky_solve(eager_rhs)
+                    solves = base_lazy_tensor.cholesky()._cholesky_solve(eager_rhs)
                 dtype = solves.dtype
                 device = solves.device
                 return (
@@ -139,7 +139,7 @@ class CachedCGLazyTensor(LazyTensor):
         from .triangular_lazy_tensor import TriangularLazyTensor
 
         res = self.__class__(
-            self.base_lazy_tensor._cholesky(upper=upper),
+            self.base_lazy_tensor.cholesky(upper=upper),
             eager_rhss=self.eager_rhss,
             solves=self.solves,
             probe_vectors=self.probe_vectors,

--- a/gpytorch/lazy/cached_cg_lazy_tensor.py
+++ b/gpytorch/lazy/cached_cg_lazy_tensor.py
@@ -134,9 +134,9 @@ class CachedCGLazyTensor(LazyTensor):
     def requires_grad(self, val):
         self.base_lazy_tensor.requires_grad = val
 
-    def _cholesky(self):
+    def _cholesky(self, upper=False):
         res = self.__class__(
-            self.base_lazy_tensor._cholesky(),
+            self.base_lazy_tensor._cholesky(upper=upper),
             eager_rhss=self.eager_rhss,
             solves=self.solves,
             probe_vectors=self.probe_vectors,
@@ -146,7 +146,7 @@ class CachedCGLazyTensor(LazyTensor):
         )
         return res
 
-    def _cholesky_solve(self, rhs):
+    def _cholesky_solve(self, rhs, upper: bool = False):
         # Here we check to see what solves we've already performed
         for eager_rhs, solve in zip(self.eager_rhss, self.solves):
             if torch.equal(rhs, eager_rhs):
@@ -158,7 +158,7 @@ class CachedCGLazyTensor(LazyTensor):
                 "LazyTensor should pre-register all vectors to run CG against.".format(rhs.shape),
                 ExtraComputationWarning,
             )
-        return super(CachedCGLazyTensor, self)._cholesky_solve(rhs)
+        return super()._cholesky_solve(rhs, upper=upper)
 
     def _expand_batch(self, batch_shape):
         return self.base_lazy_tensor._expand_batch(batch_shape)

--- a/gpytorch/lazy/chol_lazy_tensor.py
+++ b/gpytorch/lazy/chol_lazy_tensor.py
@@ -104,3 +104,7 @@ class CholLazyTensor(RootLazyTensor):
             logdet_term = self._chol_diag.pow(2).log().sum(-1)
 
         return inv_quad_term, logdet_term
+
+    def root_inv_decomposition(self, initial_vectors=None, test_vectors=None):
+        inv_root = self.root.inverse()
+        return RootLazyTensor(inv_root.transpose(-1, -2))

--- a/gpytorch/lazy/chol_lazy_tensor.py
+++ b/gpytorch/lazy/chol_lazy_tensor.py
@@ -16,11 +16,12 @@ class CholLazyTensor(RootLazyTensor):
     def _chol_diag(self):
         return self.root.diag()
 
+    @cached(name="cholesky")
     def _cholesky(self, upper=False):
         if upper == self.upper:
             return self.root
         else:
-            return self.root.transpose(-1, -2)
+            return self.root._transpose_nonbatch()
 
     def _solve(self, rhs, preconditioner, num_tridiag=0):
         if num_tridiag:
@@ -36,9 +37,9 @@ class CholLazyTensor(RootLazyTensor):
     def evaluate(self):
         root = self.root
         if self.upper:
-            res = root.transpose(-1, -2) @ root
+            res = root._transpose_nonbatch() @ root
         else:
-            res = root @ root.transpose(-1, -2)
+            res = root @ root._transpose_nonbatch()
         return res.evaluate()
 
     @cached
@@ -107,4 +108,4 @@ class CholLazyTensor(RootLazyTensor):
 
     def root_inv_decomposition(self, initial_vectors=None, test_vectors=None):
         inv_root = self.root.inverse()
-        return RootLazyTensor(inv_root.transpose(-1, -2))
+        return RootLazyTensor(inv_root._transpose_nonbatch())

--- a/gpytorch/lazy/chol_lazy_tensor.py
+++ b/gpytorch/lazy/chol_lazy_tensor.py
@@ -29,6 +29,7 @@ class CholLazyTensor(RootLazyTensor):
 
     @cached
     def diag(self):
+        # TODO: Can we be smarter here?
         return (self.root.evaluate() ** 2).sum(-1)
 
     @cached
@@ -42,7 +43,7 @@ class CholLazyTensor(RootLazyTensor):
 
     @cached
     def inverse(self):
-        Linv = self.root.inverse()
+        Linv = self.root.inverse()  # this could be slow in some cases w/ structured lazies
         return CholLazyTensor(Linv, upper=not self.upper)
 
     def inv_matmul(self, right_tensor, left_tensor=None):
@@ -57,7 +58,7 @@ class CholLazyTensor(RootLazyTensor):
         return res
 
     def inv_quad(self, tensor, reduce_inv_quad=True):
-        if self.root.upper:
+        if self.upper:
             R = self.root._transpose_nonbatch().inv_matmul(tensor)
         else:
             R = self.root.inv_matmul(tensor)

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -196,7 +196,7 @@ class ConstantDiagLazyTensor(DiagLazyTensor):
                 A `b1 x ... x bk x 1` Tensor, representing a `b1 x ... x bk`-sized batch
                 of `n x n` diagonal matrices
         """
-        super(DiagLazyTensor, self).__init__(diag_values, diag_shape=diag_shape)
+        super(TriangularLazyTensor, self).__init__(diag_values, diag_shape=diag_shape)
         self.diag_shape = diag_shape
         self._diag = diag_values.expand(*diag_values.shape[:-1], diag_shape)
 

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -8,6 +8,7 @@ from .lazy_tensor import LazyTensor
 from .non_lazy_tensor import NonLazyTensor
 
 
+# TODO: Subclass DiagLazyTensor from TriangularLazyTensor
 class DiagLazyTensor(LazyTensor):
     def __init__(self, diag):
         """
@@ -30,7 +31,10 @@ class DiagLazyTensor(LazyTensor):
 
     @cached(name="cholesky")
     def _cholesky(self, upper=False):
-        return self.sqrt()
+        from .triangular_lazy_tensor import TriangularLazyTensor
+
+        # if upper or lower doesn't matter here
+        return TriangularLazyTensor(self.sqrt())
 
     def _cholesky_solve(self, rhs, upper: bool = False):
         return rhs / self._diag.pow(2)

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -34,7 +34,7 @@ class DiagLazyTensor(LazyTensor):
         from .triangular_lazy_tensor import TriangularLazyTensor
 
         # if upper or lower doesn't matter here
-        return TriangularLazyTensor(self.sqrt())
+        return TriangularLazyTensor(self.sqrt(), upper=upper)
 
     def _cholesky_solve(self, rhs, upper: bool = False):
         return rhs / self._diag.pow(2)

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -4,12 +4,11 @@ import torch
 
 from ..utils.broadcasting import _mul_broadcast_shape
 from ..utils.memoize import cached
-from .lazy_tensor import LazyTensor
 from .non_lazy_tensor import NonLazyTensor
+from .triangular_lazy_tensor import TriangularLazyTensor
 
 
-# TODO: Subclass DiagLazyTensor from TriangularLazyTensor
-class DiagLazyTensor(LazyTensor):
+class DiagLazyTensor(TriangularLazyTensor):
     def __init__(self, diag):
         """
         Diagonal lazy tensor. Supports arbitrary batch sizes.
@@ -19,7 +18,7 @@ class DiagLazyTensor(LazyTensor):
                 A `b1 x ... x bk x n` Tensor, representing a `b1 x ... x bk`-sized batch
                 of `n x n` diagonal matrices
         """
-        super().__init__(diag)
+        super(TriangularLazyTensor, self).__init__(diag)
         self._diag = diag
 
     def __add__(self, other):
@@ -31,10 +30,7 @@ class DiagLazyTensor(LazyTensor):
 
     @cached(name="cholesky")
     def _cholesky(self, upper=False):
-        from .triangular_lazy_tensor import TriangularLazyTensor
-
-        # if upper or lower doesn't matter here
-        return TriangularLazyTensor(self.sqrt(), upper=upper)
+        return self.sqrt()
 
     def _cholesky_solve(self, rhs, upper: bool = False):
         return rhs / self._diag.pow(2)

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -28,7 +28,7 @@ class DiagLazyTensor(TriangularLazyTensor):
 
         return AddedDiagLazyTensor(other, self)
 
-    @cached(name="cholesky")
+    @cached(name="cholesky", ignore_args=True)
     def _cholesky(self, upper=False):
         return self.sqrt()
 

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -130,7 +130,7 @@ class KroneckerProductLazyTensor(LazyTensor):
 
     @cached(name="cholesky")
     def _cholesky(self, upper=False):
-        chol_factors = [lt._cholesky(upper=upper) for lt in self.lazy_tensors]
+        chol_factors = [lt.cholesky(upper=upper) for lt in self.lazy_tensors]
         return KroneckerProductTriangularLazyTensor(*chol_factors, upper=upper)
 
     def _get_indices(self, row_index, col_index, *batch_indices):

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -9,7 +9,7 @@ from torch import Tensor
 from .. import settings
 from ..utils.broadcasting import _matmul_broadcast_shape, _mul_broadcast_shape
 from ..utils.memoize import cached
-from .diag_lazy_tensor import ConstantDiagLazyTensor, DiagLazyTensor
+from .diag_lazy_tensor import DiagLazyTensor
 from .lazy_tensor import LazyTensor
 from .non_lazy_tensor import lazify
 from .triangular_lazy_tensor import TriangularLazyTensor

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -11,6 +11,7 @@ from ..utils.memoize import cached
 from .diag_lazy_tensor import DiagLazyTensor
 from .lazy_tensor import LazyTensor
 from .non_lazy_tensor import lazify
+from .triangular_lazy_tensor import TriangularLazyTensor
 
 
 def _kron_diag(*lts) -> Tensor:
@@ -97,6 +98,11 @@ class KroneckerProductLazyTensor(LazyTensor):
             if not self.is_square:
                 raise RuntimeError("Diag works on square matrices (or batches)")
         return _kron_diag(*self.lazy_tensors)
+
+    @cached(name="cholesky")
+    def _cholesky(self, upper=False):
+        chol = KroneckerProductLazyTensor(*[lt._cholesky(upper=upper) for lt in self.lazy_tensors])
+        return TriangularLazyTensor(chol, upper=upper)
 
     def _get_indices(self, row_index, col_index, *batch_indices):
         row_factor = self.size(-2)

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -3,7 +3,8 @@
 import operator
 from functools import reduce
 
-from torch import Size, Tensor
+import torch
+from torch import Tensor
 
 from .. import settings
 from ..utils.broadcasting import _matmul_broadcast_shape
@@ -45,7 +46,7 @@ def _matmul(lazy_tensors, kp_shape, rhs):
 def _t_matmul(lazy_tensors, kp_shape, rhs):
     kp_t_shape = (*kp_shape[:-2], kp_shape[-1], kp_shape[-2])
     output_shape = _matmul_broadcast_shape(kp_t_shape, rhs.shape)
-    output_batch_shape = Size(output_shape[:-2])
+    output_batch_shape = torch.Size(output_shape[:-2])
 
     res = rhs.contiguous().expand(*output_batch_shape, *rhs.shape[-2:])
     num_cols = rhs.size(-1)
@@ -76,7 +77,7 @@ class KroneckerProductLazyTensor(LazyTensor):
                     "KroneckerProductLazyTensor expects lazy tensors with the "
                     "same batch shapes. Got {}.".format([lv.batch_shape for lv in lazy_tensors])
                 )
-        super(KroneckerProductLazyTensor, self).__init__(*lazy_tensors)
+        super().__init__(*lazy_tensors)
         self.lazy_tensors = lazy_tensors
 
     def __add__(self, other):
@@ -84,6 +85,27 @@ class KroneckerProductLazyTensor(LazyTensor):
             return self.add_diag(other.diag())
         else:
             return super().__add__(other)
+
+    def add_diag(self, diag):
+        r"""
+        Adds a diagonal to a KroneckerProductLazyTensor
+        """
+
+        from .kronecker_product_added_diag_lazy_tensor import KroneckerProductAddedDiagLazyTensor
+
+        if not self.is_square:
+            raise RuntimeError("add_diag only defined for square matrices")
+
+        try:
+            expanded_diag = diag.expand(self.shape[:-1])
+        except RuntimeError:
+            raise RuntimeError(
+                "add_diag for LazyTensor of size {} received invalid diagonal of size {}.".format(
+                    self.shape, diag.shape
+                )
+            )
+
+        return KroneckerProductAddedDiagLazyTensor(self, DiagLazyTensor(expanded_diag))
 
     def diag(self):
         r"""
@@ -99,10 +121,18 @@ class KroneckerProductLazyTensor(LazyTensor):
                 raise RuntimeError("Diag works on square matrices (or batches)")
         return _kron_diag(*self.lazy_tensors)
 
+    @cached
+    def inverse(self):
+        # here we use that (A \kron B)^-1 = A^-1 \kron B^-1
+        inverses = [lt.inverse() for lt in self.lazy_tensors]
+        return self.__class__(*inverses)
+
+    # TODO: Investigate under what conditions computing individual individual inverses makes sense
+
     @cached(name="cholesky")
     def _cholesky(self, upper=False):
-        chol = KroneckerProductLazyTensor(*[lt._cholesky(upper=upper) for lt in self.lazy_tensors])
-        return TriangularLazyTensor(chol, upper=upper)
+        chol_factors = [lt._cholesky(upper=upper) for lt in self.lazy_tensors]
+        return KroneckerProductTriangularLazyTensor(*chol_factors, upper=upper)
 
     def _get_indices(self, row_index, col_index, *batch_indices):
         row_factor = self.size(-2)
@@ -153,31 +183,7 @@ class KroneckerProductLazyTensor(LazyTensor):
     def _size(self):
         left_size = _prod(lazy_tensor.size(-2) for lazy_tensor in self.lazy_tensors)
         right_size = _prod(lazy_tensor.size(-1) for lazy_tensor in self.lazy_tensors)
-        return Size((*self.lazy_tensors[0].batch_shape, left_size, right_size))
-
-    def _transpose_nonbatch(self):
-        return self.__class__(*(lazy_tensor._transpose_nonbatch() for lazy_tensor in self.lazy_tensors), **self._kwargs)
-
-    def add_diag(self, diag):
-        r"""
-        Adds a diagonal to a KroneckerProductLazyTensor
-        """
-
-        from .kronecker_product_added_diag_lazy_tensor import KroneckerProductAddedDiagLazyTensor
-
-        if not self.is_square:
-            raise RuntimeError("add_diag only defined for square matrices")
-
-        try:
-            expanded_diag = diag.expand(self.shape[:-1])
-        except RuntimeError:
-            raise RuntimeError(
-                "add_diag for LazyTensor of size {} received invalid diagonal of size {}.".format(
-                    self.shape, diag.shape
-                )
-            )
-
-        return KroneckerProductAddedDiagLazyTensor(self, DiagLazyTensor(expanded_diag))
+        return torch.Size((*self.lazy_tensors[0].batch_shape, left_size, right_size))
 
     @cached(name="symeig")
     def _symeig(self, eigenvectors=True):
@@ -208,3 +214,45 @@ class KroneckerProductLazyTensor(LazyTensor):
             evecs = Tensor([])
 
         return evals, evecs
+
+    def _transpose_nonbatch(self):
+        return self.__class__(*(lazy_tensor._transpose_nonbatch() for lazy_tensor in self.lazy_tensors), **self._kwargs)
+
+
+class KroneckerProductTriangularLazyTensor(KroneckerProductLazyTensor):
+    def __init__(self, *lazy_tensors, upper=False):
+        from .triangular_lazy_tensor import TriangularLazyTensor
+
+        if not all(isinstance(lt, TriangularLazyTensor) for lt in lazy_tensors):
+            raise RuntimeError("Components of KroneckerProductTriangularLazyTensor must be TriangularLazyTensor.")
+        super().__init__(*lazy_tensors)
+        self.upper = upper
+
+    @cached(name="cholesky")
+    def _cholesky(self, upper=False):
+        chol = KroneckerProductLazyTensor(*[lt._cholesky(upper=upper) for lt in self.lazy_tensors])
+        return TriangularLazyTensor(chol, upper=upper)
+
+    def _cholesky_solve(self, rhs, upper=False):
+        if upper:
+            # res = (U.T @ U)^-1 @ v = U^-1 @ U^-T @ v
+            w = self._transpose_nonbatch().inv_matmul(rhs)
+            res = self.inv_matmul(w)
+        else:
+            # res = (L @ L.T)^-1 @ v = L^-T @ L^-1 @ v
+            w = self.inv_matmul(rhs)
+            res = self._transpose_nonbatch().inv_matmul(w)
+        return res
+
+    @cached
+    def inverse(self):
+        # here we use that (A \kron B)^-1 = A^-1 \kron B^-1
+        inverses = [lt.inverse() for lt in self.lazy_tensors]
+        return self.__class__(*inverses, upper=self.upper)
+
+    def inv_matmul(self, right_tensor, left_tensor=None):
+        # Since the individual tensors are triangular, their inverses can be computed cheaply
+        res = self.inverse() @ right_tensor
+        if left_tensor is not None:
+            res = left_tensor @ res
+        return res

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -395,11 +395,8 @@ class LazyTensor(ABC):
             This method is used as an internal helper. Calling this method directly is discouraged.
 
         Returns:
-            (LazyTensor) Cholesky factor
+            (TriangularLazyTensor) Cholesky factor
         """
-        if upper:
-            return self._cholesky(upper=False)._transpose_nonbatch()
-
         from .triangular_lazy_tensor import TriangularLazyTensor
         from .keops_lazy_tensor import KeOpsLazyTensor
 
@@ -740,8 +737,10 @@ class LazyTensor(ABC):
         Returns:
             (LazyTensor) Cholesky factor (lower triangular)
         """
-        # TODO: Rename _cholesky -> cholesky everywhere
-        return self._cholesky(upper=upper)
+        chol = self._cholesky(upper=False)
+        if upper:
+            chol = chol._transpose_nonbatch()
+        return chol
 
     def clone(self):
         """

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -412,7 +412,7 @@ class LazyTensor(ABC):
             return TriangularLazyTensor(evaluated_mat.clamp_min(0.0).sqrt())
 
         # contiguous call is necessary here
-        cholesky = psd_safe_cholesky(evaluated_mat, jitter=settings.cholesky_jitter.value()).contiguous()
+        cholesky = psd_safe_cholesky(evaluated_mat, jitter=settings.cholesky_jitter.value(), upper=upper).contiguous()
         return TriangularLazyTensor(cholesky, upper=upper)
 
     def _cholesky_solve(self, rhs, upper: bool = False):

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -425,7 +425,7 @@ class LazyTensor(ABC):
         Returns:
             (LazyTensor) Cholesky factor
         """
-        return torch.cholesky_solve(rhs, self.evaluate(), upper=upper)
+        raise NotImplementedError("_cholesky_solve not implemented for the base LazyTensor")
 
     def _inv_matmul_preconditioner(self):
         """
@@ -1015,9 +1015,8 @@ class LazyTensor(ABC):
         # Special case: use Cholesky to compute these terms
         if settings.fast_computations.log_prob.off() or (self.size(-1) <= settings.max_cholesky_size.value()):
             from .chol_lazy_tensor import CholLazyTensor
-            from .triangular_lazy_tensor import TriangularLazyTensor
 
-            cholesky = CholLazyTensor(TriangularLazyTensor(self.cholesky()))
+            cholesky = CholLazyTensor(self.cholesky())
             return cholesky.inv_quad_logdet(inv_quad_rhs=inv_quad_rhs, logdet=logdet, reduce_inv_quad=reduce_inv_quad)
 
         # Default: use modified batch conjugate gradients to compute these terms

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1266,6 +1266,7 @@ class LazyTensor(ABC):
                 "Invalid repeat arguments {}. Currently, repeat only works to create repeated "
                 "batches of a 2D LazyTensor.".format(tuple(sizes))
             )
+
         return BatchRepeatLazyTensor(self, batch_repeat=torch.Size(sizes[:-2]))
 
     def representation(self):

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -397,6 +397,9 @@ class LazyTensor(ABC):
         Returns:
             (LazyTensor) Cholesky factor
         """
+        if upper:
+            return self._cholesky(upper=False)._transpose_nonbatch()
+
         from .triangular_lazy_tensor import TriangularLazyTensor
         from .keops_lazy_tensor import KeOpsLazyTensor
 

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1015,8 +1015,9 @@ class LazyTensor(ABC):
         # Special case: use Cholesky to compute these terms
         if settings.fast_computations.log_prob.off() or (self.size(-1) <= settings.max_cholesky_size.value()):
             from .chol_lazy_tensor import CholLazyTensor
+            from .triangular_lazy_tensor import TriangularLazyTensor
 
-            cholesky = CholLazyTensor(self.cholesky())
+            cholesky = CholLazyTensor(TriangularLazyTensor(self.cholesky()))
             return cholesky.inv_quad_logdet(inv_quad_rhs=inv_quad_rhs, logdet=logdet, reduce_inv_quad=reduce_inv_quad)
 
         # Default: use modified batch conjugate gradients to compute these terms

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -263,7 +263,7 @@ class LazyTensor(ABC):
             This method is used internally by the related function :func:`~gpytorch.lazy.LazyTensor.expand`,
             which does some additional work. Calling this method directly is discouraged.
         """
-        current_shape = torch.Size([1 for _ in range(len(batch_shape) - self.dim() - 2)] + list(self.batch_shape))
+        current_shape = torch.Size([1 for _ in range(len(batch_shape) - self.dim() + 2)] + list(self.batch_shape))
         batch_repeat = torch.Size(
             [expand_size // current_size for expand_size, current_size in zip(batch_shape, current_shape)]
         )
@@ -1679,8 +1679,8 @@ class LazyTensor(ABC):
         elif isinstance(other, Tensor):
             other = lazify(other)
             shape = _mul_broadcast_shape(self.shape, other.shape)
-            new_self = self if self.shape == shape else self._expand_batch(shape[:-2])
-            new_other = other if other.shape == shape else other._expand_batch(shape[:-2])
+            new_self = self if self.shape[:-2] == shape[:-2] else self._expand_batch(shape[:-2])
+            new_other = other if other.shape[:-2] == shape[:-2] else other._expand_batch(shape[:-2])
             return SumLazyTensor(new_self, new_other)
         else:
             return SumLazyTensor(self, other)

--- a/gpytorch/lazy/non_lazy_tensor.py
+++ b/gpytorch/lazy/non_lazy_tensor.py
@@ -24,6 +24,9 @@ class NonLazyTensor(LazyTensor):
         super(NonLazyTensor, self).__init__(tsr)
         self.tensor = tsr
 
+    def _cholesky_solve(self, rhs, upper=False):
+        return torch.cholesky_solve(rhs, self.evaluate(), upper=upper)
+
     def _expand_batch(self, batch_shape):
         return self.__class__(self.tensor.expand(*batch_shape, *self.matrix_shape))
 

--- a/gpytorch/lazy/root_lazy_tensor.py
+++ b/gpytorch/lazy/root_lazy_tensor.py
@@ -69,6 +69,9 @@ class RootLazyTensor(LazyTensor):
             deriv.append(item_part_1 + item_part_2)
         return tuple(deriv)
 
+    def root_decomposition(self):
+        return self
+
     def _root_decomposition(self):
         return self.root
 

--- a/gpytorch/lazy/root_lazy_tensor.py
+++ b/gpytorch/lazy/root_lazy_tensor.py
@@ -17,6 +17,8 @@ class RootLazyTensor(LazyTensor):
         self.root = root
 
     def _expand_batch(self, batch_shape):
+        if len(batch_shape) == 0:
+            return self
         return self.__class__(self.root._expand_batch(batch_shape))
 
     def _get_indices(self, row_index, col_index, *batch_indices):

--- a/gpytorch/lazy/root_lazy_tensor.py
+++ b/gpytorch/lazy/root_lazy_tensor.py
@@ -13,7 +13,7 @@ from .non_lazy_tensor import NonLazyTensor, lazify
 class RootLazyTensor(LazyTensor):
     def __init__(self, root):
         root = lazify(root)
-        super(RootLazyTensor, self).__init__(root)
+        super().__init__(root)
         self.root = root
 
     def _expand_batch(self, batch_shape):

--- a/gpytorch/lazy/root_lazy_tensor.py
+++ b/gpytorch/lazy/root_lazy_tensor.py
@@ -85,7 +85,7 @@ class RootLazyTensor(LazyTensor):
         if isinstance(self.root, NonLazyTensor):
             return (self.root.tensor ** 2).sum(-1)
         else:
-            return super(RootLazyTensor, self).diag()
+            return super().diag()
 
     @cached
     def evaluate(self):

--- a/gpytorch/lazy/triangular_lazy_tensor.py
+++ b/gpytorch/lazy/triangular_lazy_tensor.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+import torch
+
+from ..utils.broadcasting import _mul_broadcast_shape
+from ..utils.memoize import cached
+from .added_diag_lazy_tensor import AddedDiagLazyTensor
+from .lazy_tensor import LazyTensor
+from .non_lazy_tensor import NonLazyTensor
+
+
+class TriangularLazyTensor(LazyTensor):
+    def __init__(self, tensor, upper=False):
+        """
+        Triangular lazy tensor. Supports arbitrary batch sizes.
+
+        Args:
+            :attr:`tensor` (Tensor or LazyTensor):
+                A `b1 x ... x bk x n x n` Tensor, representing a `b1 x ... x bk`-sized batch
+                of `n x n` triangular matrices.
+            :attr:`upper` (bool):
+                If True, the tensor is upper-triangular, otherwise lower-triangular.
+        """
+        super().__init__(tensor)
+        if torch.is_tensor(tensor):
+            tensor = NonLazyTensor(tensor)
+        self._upper = upper
+        self._tensor = tensor
+
+    def __add__(self, other):
+        if isinstance(other, TriangularLazyTensor) and not self._upper ^ other.upper:
+            return self.__class__(self._tensor + other._tensor, upper=self._upper)
+        return self._tensor + other
+
+    @cached(name="cholesky")
+    def _cholesky(self):
+        return self.__class__(self._tensor._cholesky(), upper=self._upper)
+
+    def _mul_constant(self, constant):
+        return self.__class__(self._tensor * constant.unsqueeze(-1), upper=self._upper)
+
+    def _root_decomposition(self):
+        return self._tensor._root_decomposition()
+
+    def _root_inv_decomposition(self, initial_vectors=None):
+        self._tensor._root_inv_decomposition(initial_vectors=initial_vectors)
+
+    def _size(self):
+        return self._tensor.shape
+
+    def _sum_batch(self, dim):
+        return self.__class__(self._tensor._sum_batch(dim), upper=self._upper)
+
+    def abs(self):
+        return self.__class__(self._tensor.abs(), upper=self._upper)
+
+    def add_diag(self, added_diag):
+        shape = _mul_broadcast_shape(self._diag.shape, added_diag.shape)
+        return self.__class__(
+            AddedDiagLazyTensor(self._tensor.expand(shape), added_diag.expand(shape)), upper=self._upper
+        )
+
+    def diag(self):
+        return self._tensor.diag()
+
+    @cached
+    def evaluate(self):
+        return self._tensor.evaluate()
+
+    def exp(self):
+        return self.__class__(self._tensor.exp(), upper=self._upper)
+
+    def inverse(self):
+        eye = torch.eye(self._tensor.shape[-2:], device=self._tensor.device, dtype=self._tensor.dtype)
+        inv = self.inv_matmul(eye)
+        return self.__class__(inv, upper=self._upper)
+
+    def inv_matmul(self, right_tensor, left_tensor=None):
+        tsr = self.evaluate()
+        res = torch.triangular_solve(right_tensor, tsr, upper=self._upper).solution
+        if left_tensor is not None:
+            res = left_tensor @ res
+        return res
+
+    def inv_quad_logdet(self, inv_quad_rhs=None, logdet=False, reduce_inv_quad=True):
+        # triangular, inv_matmul is cheap
+        inv_quad_term = inv_quad_rhs.transpose(-1, -2) @ self.inv_matmul(inv_quad_rhs)
+        logdet_term = self.diag().prod(-1) if logdet else None
+        if inv_quad_term.numel() and reduce_inv_quad:
+            inv_quad_term = inv_quad_term.sum(-1)
+        return inv_quad_term, logdet_term
+
+    def _matmul(self, rhs):
+        return self._tensor.matmul(rhs)
+
+    def _solve(self, rhs, preconditioner, num_tridiag=0):
+        # already triangular, can just call inv_matmul for the solve
+        return self.inv_matmul(rhs)
+
+    def _transpose_nonbatch(self):
+        return self.__class__(self._tensor._transpose_nonbatch(), upper=not self._upper)

--- a/gpytorch/lazy/triangular_lazy_tensor.py
+++ b/gpytorch/lazy/triangular_lazy_tensor.py
@@ -161,3 +161,8 @@ class TriangularLazyTensor(LazyTensor):
         eye = torch.eye(self._tensor.size(-1), device=self._tensor.device, dtype=self._tensor.dtype)
         inv = self.inv_matmul(eye)
         return TriangularLazyTensor(inv, upper=self.upper)
+
+    def _expand_batch(self, batch_shape):
+        if len(batch_shape) == 0:
+            return self
+        return self.__class__(tensor=self._tensor._expand_batch(batch_shape), upper=self.upper)

--- a/gpytorch/lazy/triangular_lazy_tensor.py
+++ b/gpytorch/lazy/triangular_lazy_tensor.py
@@ -80,6 +80,10 @@ class TriangularLazyTensor(LazyTensor):
     def _mul_constant(self, constant: Tensor) -> "TriangularLazyTensor":
         return TriangularLazyTensor(self._tensor * constant.unsqueeze(-1), upper=self.upper)
 
+    def _quad_form_derivative(self, left_vecs, right_vecs):
+        res = left_vecs.matmul(right_vecs.transpose(-1, -2))
+        return (res,)
+
     def _root_decomposition(self) -> Allsor:
         raise NotPSDError("TriangularLazyTensor does not allow a root decomposition")
 

--- a/gpytorch/lazy/triangular_lazy_tensor.py
+++ b/gpytorch/lazy/triangular_lazy_tensor.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 from typing import Callable, Optional, Tuple, Union
 
 import torch
@@ -65,7 +63,7 @@ class TriangularLazyTensor(LazyTensor):
     def _matmul(self, rhs: Tensor) -> Tensor:
         return self._tensor.matmul(rhs)
 
-    def _mul_constant(self, constant: Tensor) -> TriangularLazyTensor:
+    def _mul_constant(self, constant: Tensor) -> "TriangularLazyTensor":
         return TriangularLazyTensor(self._tensor * constant.unsqueeze(-1), upper=self.upper)
 
     def _root_decomposition(self) -> Allsor:
@@ -81,16 +79,16 @@ class TriangularLazyTensor(LazyTensor):
         # already triangular, can just call inv_matmul for the solve
         return self.inv_matmul(rhs)
 
-    def _sum_batch(self, dim: int) -> TriangularLazyTensor:
+    def _sum_batch(self, dim: int) -> "TriangularLazyTensor":
         return TriangularLazyTensor(self._tensor._sum_batch(dim), upper=self.upper)
 
-    def _transpose_nonbatch(self) -> TriangularLazyTensor:
+    def _transpose_nonbatch(self) -> "TriangularLazyTensor":
         return TriangularLazyTensor(self._tensor._transpose_nonbatch(), upper=not self.upper)
 
-    def abs(self) -> TriangularLazyTensor:
+    def abs(self) -> "TriangularLazyTensor":
         return TriangularLazyTensor(self._tensor.abs(), upper=self.upper)
 
-    def add_diag(self, added_diag: Tensor) -> TriangularLazyTensor:
+    def add_diag(self, added_diag: Tensor) -> "TriangularLazyTensor":
         from .added_diag_lazy_tensor import AddedDiagLazyTensor
 
         shape = _mul_broadcast_shape(self._diag.shape, added_diag.shape)
@@ -104,7 +102,7 @@ class TriangularLazyTensor(LazyTensor):
     def evaluate(self) -> Tensor:
         return self._tensor.evaluate()
 
-    def exp(self) -> TriangularLazyTensor:
+    def exp(self) -> "TriangularLazyTensor":
         return TriangularLazyTensor(self._tensor.exp(), upper=self.upper)
 
     def inv_matmul(self, right_tensor: Tensor, left_tensor: Optional[Tensor] = None) -> Tensor:
@@ -134,7 +132,7 @@ class TriangularLazyTensor(LazyTensor):
         return inv_quad_term, logdet_term
 
     @cached
-    def inverse(self) -> TriangularLazyTensor:
+    def inverse(self) -> "TriangularLazyTensor":
         eye = torch.eye(self._tensor.size(-1), device=self._tensor.device, dtype=self._tensor.dtype)
         inv = self.inv_matmul(eye)
         return TriangularLazyTensor(inv, upper=self.upper)

--- a/gpytorch/lazy/triangular_lazy_tensor.py
+++ b/gpytorch/lazy/triangular_lazy_tensor.py
@@ -59,6 +59,9 @@ class TriangularLazyTensor(LazyTensor):
             res = self._transpose_nonbatch().inv_matmul(w)
         return res
 
+    def _get_indices(self, row_index, col_index, *batch_indices):
+        return self._tensor._get_indices(row_index, col_index, *batch_indices)
+
     def _matmul(self, rhs: Tensor) -> Tensor:
         return self._tensor.matmul(rhs)
 

--- a/gpytorch/lazy/triangular_lazy_tensor.py
+++ b/gpytorch/lazy/triangular_lazy_tensor.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
+from typing import Callable, Optional, Tuple, Union
+
 import torch
+from torch import Tensor
 
 from ..utils.broadcasting import _mul_broadcast_shape
+from ..utils.errors import NotPSDError
 from ..utils.memoize import cached
-from .added_diag_lazy_tensor import AddedDiagLazyTensor
 from .lazy_tensor import LazyTensor
 from .non_lazy_tensor import NonLazyTensor
 
+Allsor = Union[Tensor, LazyTensor]
+
 
 class TriangularLazyTensor(LazyTensor):
-    def __init__(self, tensor, upper=False):
+    def __init__(self, tensor: Allsor, upper: bool = False) -> None:
         """
         Triangular lazy tensor. Supports arbitrary batch sizes.
 
@@ -19,83 +26,112 @@ class TriangularLazyTensor(LazyTensor):
                 A `b1 x ... x bk x n x n` Tensor, representing a `b1 x ... x bk`-sized batch
                 of `n x n` triangular matrices.
             :attr:`upper` (bool):
-                If True, the tensor is upper-triangular, otherwise lower-triangular.
+                If True, the tensor is considered to be upper-triangular, otherwise lower-triangular.
         """
-        super().__init__(tensor)
         if torch.is_tensor(tensor):
             tensor = NonLazyTensor(tensor)
-        self._upper = upper
+        super().__init__(tensor)
+        self.upper = upper
         self._tensor = tensor
 
-    def __add__(self, other):
-        if isinstance(other, TriangularLazyTensor) and not self._upper ^ other.upper:
-            return self.__class__(self._tensor + other._tensor, upper=self._upper)
+    def __add__(self, other: Allsor) -> LazyTensor:
+        from .diag_lazy_tensor import DiagLazyTensor
+
+        if isinstance(other, DiagLazyTensor):
+            from .added_diag_lazy_tensor import AddedDiagLazyTensor
+
+            return self.__class__(AddedDiagLazyTensor(self._tensor, other), upper=self.upper)
+        if isinstance(other, TriangularLazyTensor) and not self.upper ^ other.upper:
+            return self.__class__(self._tensor + other._tensor, upper=self.upper)
         return self._tensor + other
 
-    @cached(name="cholesky")
-    def _cholesky(self):
-        return self.__class__(self._tensor._cholesky(), upper=self._upper)
+    def _cholesky(self, upper=False) -> LazyTensor:
+        raise NotPSDError("TriangularLazyTensor does not allow a Cholesky decomposition")
 
-    def _mul_constant(self, constant):
-        return self.__class__(self._tensor * constant.unsqueeze(-1), upper=self._upper)
+    def _cholesky_solve(self, rhs: Tensor, upper: bool = False) -> Tensor:
+        if upper:
+            # res = (U.T @ U)^-1 @ v = U^-1 @ U^-T @ v
+            w = self._transpose_nonbatch().inv_matmul(rhs)
+            res = self.inv_matmul(w)
+        else:
+            # res = (L @ L.T)^-1 @ v = L^-T @ L^-1 @ v
+            w = self.inv_matmul(rhs)
+            res = self._transpose_nonbatch().inv_matmul(w)
+        return res
 
-    def _root_decomposition(self):
-        return self._tensor._root_decomposition()
+    def _matmul(self, rhs: Tensor) -> Tensor:
+        return self._tensor.matmul(rhs)
 
-    def _root_inv_decomposition(self, initial_vectors=None):
-        self._tensor._root_inv_decomposition(initial_vectors=initial_vectors)
+    def _mul_constant(self, constant: Tensor) -> TriangularLazyTensor:
+        return TriangularLazyTensor(self._tensor * constant.unsqueeze(-1), upper=self.upper)
 
-    def _size(self):
+    def _root_decomposition(self) -> Allsor:
+        raise NotPSDError("TriangularLazyTensor does not allow a root decomposition")
+
+    def _root_inv_decomposition(self, initial_vectors: Optional[Tensor] = None) -> Allsor:
+        raise NotPSDError("TriangularLazyTensor does not allow an inverse root decomposition")
+
+    def _size(self) -> torch.Size:
         return self._tensor.shape
 
-    def _sum_batch(self, dim):
-        return self.__class__(self._tensor._sum_batch(dim), upper=self._upper)
+    def _solve(self, rhs: Tensor, preconditioner: Callable[[Tensor], Tensor], num_tridiag: int = 0) -> Tensor:
+        # already triangular, can just call inv_matmul for the solve
+        return self.inv_matmul(rhs)
 
-    def abs(self):
-        return self.__class__(self._tensor.abs(), upper=self._upper)
+    def _sum_batch(self, dim: int) -> TriangularLazyTensor:
+        return TriangularLazyTensor(self._tensor._sum_batch(dim), upper=self.upper)
 
-    def add_diag(self, added_diag):
+    def _transpose_nonbatch(self) -> TriangularLazyTensor:
+        return TriangularLazyTensor(self._tensor._transpose_nonbatch(), upper=not self.upper)
+
+    def abs(self) -> TriangularLazyTensor:
+        return TriangularLazyTensor(self._tensor.abs(), upper=self.upper)
+
+    def add_diag(self, added_diag: Tensor) -> TriangularLazyTensor:
+        from .added_diag_lazy_tensor import AddedDiagLazyTensor
+
         shape = _mul_broadcast_shape(self._diag.shape, added_diag.shape)
-        return self.__class__(
-            AddedDiagLazyTensor(self._tensor.expand(shape), added_diag.expand(shape)), upper=self._upper
-        )
+        added_diag_lt = AddedDiagLazyTensor(self._tensor.expand(shape), added_diag.expand(shape))
+        return TriangularLazyTensor(added_diag_lt, upper=self.upper)
 
-    def diag(self):
+    def diag(self) -> Tensor:
         return self._tensor.diag()
 
     @cached
-    def evaluate(self):
+    def evaluate(self) -> Tensor:
         return self._tensor.evaluate()
 
-    def exp(self):
-        return self.__class__(self._tensor.exp(), upper=self._upper)
+    def exp(self) -> TriangularLazyTensor:
+        return TriangularLazyTensor(self._tensor.exp(), upper=self.upper)
 
-    def inverse(self):
-        eye = torch.eye(self._tensor.shape[-2:], device=self._tensor.device, dtype=self._tensor.dtype)
-        inv = self.inv_matmul(eye)
-        return self.__class__(inv, upper=self._upper)
-
-    def inv_matmul(self, right_tensor, left_tensor=None):
+    def inv_matmul(self, right_tensor: Tensor, left_tensor: Optional[Tensor] = None) -> Tensor:
         tsr = self.evaluate()
-        res = torch.triangular_solve(right_tensor, tsr, upper=self._upper).solution
+        res = torch.triangular_solve(right_tensor, tsr, upper=self.upper).solution
         if left_tensor is not None:
             res = left_tensor @ res
         return res
 
-    def inv_quad_logdet(self, inv_quad_rhs=None, logdet=False, reduce_inv_quad=True):
-        # triangular, inv_matmul is cheap
-        inv_quad_term = inv_quad_rhs.transpose(-1, -2) @ self.inv_matmul(inv_quad_rhs)
-        logdet_term = self.diag().prod(-1) if logdet else None
+    def inv_quad_logdet(
+        self, inv_quad_rhs: Optional[Tensor] = None, logdet: bool = False, reduce_inv_quad: bool = True,
+    ) -> Tuple[Tensor, Tensor]:
+        if inv_quad_rhs is None:
+            inv_quad_term = torch.empty(0, dtype=self.dtype, device=self.device)
+        else:
+            # triangular, inv_matmul is cheap
+            inv_quad_term = inv_quad_rhs.transpose(-1, -2) @ self.inv_matmul(inv_quad_rhs)
+        if logdet:
+            diag = self.diag()
+            logdet_term = self.diag().abs().log().sum(-1)
+            if torch.sign(diag).prod(-1) < 0:
+                logdet_term = torch.full_like(logdet_term, float("nan"))
+        else:
+            logdet_term = torch.empty(0, dtype=self.dtype, device=self.device)
         if inv_quad_term.numel() and reduce_inv_quad:
             inv_quad_term = inv_quad_term.sum(-1)
         return inv_quad_term, logdet_term
 
-    def _matmul(self, rhs):
-        return self._tensor.matmul(rhs)
-
-    def _solve(self, rhs, preconditioner, num_tridiag=0):
-        # already triangular, can just call inv_matmul for the solve
-        return self.inv_matmul(rhs)
-
-    def _transpose_nonbatch(self):
-        return self.__class__(self._tensor._transpose_nonbatch(), upper=not self._upper)
+    @cached
+    def inverse(self) -> TriangularLazyTensor:
+        eye = torch.eye(self._tensor.size(-1), device=self._tensor.device, dtype=self._tensor.dtype)
+        inv = self.inv_matmul(eye)
+        return TriangularLazyTensor(inv, upper=self.upper)

--- a/gpytorch/priors/lkj_prior.py
+++ b/gpytorch/priors/lkj_prior.py
@@ -7,6 +7,7 @@ import torch
 from torch.distributions import constraints
 from torch.nn import Module as TModule
 
+from ..utils.cholesky import psd_safe_cholesky
 from .prior import Prior
 
 
@@ -56,7 +57,7 @@ class LKJPrior(Prior):
             raise ValueError("Correlation matrix is not of size n={}".format(self.n.item()))
         if not _is_valid_correlation_matrix(X):
             raise ValueError("Input is not a valid correlation matrix")
-        log_diag_sum = torch.cholesky(X, upper=True).diagonal(dim1=-2, dim2=-1).log().sum(-1)
+        log_diag_sum = psd_safe_cholesky(X, upper=True).diagonal(dim1=-2, dim2=-1).log().sum(-1)
         return self.C + (self.eta - 1) * 2 * log_diag_sum
 
 

--- a/gpytorch/priors/lkj_prior.py
+++ b/gpytorch/priors/lkj_prior.py
@@ -56,7 +56,7 @@ class LKJPrior(Prior):
             raise ValueError("Correlation matrix is not of size n={}".format(self.n.item()))
         if not _is_valid_correlation_matrix(X):
             raise ValueError("Input is not a valid correlation matrix")
-        log_diag_sum = X.cholesky(upper=True).diagonal(dim1=-2, dim2=-1).log().sum(-1)
+        log_diag_sum = torch.cholesky(X, upper=True).diagonal(dim1=-2, dim2=-1).log().sum(-1)
         return self.C + (self.eta - 1) * 2 * log_diag_sum
 
 

--- a/gpytorch/test/lazy_tensor_test_case.py
+++ b/gpytorch/test/lazy_tensor_test_case.py
@@ -376,6 +376,14 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
                 actual[..., i, i] = actual[..., i, i] + other_diag[..., i]
             self.assertAllClose(res, actual, rtol=1e-2, atol=1e-5)
 
+    def test_cholesky(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+        for upper in (False, True):
+            res = lazy_tensor.cholesky(upper=upper).evaluate()
+            actual = torch.cholesky(evaluated, upper=upper)
+            self.assertAllClose(res, actual, rtol=1e-3, atol=1e-5)
+
     def test_diag(self):
         lazy_tensor = self.create_lazy_tensor()
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)

--- a/gpytorch/test/lazy_tensor_test_case.py
+++ b/gpytorch/test/lazy_tensor_test_case.py
@@ -383,6 +383,7 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
             res = lazy_tensor.cholesky(upper=upper).evaluate()
             actual = torch.cholesky(evaluated, upper=upper)
             self.assertAllClose(res, actual, rtol=1e-3, atol=1e-5)
+            # TODO: Check gradients
 
     def test_diag(self):
         lazy_tensor = self.create_lazy_tensor()

--- a/gpytorch/utils/cholesky.py
+++ b/gpytorch/utils/cholesky.py
@@ -4,7 +4,7 @@ import warnings
 
 import torch
 
-from .errors import NanError
+from .errors import NanError, NotPSDError
 from .warnings import NumericalWarning
 
 
@@ -47,4 +47,6 @@ def psd_safe_cholesky(A, upper=False, out=None, jitter=None, max_tries=3):
                 return L
             except RuntimeError:
                 continue
-        raise e
+        raise NotPSDError(
+            f"Matrix not positive definite after repeatedly adding jitter. Original error on first attempt: {e}"
+        )

--- a/gpytorch/utils/errors.py
+++ b/gpytorch/utils/errors.py
@@ -5,4 +5,8 @@ class NanError(RuntimeError):
     pass
 
 
-__all__ = ["NanError"]
+class NotPSDError(RuntimeError):
+    pass
+
+
+__all__ = ["NanError", "NotPSDError"]

--- a/gpytorch/utils/errors.py
+++ b/gpytorch/utils/errors.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
 
+class CachingError(RuntimeError):
+    pass
+
+
 class NanError(RuntimeError):
     pass
 
@@ -9,4 +13,4 @@ class NotPSDError(RuntimeError):
     pass
 
 
-__all__ = ["NanError", "NotPSDError"]
+__all__ = ["CachingError", "NanError", "NotPSDError"]

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -1,25 +1,31 @@
 #!/usr/bin/env python3
 
 import functools
+import pickle
 
 
-def add_to_cache(obj, name, val):
+def add_to_cache(obj, name, val, *args, **kwargs):
+    """Add a result to the cache of an object."""
+    return _add_to_cache(obj, name, *args, pickle.dumps(kwargs))
+
+
+def _add_to_cache(obj, name, val, *args, kwargs_pkl):
     """Add a result to the cache of an object."""
     if not hasattr(obj, "_memoize_cache"):
-        obj._memoize_cache = dict()
-    obj._memoize_cache[name] = val
+        obj._memoize_cache = {}
+    obj._memoize_cache[(name, args, kwargs_pkl)] = val
     return obj
 
 
-def get_from_cache(obj, name):
+def _get_from_cache(obj, name, *args, kwargs_pkl):
     """Get an item from the cache."""
-    if not is_in_cache(obj, name):
+    if not _is_in_cache(obj, name, *args, kwargs_pkl=kwargs_pkl):
         raise RuntimeError("Object does not have item {} stored in cache.".format(name))
-    return obj._memoize_cache[name]
+    return obj._memoize_cache[(name, args, kwargs_pkl)]
 
 
-def is_in_cache(obj, name):
-    return hasattr(obj, "_memoize_cache") and name in obj._memoize_cache
+def _is_in_cache(obj, name, *args, kwargs_pkl):
+    return hasattr(obj, "_memoize_cache") and (name, args, kwargs_pkl) in obj._memoize_cache
 
 
 def cached(method=None, name=None):
@@ -30,15 +36,9 @@ def cached(method=None, name=None):
     @functools.wraps(method)
     def g(self, *args, **kwargs):
         cache_name = name if name is not None else method
-        if not is_in_cache(self, cache_name):
-            add_to_cache(self, cache_name, method(self, *args, **kwargs))
-        return get_from_cache(self, cache_name)
+        kwargs_pkl = pickle.dumps(kwargs)
+        if not _is_in_cache(self, cache_name, *args, kwargs_pkl=kwargs_pkl):
+            _add_to_cache(self, cache_name, method(self, *args, **kwargs), *args, kwargs_pkl=kwargs_pkl)
+        return _get_from_cache(self, cache_name, *args, kwargs_pkl=kwargs_pkl)
 
     return g
-
-
-def is_cached(self, name):
-    """
-    Determine if a cached item has been computed
-    """
-    return hasattr(self, "_memoize_cache") and name in self._memoize_cache.keys()

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -14,7 +14,7 @@ def _add_to_cache(obj, name, val, *args, kwargs_pkl):
     if not hasattr(obj, "_memoize_cache"):
         obj._memoize_cache = {}
     obj._memoize_cache[(name, args, kwargs_pkl)] = val
-    return obj
+    return val
 
 
 def _get_from_cache(obj, name, *args, kwargs_pkl):
@@ -38,7 +38,7 @@ def cached(method=None, name=None):
         cache_name = name if name is not None else method
         kwargs_pkl = pickle.dumps(kwargs)
         if not _is_in_cache(self, cache_name, *args, kwargs_pkl=kwargs_pkl):
-            _add_to_cache(self, cache_name, method(self, *args, **kwargs), *args, kwargs_pkl=kwargs_pkl)
+            return _add_to_cache(self, cache_name, method(self, *args, **kwargs), *args, kwargs_pkl=kwargs_pkl)
         return _get_from_cache(self, cache_name, *args, kwargs_pkl=kwargs_pkl)
 
     return g

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -3,10 +3,17 @@
 import functools
 import pickle
 
+from .errors import CachingError
+
 
 def add_to_cache(obj, name, val, *args, **kwargs):
     """Add a result to the cache of an object (honoring calling args)."""
     return _add_to_cache(obj, name, val, *args, kwargs_pkl=pickle.dumps(kwargs))
+
+
+def get_from_cache(obj, name, *args, **kwargs):
+    """Get an item from the cache (honoring calling args)."""
+    return _get_from_cache(obj, name, *args, kwargs_pkl=pickle.dumps(kwargs))
 
 
 def _add_to_cache(obj, name, val, *args, kwargs_pkl):
@@ -20,7 +27,7 @@ def _add_to_cache(obj, name, val, *args, kwargs_pkl):
 def _get_from_cache(obj, name, *args, kwargs_pkl):
     """Get an item from the cache (honoring calling args)."""
     if not _is_in_cache(obj, name, *args, kwargs_pkl=kwargs_pkl):
-        raise RuntimeError("Object does not have item {} stored in cache.".format(name))
+        raise CachingError("Object does not have item {} stored in cache.".format(name))
     return obj._memoize_cache[(name, args, kwargs_pkl)]
 
 
@@ -39,7 +46,7 @@ def _add_to_cache_ignore_args(obj, name, val):
 def _get_from_cache_ignore_args(obj, name):
     """Get an item from the cache (ignoring calling args)."""
     if not _is_in_cache_ignore_args(obj, name):
-        raise RuntimeError("Object does not have item {} stored in cache.".format(name))
+        raise CachingError("Object does not have item {} stored in cache.".format(name))
     return obj._memoize_cache[name]
 
 

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -6,6 +6,14 @@ import pickle
 from .errors import CachingError
 
 
+def cached(method=None, name=None, ignore_args=False):
+    """A decorator allowing for specifying the name of a cache, allowing it to be modified elsewhere."""
+    if ignore_args:
+        return _cached_ignore_args(method=method, name=name)
+    else:
+        return _cached(method=method, name=name)
+
+
 def add_to_cache(obj, name, val, *args, **kwargs):
     """Add a result to the cache of an object (honoring calling args)."""
     return _add_to_cache(obj, name, val, *args, kwargs_pkl=pickle.dumps(kwargs))
@@ -16,59 +24,16 @@ def get_from_cache(obj, name, *args, **kwargs):
     return _get_from_cache(obj, name, *args, kwargs_pkl=pickle.dumps(kwargs))
 
 
-def _add_to_cache(obj, name, val, *args, kwargs_pkl):
-    """Add a result to the cache of an object (honoring calling args)."""
-    if not hasattr(obj, "_memoize_cache"):
-        obj._memoize_cache = {}
-    obj._memoize_cache[(name, args, kwargs_pkl)] = val
-    return val
-
-
-def _get_from_cache(obj, name, *args, kwargs_pkl):
-    """Get an item from the cache (honoring calling args)."""
-    if not _is_in_cache(obj, name, *args, kwargs_pkl=kwargs_pkl):
+def pop_from_cache(obj, name, *args, **kwargs):
+    """Pop an item from the cache (honoring calling args)."""
+    try:
+        return obj._memoize_cache.pop((name, args, pickle.dumps(kwargs)))
+    except KeyError:
         raise CachingError("Object does not have item {} stored in cache.".format(name))
-    return obj._memoize_cache[(name, args, kwargs_pkl)]
 
 
-def _is_in_cache(obj, name, *args, kwargs_pkl):
-    return hasattr(obj, "_memoize_cache") and (name, args, kwargs_pkl) in obj._memoize_cache
-
-
-def _add_to_cache_ignore_args(obj, name, val):
-    """Add a result to the cache of an object (ignoring calling args)."""
-    if not hasattr(obj, "_memoize_cache"):
-        obj._memoize_cache = {}
-    obj._memoize_cache[name] = val
-    return val
-
-
-def _get_from_cache_ignore_args(obj, name):
-    """Get an item from the cache (ignoring calling args)."""
-    if not _is_in_cache_ignore_args(obj, name):
-        raise CachingError("Object does not have item {} stored in cache.".format(name))
-    return obj._memoize_cache[name]
-
-
-def _is_in_cache_ignore_args(obj, name):
-    return hasattr(obj, "_memoize_cache") and name in obj._memoize_cache
-
-
-def _cached_ignore_args(method=None, name=None):
-    """A decorator allowing for specifying the name of a cache, allowing it to be modified elsewhere.
-    This variant ignores the calling args to the decorated function.
-    """
-    if method is None:
-        return functools.partial(_cached_ignore_args, name=name)
-
-    @functools.wraps(method)
-    def g(self, *args, **kwargs):
-        cache_name = name if name is not None else method
-        if not _is_in_cache_ignore_args(self, cache_name):
-            return _add_to_cache_ignore_args(self, cache_name, method(self, *args, **kwargs))
-        return _get_from_cache_ignore_args(self, cache_name)
-
-    return g
+def clear_cache_hook(module, *args, **kwargs):
+    module._memoize_cache = {}
 
 
 def _cached(method=None, name=None):
@@ -89,9 +54,58 @@ def _cached(method=None, name=None):
     return g
 
 
-def cached(method=None, name=None, ignore_args=False):
-    """A decorator allowing for specifying the name of a cache, allowing it to be modified elsewhere."""
-    if ignore_args:
-        return _cached_ignore_args(method=method, name=name)
-    else:
-        return _cached(method=method, name=name)
+def _cached_ignore_args(method=None, name=None):
+    """A decorator allowing for specifying the name of a cache, allowing it to be modified elsewhere.
+    This variant ignores the calling args to the decorated function.
+    """
+    if method is None:
+        return functools.partial(_cached_ignore_args, name=name)
+
+    @functools.wraps(method)
+    def g(self, *args, **kwargs):
+        cache_name = name if name is not None else method
+        if not _is_in_cache_ignore_args(self, cache_name):
+            return _add_to_cache_ignore_args(self, cache_name, method(self, *args, **kwargs))
+        return _get_from_cache_ignore_args(self, cache_name)
+
+    return g
+
+
+def _add_to_cache(obj, name, val, *args, kwargs_pkl):
+    """Add a result to the cache of an object (honoring calling args)."""
+    if not hasattr(obj, "_memoize_cache"):
+        obj._memoize_cache = {}
+    obj._memoize_cache[(name, args, kwargs_pkl)] = val
+    return val
+
+
+def _get_from_cache(obj, name, *args, kwargs_pkl):
+    """Get an item from the cache (honoring calling args)."""
+    try:
+        return obj._memoize_cache[(name, args, kwargs_pkl)]
+    except (AttributeError, KeyError):
+        raise CachingError("Object does not have item {} stored in cache.".format(name))
+
+
+def _is_in_cache(obj, name, *args, kwargs_pkl):
+    return hasattr(obj, "_memoize_cache") and (name, args, kwargs_pkl) in obj._memoize_cache
+
+
+def _add_to_cache_ignore_args(obj, name, val):
+    """Add a result to the cache of an object (ignoring calling args)."""
+    if not hasattr(obj, "_memoize_cache"):
+        obj._memoize_cache = {}
+    obj._memoize_cache[name] = val
+    return val
+
+
+def _get_from_cache_ignore_args(obj, name):
+    """Get an item from the cache (ignoring calling args)."""
+    try:
+        return obj._memoize_cache[name]
+    except (AttributeError, KeyError):
+        raise CachingError("Object does not have item {} stored in cache.".format(name))
+
+
+def _is_in_cache_ignore_args(obj, name):
+    return hasattr(obj, "_memoize_cache") and name in obj._memoize_cache

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -6,7 +6,7 @@ import pickle
 
 def add_to_cache(obj, name, val, *args, **kwargs):
     """Add a result to the cache of an object."""
-    return _add_to_cache(obj, name, *args, pickle.dumps(kwargs))
+    return _add_to_cache(obj, name, val, *args, kwargs_pkl=pickle.dumps(kwargs))
 
 
 def _add_to_cache(obj, name, val, *args, kwargs_pkl):

--- a/gpytorch/variational/_variational_strategy.py
+++ b/gpytorch/variational/_variational_strategy.py
@@ -8,7 +8,7 @@ from .. import settings
 from ..distributions import Delta, MultivariateNormal
 from ..module import Module
 from ..utils.broadcasting import _mul_broadcast_shape
-from ..utils.memoize import cached
+from ..utils.memoize import cached, clear_cache_hook
 
 
 class _VariationalStrategy(Module, ABC):
@@ -97,8 +97,7 @@ class _VariationalStrategy(Module, ABC):
     def train(self, mode=True):
         # Make sure we are clearing the cache if we change modes
         if (self.training and not mode) or mode:
-            if hasattr(self, "_memoize_cache"):
-                delattr(self, "_memoize_cache")
+            clear_cache_hook(self)
         return super().train(mode=mode)
 
     def __call__(self, x, prior=False):
@@ -108,9 +107,7 @@ class _VariationalStrategy(Module, ABC):
 
         # Delete previously cached items from the training distribution
         if self.training:
-            if hasattr(self, "_memoize_cache"):
-                delattr(self, "_memoize_cache")
-                self._memoize_cache = dict()
+            clear_cache_hook(self)
         # (Maybe) initialize variational distribution
         if not self.variational_params_initialized.item():
             prior_dist = self.prior_distribution

--- a/gpytorch/variational/batch_decoupled_variational_strategy.py
+++ b/gpytorch/variational/batch_decoupled_variational_strategy.py
@@ -186,7 +186,7 @@ class BatchDecoupledVariationalStrategy(VariationalStrategy):
             # Aggressive caching can cause nasty shape incompatibilies when evaluating with different batch shapes
             del self._memoize_cache["cholesky_factor"]
             L = self._cholesky_factor(induc_induc_covar)
-        interp_term = torch.triangular_solve(induc_data_covar.double(), L, upper=False)[0].to(full_inputs.dtype)
+        interp_term = L.inv_matmul(induc_data_covar.double()).to(full_inputs.dtype)
         mean_interp_term = interp_term.select(mean_var_batch_dim - 2, 0)
         var_interp_term = interp_term.select(mean_var_batch_dim - 2, 1)
 

--- a/gpytorch/variational/batch_decoupled_variational_strategy.py
+++ b/gpytorch/variational/batch_decoupled_variational_strategy.py
@@ -5,6 +5,7 @@ from torch.distributions.kl import kl_divergence
 
 from ..distributions import Delta, MultivariateNormal
 from ..lazy import MatmulLazyTensor, SumLazyTensor
+from ..utils.memoize import pop_from_cache
 from .delta_variational_distribution import DeltaVariationalDistribution
 from .variational_strategy import VariationalStrategy
 
@@ -184,7 +185,8 @@ class BatchDecoupledVariationalStrategy(VariationalStrategy):
         L = self._cholesky_factor(induc_induc_covar)
         if L.shape != induc_induc_covar.shape:
             # Aggressive caching can cause nasty shape incompatibilies when evaluating with different batch shapes
-            del self._memoize_cache["cholesky_factor"]
+            # TODO: Use a hook to make this cleaner
+            pop_from_cache(self, "cholesky_factor")
             L = self._cholesky_factor(induc_induc_covar)
         interp_term = L.inv_matmul(induc_data_covar.double()).to(full_inputs.dtype)
         mean_interp_term = interp_term.select(mean_var_batch_dim - 2, 0)

--- a/gpytorch/variational/cholesky_variational_distribution.py
+++ b/gpytorch/variational/cholesky_variational_distribution.py
@@ -3,7 +3,7 @@
 import torch
 
 from ..distributions import MultivariateNormal
-from ..lazy import CholLazyTensor
+from ..lazy import CholLazyTensor, TriangularLazyTensor
 from ._variational_distribution import _VariationalDistribution
 
 
@@ -40,7 +40,7 @@ class CholeskyVariationalDistribution(_VariationalDistribution):
 
         # First make the cholesky factor is upper triangular
         lower_mask = torch.ones(self.chol_variational_covar.shape[-2:], dtype=dtype, device=device).tril(0)
-        chol_variational_covar = chol_variational_covar.mul(lower_mask)
+        chol_variational_covar = TriangularLazyTensor(chol_variational_covar.mul(lower_mask))
 
         # Now construct the actual matrix
         variational_covar = CholLazyTensor(chol_variational_covar)

--- a/gpytorch/variational/orthogonally_decoupled_variational_strategy.py
+++ b/gpytorch/variational/orthogonally_decoupled_variational_strategy.py
@@ -3,7 +3,7 @@
 import torch
 
 from ..distributions import MultivariateNormal
-from ..utils.memoize import cached
+from ..utils.memoize import add_to_cache, cached
 from ._variational_strategy import _VariationalStrategy
 from .delta_variational_distribution import DeltaVariationalDistribution
 
@@ -78,7 +78,8 @@ class OrthogonallyDecoupledVariationalStrategy(_VariationalStrategy):
         if self.training:
             induc_mean = full_mean[..., num_data:]
             induc_induc_covar = full_covar[..., num_data:, num_data:]
-            self._memoize_cache["prior_distribution_memo"] = MultivariateNormal(induc_mean, induc_induc_covar)
+            prior_dist = MultivariateNormal(induc_mean, induc_induc_covar)
+            add_to_cache(self, "prior_distribution_memo", prior_dist)
 
         test_mean = full_mean[..., :num_data]
         data_induc_covar = full_covar[..., :num_data, num_data:]

--- a/gpytorch/variational/unwhitened_variational_strategy.py
+++ b/gpytorch/variational/unwhitened_variational_strategy.py
@@ -18,7 +18,7 @@ from ..lazy import (
 )
 from ..utils.broadcasting import _mul_broadcast_shape
 from ..utils.cholesky import psd_safe_cholesky
-from ..utils.memoize import cached
+from ..utils.memoize import add_to_cache, cached
 from ._variational_strategy import _VariationalStrategy
 
 
@@ -157,7 +157,8 @@ class UnwhitenedVariationalStrategy(_VariationalStrategy):
 
         # Cache the kernel matrix with the cached CG calls
         if self.training:
-            self._memoize_cache["prior_distribution_memo"] = MultivariateNormal(induc_mean, induc_induc_covar)
+            prior_dist = MultivariateNormal(induc_mean, induc_induc_covar)
+            add_to_cache(self, "prior_distribution_memo", prior_dist)
 
         # Compute predictive mean
         inv_products = induc_induc_covar.inv_matmul(induc_data_covar, left_tensors.transpose(-1, -2))

--- a/gpytorch/variational/unwhitened_variational_strategy.py
+++ b/gpytorch/variational/unwhitened_variational_strategy.py
@@ -12,6 +12,7 @@ from ..lazy import (
     DiagLazyTensor,
     PsdSumLazyTensor,
     RootLazyTensor,
+    TriangularLazyTensor,
     ZeroLazyTensor,
     delazify,
 )
@@ -49,7 +50,7 @@ class UnwhitenedVariationalStrategy(_VariationalStrategy):
     def _cholesky_factor(self, induc_induc_covar):
         # Maybe used - if we're not using CG
         L = psd_safe_cholesky(delazify(induc_induc_covar), jitter=settings.cholesky_jitter.value())
-        return L
+        return TriangularLazyTensor(L)
 
     @property
     @cached(name="prior_distribution_memo")

--- a/gpytorch/variational/unwhitened_variational_strategy.py
+++ b/gpytorch/variational/unwhitened_variational_strategy.py
@@ -45,7 +45,7 @@ class UnwhitenedVariationalStrategy(_VariationalStrategy):
         parameters of the model).
     """
 
-    @cached(name="cholesky_factor")
+    @cached(name="cholesky_factor", ignore_args=True)
     def _cholesky_factor(self, induc_induc_covar):
         # Maybe used - if we're not using CG
         L = psd_safe_cholesky(delazify(induc_induc_covar), jitter=settings.cholesky_jitter.value())

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -147,7 +147,7 @@ class VariationalStrategy(_VariationalStrategy):
                 # Change the variational parameters to be whitened
                 variational_dist = self.variational_distribution
                 mean_diff = (variational_dist.loc - prior_mean).unsqueeze(-1).double()
-                whitened_mean = L.inv_matmul(mean_diff).to(variational_dist.loc.dtype)
+                whitened_mean = L.inv_matmul(mean_diff).squeeze(-1).to(variational_dist.loc.dtype)
                 covar_root = variational_dist.lazy_covariance_matrix.root_decomposition().root.evaluate().double()
                 whitened_covar = RootLazyTensor(L.inv_matmul(covar_root).to(variational_dist.loc.dtype))
                 whitened_variational_distribution = variational_dist.__class__(whitened_mean, whitened_covar)

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -9,7 +9,7 @@ from ..distributions import MultivariateNormal
 from ..lazy import DiagLazyTensor, MatmulLazyTensor, RootLazyTensor, SumLazyTensor, TriangularLazyTensor, delazify
 from ..settings import trace_mode
 from ..utils.cholesky import psd_safe_cholesky
-from ..utils.memoize import cached
+from ..utils.memoize import cached, clear_cache_hook, pop_from_cache
 from ..utils.warnings import OldVersionWarning
 from ._variational_strategy import _VariationalStrategy
 
@@ -99,7 +99,8 @@ class VariationalStrategy(_VariationalStrategy):
         L = self._cholesky_factor(induc_induc_covar)
         if L.shape != induc_induc_covar.shape:
             # Aggressive caching can cause nasty shape incompatibilies when evaluating with different batch shapes
-            del self._memoize_cache["cholesky_factor"]
+            # TODO: Use a hook fo this
+            pop_from_cache(self, "cholesky_factor")
             L = self._cholesky_factor(induc_induc_covar)
         interp_term = L.inv_matmul(induc_data_covar.double()).to(full_inputs.dtype)
 
@@ -157,9 +158,7 @@ class VariationalStrategy(_VariationalStrategy):
                 self._variational_distribution.mean_init_std = orig_mean_init_std
 
                 # Reset the cache
-                if hasattr(self, "_memoize_cache"):
-                    delattr(self, "_memoize_cache")
-                    self._memoize_cache = dict()
+                clear_cache_hook(self)
 
                 # Mark that we have updated the variational strategy
                 self.updated_strategy.fill_(True)

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -6,7 +6,7 @@ import torch
 
 from .. import settings
 from ..distributions import MultivariateNormal
-from ..lazy import DiagLazyTensor, MatmulLazyTensor, RootLazyTensor, SumLazyTensor, delazify
+from ..lazy import DiagLazyTensor, MatmulLazyTensor, RootLazyTensor, SumLazyTensor, TriangularLazyTensor, delazify
 from ..settings import trace_mode
 from ..utils.cholesky import psd_safe_cholesky
 from ..utils.memoize import cached
@@ -70,7 +70,7 @@ class VariationalStrategy(_VariationalStrategy):
     @cached(name="cholesky_factor", ignore_args=True)
     def _cholesky_factor(self, induc_induc_covar):
         L = psd_safe_cholesky(delazify(induc_induc_covar).double(), jitter=settings.cholesky_jitter.value())
-        return L
+        return TriangularLazyTensor(L)
 
     @property
     @cached(name="prior_distribution_memo")
@@ -101,7 +101,7 @@ class VariationalStrategy(_VariationalStrategy):
             # Aggressive caching can cause nasty shape incompatibilies when evaluating with different batch shapes
             del self._memoize_cache["cholesky_factor"]
             L = self._cholesky_factor(induc_induc_covar)
-        interp_term = torch.triangular_solve(induc_data_covar.double(), L, upper=False)[0].to(full_inputs.dtype)
+        interp_term = L.inv_matmul(induc_data_covar.double()).to(full_inputs.dtype)
 
         # Compute the mean of q(f)
         # k_XZ K_ZZ^{-1/2} (m - K_ZZ^{-1/2} \mu_Z) + \mu_X
@@ -146,20 +146,10 @@ class VariationalStrategy(_VariationalStrategy):
 
                 # Change the variational parameters to be whitened
                 variational_dist = self.variational_distribution
-                whitened_mean = (
-                    torch.triangular_solve((variational_dist.loc - prior_mean).unsqueeze(-1).double(), L, upper=False)[
-                        0
-                    ]
-                    .squeeze(-1)
-                    .to(variational_dist.loc.dtype)
-                )
-                whitened_covar = RootLazyTensor(
-                    torch.triangular_solve(
-                        variational_dist.lazy_covariance_matrix.root_decomposition().root.evaluate().double(),
-                        L,
-                        upper=False,
-                    )[0].to(variational_dist.loc.dtype)
-                )
+                mean_diff = (variational_dist.loc - prior_mean).unsqueeze(-1).double()
+                whitened_mean = L.inv_matmul(mean_diff).to(variational_dist.loc.dtype)
+                covar_root = variational_dist.lazy_covariance_matrix.root_decomposition().root.evaluate().double()
+                whitened_covar = RootLazyTensor(L.inv_matmul(covar_root).to(variational_dist.loc.dtype))
                 whitened_variational_distribution = variational_dist.__class__(whitened_mean, whitened_covar)
                 self._variational_distribution.initialize_variational_distribution(whitened_variational_distribution)
 

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -67,7 +67,7 @@ class VariationalStrategy(_VariationalStrategy):
         self.register_buffer("updated_strategy", torch.tensor(True))
         self._register_load_state_dict_pre_hook(_ensure_updated_strategy_flag_set)
 
-    @cached(name="cholesky_factor")
+    @cached(name="cholesky_factor", ignore_args=True)
     def _cholesky_factor(self, induc_induc_covar):
         L = psd_safe_cholesky(delazify(induc_induc_covar).double(), jitter=settings.cholesky_jitter.value())
         return L

--- a/test/lazy/test_chol_lazy_tensor.py
+++ b/test/lazy/test_chol_lazy_tensor.py
@@ -4,7 +4,7 @@ import unittest
 
 import torch
 
-from gpytorch.lazy import CholLazyTensor
+from gpytorch.lazy import CholLazyTensor, TriangularLazyTensor
 from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase
 
 
@@ -20,7 +20,7 @@ class TestCholLazyTensor(LazyTensorTestCase, unittest.TestCase):
             dtype=torch.float,
             requires_grad=True,
         )
-        return CholLazyTensor(chol)
+        return CholLazyTensor(TriangularLazyTensor(chol))
 
     def evaluate_lazy_tensor(self, lazy_tensor):
         chol = lazy_tensor.root.evaluate()
@@ -40,7 +40,7 @@ class TestCholLazyTensorBatch(TestCholLazyTensor):
         )
         chol.add_(torch.eye(5).unsqueeze(0))
         chol.requires_grad_(True)
-        return CholLazyTensor(chol)
+        return CholLazyTensor(TriangularLazyTensor(chol))
 
 
 class TestCholLazyTensorMultiBatch(TestCholLazyTensor):
@@ -62,7 +62,7 @@ class TestCholLazyTensorMultiBatch(TestCholLazyTensor):
         chol[2].mul_(0.5)
         chol.add_(torch.eye(5).unsqueeze_(0).unsqueeze_(0))
         chol.requires_grad_(True)
-        return CholLazyTensor(chol)
+        return CholLazyTensor(TriangularLazyTensor(chol))
 
 
 if __name__ == "__main__":

--- a/test/lazy/test_interpolated_lazy_tensor.py
+++ b/test/lazy/test_interpolated_lazy_tensor.py
@@ -5,7 +5,7 @@ import unittest
 import torch
 
 from gpytorch.lazy import InterpolatedLazyTensor, NonLazyTensor
-from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase
+from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase, RectangularLazyTensorTestCase
 
 
 class TestInterpolatedLazyTensor(LazyTensorTestCase, unittest.TestCase):
@@ -145,7 +145,7 @@ def empty_method(self):
     pass
 
 
-class TestInterpolatedLazyTensorRectangular(LazyTensorTestCase, unittest.TestCase):
+class TestInterpolatedLazyTensorRectangular(RectangularLazyTensorTestCase, unittest.TestCase):
     def create_lazy_tensor(self):
         itplzt = InterpolatedLazyTensor(NonLazyTensor(torch.rand(3, 4)))
         return itplzt


### PR DESCRIPTION
Adds a new `TriangularLazyTensor` abstraction. This tensor can be upper or lower (default) triangular. This simplifies a bunch of stuff with solves, dets, logprobs etc.

### Some of the changes with larger blast radius in this PR are:
1. `CholLazyTensor` now takes in a `TriangularLazyTensor`
2. The `_cholesky` method is expected to return a `TriangularLazyTensor`
3. The `_cholesky` method now takes an `upper` kwarg (allows to work with both lower and upper variants of `TriangularLazyTensor`)
4. `DiagLazyTensor` is not subclassed from `TriangularLazyTensor`
5. The memoization functionality is updated to allow caching results depending on args/kwargs (required for dealing with the upper/lower kwargs). By setting `ignore_args=False` in the `@cached` decorator, the existing behavior can be replicated.


### Some improvements:
1. `CholLazyTensor` now has a more efficient `inv_matmul` and `inv_quad` methods using the factorization of the matrix.
2. `KroneckerProductLazyTensor` now returns a Cholesky decomposition that itself uses a Kronecker product representation [previously suggested in #1086] 
3. Added a `test_cholesky` test to the `LazyTensorTestCase` (this covers some previously uncovered cases explicitly)
4. There were a number of hard-to-spot issues due to hacky manual cache handling - I replaced all these call sites with the cache helpers from `gpytorch.utils.memoize`, which is the correct way to go about this.
