### PR TITLE
Pin sphinx<3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,5 @@ matrix:
         apt_packages:
           - pandoc
       python: "3.6"
-      install: pip install "nbformat<=4.4" IPython ipykernel sphinx sphinx_rtd_theme nbsphinx m2r attrs==19.1
+      install: pip install "nbformat<=4.4" IPython ipykernel sphinx<3.0.0 sphinx_rtd_theme nbsphinx m2r attrs==19.1
       script: python setup.py build_sphinx


### PR DESCRIPTION
I think m2r is broken on the new release of sphinx, so pinning to <3.0.0 so Travis can build our docs.