### PR TITLE
Add cholesky_jitter to settings.

### DIFF
--- a/gpytorch/kernels/inducing_point_kernel.py
+++ b/gpytorch/kernels/inducing_point_kernel.py
@@ -5,6 +5,7 @@ import math
 
 import torch
 
+from .. import settings
 from ..distributions import MultivariateNormal
 from ..lazy import DiagLazyTensor, MatmulLazyTensor, PsdSumLazyTensor, RootLazyTensor, delazify
 from ..mlls import InducingPointKernelAddedLossTerm
@@ -44,7 +45,7 @@ class InducingPointKernel(Kernel):
         if not self.training and hasattr(self, "_cached_kernel_inv_root"):
             return self._cached_kernel_inv_root
         else:
-            chol = psd_safe_cholesky(self._inducing_mat, upper=True)
+            chol = psd_safe_cholesky(self._inducing_mat, upper=True, jitter=settings.cholesky_jitter.value())
             eye = torch.eye(chol.size(-1), device=chol.device, dtype=chol.dtype)
             inv_root = torch.triangular_solve(eye, chol)[0]
 

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -411,7 +411,7 @@ class LazyTensor(ABC):
             return NonLazyTensor(evaluated_mat.clamp_min(0.0).sqrt())
 
         # contiguous call is necessary here
-        cholesky = psd_safe_cholesky(evaluated_mat).contiguous()
+        cholesky = psd_safe_cholesky(evaluated_mat, jitter=settings.cholesky_jitter.value()).contiguous()
         return NonLazyTensor(cholesky)
 
     def _cholesky_solve(self, rhs):

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -338,6 +338,15 @@ class max_cg_iterations(_value_context):
     _global_value = 1000
 
 
+class cholesky_jitter(_value_context):
+    """
+    The jitter value passed to `psd_safe_cholesky` when using cholesky solves.
+    Default: None
+    """
+
+    _global_value = None
+
+
 class cg_tolerance(_value_context):
     """
     Relative residual tolerance to use for terminating CG.

--- a/gpytorch/variational/unwhitened_variational_strategy.py
+++ b/gpytorch/variational/unwhitened_variational_strategy.py
@@ -48,7 +48,7 @@ class UnwhitenedVariationalStrategy(_VariationalStrategy):
     @cached(name="cholesky_factor")
     def _cholesky_factor(self, induc_induc_covar):
         # Maybe used - if we're not using CG
-        L = psd_safe_cholesky(delazify(induc_induc_covar))
+        L = psd_safe_cholesky(delazify(induc_induc_covar), jitter=settings.cholesky_jitter.value())
         return L
 
     @property

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -4,6 +4,7 @@ import warnings
 
 import torch
 
+from .. import settings
 from ..distributions import MultivariateNormal
 from ..lazy import DiagLazyTensor, MatmulLazyTensor, RootLazyTensor, SumLazyTensor, delazify
 from ..settings import trace_mode
@@ -67,7 +68,7 @@ class VariationalStrategy(_VariationalStrategy):
 
     @cached(name="cholesky_factor")
     def _cholesky_factor(self, induc_induc_covar):
-        L = psd_safe_cholesky(delazify(induc_induc_covar).double())
+        L = psd_safe_cholesky(delazify(induc_induc_covar).double(), jitter=settings.cholesky_jitter.value())
         return L
 
     @property


### PR DESCRIPTION
Currently it's not easily possible to customize the jitter value in the cholesky computations inside the lazy tensors. This adds a setting so that we can now do
```
with settings.cholesky_jitter(1e-5):
    lt.cholesky()
```

Naturally, this will also apply this to the solves (when performing posterior inference). This also adds this setting to other uses of `psd_safe_cholesky` in the code.

Note that this PR does not change current behavior as the default setting value is `None`, which is the default argval of `psd_safe_cholesky`.