### PR TITLE
Adding RQ kernel to documentation

### DIFF
--- a/docs/source/kernels.rst
+++ b/docs/source/kernels.rst
@@ -71,6 +71,12 @@ Standard Kernels
 .. autoclass:: RBFKernel
    :members:
 
+:hidden:`RQKernel`
+~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: RQKernel
+   :members:
+
 :hidden:`SpectralMixtureKernel`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/kernels.rst
+++ b/docs/source/kernels.rst
@@ -93,15 +93,14 @@ Composition/Decoration Kernels
 .. autoclass:: AdditiveKernel
    :members:
 
-:hidden:`AdditiveStructureKernel`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 :hidden:`MultiDeviceKernel`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: MultiDeviceKernel
    :members:
 
+:hidden:`AdditiveStructureKernel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: AdditiveStructureKernel
    :members:

--- a/gpytorch/kernels/cosine_kernel.py
+++ b/gpytorch/kernels/cosine_kernel.py
@@ -20,7 +20,7 @@ class CosineKernel(Kernel):
             \pi \Vert \mathbf{x_1} - \mathbf{x_2} \Vert_2 / p \right)
        \end{equation*}
 
-    where :math:`p` is the periord length parameter.
+    where :math:`p` is the period length parameter.
 
     Args:
         :attr:`batch_shape` (torch.Size, optional):


### PR DESCRIPTION
Very simple PR that adds the RQ kernel to the docs.
Also fixing the position of the body for AdditiveStructureKernel, which went for walk elsewhere.