### PR TITLE
Random Fourier Features Kernel (RBF)

### DIFF
--- a/docs/source/kernels.rst
+++ b/docs/source/kernels.rst
@@ -71,6 +71,12 @@ Standard Kernels
 .. autoclass:: RBFKernel
    :members:
 
+:hidden:`RFFKernel`
+~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: RFFKernel
+   :members:
+
 :hidden:`RQKernel`
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/kernels.rst
+++ b/docs/source/kernels.rst
@@ -71,12 +71,6 @@ Standard Kernels
 .. autoclass:: RBFKernel
    :members:
 
-:hidden:`RFFKernel`
-~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: RFFKernel
-   :members:
-
 :hidden:`RQKernel`
 ~~~~~~~~~~~~~~~~~~~
 
@@ -184,4 +178,10 @@ Kernels for Scalable GP Regression Methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: InducingPointKernel
+   :members:
+
+:hidden:`RFFKernel`
+~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: RFFKernel
    :members:

--- a/gpytorch/kernels/__init__.py
+++ b/gpytorch/kernels/__init__.py
@@ -20,8 +20,8 @@ from .polynomial_kernel import PolynomialKernel
 from .polynomial_kernel_grad import PolynomialKernelGrad
 from .product_structure_kernel import ProductStructureKernel
 from .rbf_kernel import RBFKernel
-from .rff_kernel import RFFKernel
 from .rbf_kernel_grad import RBFKernelGrad
+from .rff_kernel import RFFKernel
 from .rq_kernel import RQKernel
 from .scale_kernel import ScaleKernel
 from .spectral_mixture_kernel import SpectralMixtureKernel

--- a/gpytorch/kernels/__init__.py
+++ b/gpytorch/kernels/__init__.py
@@ -20,6 +20,7 @@ from .polynomial_kernel import PolynomialKernel
 from .polynomial_kernel_grad import PolynomialKernelGrad
 from .product_structure_kernel import ProductStructureKernel
 from .rbf_kernel import RBFKernel
+from .rff_kernel import RFFKernel
 from .rbf_kernel_grad import RBFKernelGrad
 from .rq_kernel import RQKernel
 from .scale_kernel import ScaleKernel
@@ -49,6 +50,7 @@ __all__ = [
     "ProductKernel",
     "ProductStructureKernel",
     "RBFKernel",
+    "RFFKernel",
     "RBFKernelGrad",
     "RQKernel",
     "ScaleKernel",

--- a/gpytorch/kernels/rff_kernel.py
+++ b/gpytorch/kernels/rff_kernel.py
@@ -4,7 +4,7 @@ import torch
 import math
 
 from .kernel import Kernel
-from ..lazy import MatmulLazyTensor
+from ..lazy import MatmulLazyTensor, RootLazyTensor
 
 class RFFKernel(Kernel):
 
@@ -30,10 +30,13 @@ class RFFKernel(Kernel):
             z2 = self._featurize(x2, normalize=False)
         else:
             z2 = z1
-        D = self.num_samples
+        D = float(self.num_samples)
         if diag:
-            return (z1 * z1).sum(-1) / D
-        return MatmulLazyTensor(z1 / D, z2.transpose(-1, -2))
+            return (z1 * z2).sum(-1) / D
+        if x1_eq_x2:
+            return RootLazyTensor(z1 / math.sqrt(D))
+        else:
+            return MatmulLazyTensor(z1 / D, z2.transpose(-1, -2))
 
     def _featurize(self, x, normalize=False):
         # Recompute division each time to allow backprop through lengthscale

--- a/gpytorch/kernels/rff_kernel.py
+++ b/gpytorch/kernels/rff_kernel.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import torch
+import math
+
+from .kernel import Kernel
+from ..lazy import MatmulLazyTensor
+
+class RFFKernel(Kernel):
+
+    has_lengthscale = True
+
+    def __init__(self, input_dim, num_samples, **kwargs):
+        super().__init__(**kwargs)
+        self.num_samples = num_samples
+        self.input_dim = input_dim
+
+        d = input_dim
+        D = num_samples
+        randn_shape = torch.Size([d, D])
+        randn_weights = torch.randn(randn_shape, dtype=self.raw_lengthscale.dtype, device=self.raw_lengthscale.device)
+        self.register_buffer("randn_weights", randn_weights)
+
+    def forward(self, x1, x2, **kwargs):
+        x1_eq_x2 = torch.equal(x1, x2)
+        z1 = self._featurize(x1, normalize=False)
+        if not x1_eq_x2:
+            z2 = self._featurize(x2, normalize=False)
+        else:
+            z2 = z1
+        D = self.num_samples
+        return MatmulLazyTensor(z1 / D, z2.transpose(-1, -2))
+
+    def _featurize(self, x, normalize=False):
+        # Recompute division each time to allow backprop through lengthscale
+        # Transpose lengthscale to allow for ARD
+        x = x.matmul(self.randn_weights / self.lengthscale.transpose(-1, -2))
+        z = torch.cat([torch.cos(x), torch.sin(x)], dim=-1)
+        if normalize:
+            D = self.num_samples
+            z = z / math.sqrt(D)
+        return z

--- a/gpytorch/kernels/rff_kernel.py
+++ b/gpytorch/kernels/rff_kernel.py
@@ -7,6 +7,7 @@ import torch
 from torch import Tensor
 
 from ..lazy import MatmulLazyTensor, RootLazyTensor
+from ..models.exact_prediction_strategies import RFFPredictionStrategy
 from .kernel import Kernel
 
 
@@ -135,3 +136,7 @@ class RFFKernel(Kernel):
             D = self.num_samples
             z = z / math.sqrt(D)
         return z
+
+    def prediction_strategy(self, train_inputs, train_prior_dist, train_labels, likelihood):
+        # Allow for fast sampling
+        return RFFPredictionStrategy(train_inputs, train_prior_dist, train_labels, likelihood)

--- a/gpytorch/kernels/rff_kernel.py
+++ b/gpytorch/kernels/rff_kernel.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
+import math
 from typing import Optional
+
 import torch
 from torch import Tensor
-import math
 
-from .kernel import Kernel
 from ..lazy import MatmulLazyTensor, RootLazyTensor
+from .kernel import Kernel
 
 
 class RFFKernel(Kernel):
@@ -45,10 +46,7 @@ class RFFKernel(Kernel):
             self._init_weights(num_dims, num_samples)
 
     def _init_weights(
-            self,
-            num_dims: Optional[int] = None,
-            num_samples: Optional[int] = None,
-            randn_weights: Optional[Tensor] = None
+        self, num_dims: Optional[int] = None, num_samples: Optional[int] = None, randn_weights: Optional[Tensor] = None
     ):
         if num_dims is not None and num_samples is not None:
             d = num_dims
@@ -56,9 +54,7 @@ class RFFKernel(Kernel):
         if randn_weights is None:
             randn_shape = torch.Size([*self._batch_shape, d, D])
             randn_weights = torch.randn(
-                randn_shape,
-                dtype=self.raw_lengthscale.dtype,
-                device=self.raw_lengthscale.device
+                randn_shape, dtype=self.raw_lengthscale.dtype, device=self.raw_lengthscale.device
             )
         self.register_buffer("randn_weights", randn_weights)
 

--- a/gpytorch/kernels/rff_kernel.py
+++ b/gpytorch/kernels/rff_kernel.py
@@ -13,8 +13,7 @@ from .kernel import Kernel
 
 class RFFKernel(Kernel):
     r"""
-    Computes a covariance matrix based on Random Fourier Features with the
-    RBFKernel.
+    Computes a covariance matrix based on Random Fourier Features with the RBFKernel.
 
     Random Fourier features was originally proposed in
     'Random Features for Large-Scale Kernel Machines' by Rahimi and Recht (2008).
@@ -23,8 +22,8 @@ class RFFKernel(Kernel):
     'On the Error of Random Fourier Features' by Sutherland and Schneider (2015).
 
     By Bochner's theorem, any continuous kernel :math:`k` is positive definite
-    if and only if it is the Fourier transform of a non-negative measure
-    :math:`p(\omega)`, i.e.
+    if and only if it is the Fourier transform of a non-negative measure :math:`p(\omega)`, i.e.
+
     .. math::
         \begin{equation}
             k(x, x') = k(x - x') = \int p(\omega) e^{i(\omega^\top (x - x'))} d\omega.
@@ -33,14 +32,17 @@ class RFFKernel(Kernel):
     where :math:`p(\omega)` is a normalized probability measure if :math:`k(0)=1`.
 
     For the RBF kernel,
+
     .. math::
         \begin{equation}
         k(\Delta) = \exp{(-\frac{\Delta^2}{2\sigma^2})}$ and $p(\omega) = \exp{(-\frac{\sigma^2\omega^2}{2})}
         \end{equation}
+
     where :math:`\Delta = x - x'`.
 
     Given datapoint :math:`x\in \mathbb{R}^d`, we can construct its random Fourier features
     :math:`z(x) \in \mathbb{R}^{2D}` by
+
     .. math::
         \begin{equation}
         z(x) = \sqrt{\frac{1}{D}}
@@ -54,6 +56,7 @@ class RFFKernel(Kernel):
         \end{equation}
 
     such that we have an unbiased Monte Carlo estimator
+
     .. math::
         \begin{equation}
             k(x, x') = k(x - x') \approx z(x)^\top z(x') = \frac{1}{D}\sum_{i=1}^D \cos(\omega_i^\top (x - x')).
@@ -77,12 +80,14 @@ class RFFKernel(Kernel):
     :var torch.Tensor randn_weights: The random frequencies that are drawn once and then fixed.
 
     Example:
+
         >>> # This will infer `num_dims` automatically
         >>> kernel= gpytorch.kernels.RFFKernel(num_samples=5)
         >>> x = torch.randn(10, 3)
         >>> kxx = kernel(x, x).evaluate()
         >>> print(kxx.randn_weights.size())
         torch.Size([3, 5])
+
     """
 
     has_lengthscale = True

--- a/gpytorch/kernels/rff_kernel.py
+++ b/gpytorch/kernels/rff_kernel.py
@@ -1,29 +1,74 @@
 #!/usr/bin/env python3
 
+from typing import Optional
 import torch
+from torch import Tensor
 import math
 
 from .kernel import Kernel
 from ..lazy import MatmulLazyTensor, RootLazyTensor
 
+
 class RFFKernel(Kernel):
+    r"""
+    Computes a covariance matrix based on Random Fourier Features with the
+    RBFKernel.
+
+    See Random Features for Large-Scale Kernel Machines by Rahimi and Recht
+
+    Here we use sine and cosine features which gives a lower-variance estimator.
+    See On the Error of Random Fourier Features by Sutherland and Schneider.
+
+    Args:
+        :attr:`num_samples` (int):
+            Number of random frequencies to draw. This is :math:`D` in the above
+            papers. This will produce :math:`D` sine features and :math:`D`
+            cosine features.
+        :attr:`num_dims` (Optional[int]):
+            Dimensionality of the data space. This is :math:`d` in the above
+            papers. Note that if you want an independent lengthscale for each
+            dimension, set `ard_num_dims` equal to `num_dims`. If unspecified,
+            it will be inferred the first time `forward` is called.
+
+    Attributes:
+        :attr:`randn_weights` (Tensor):
+            The random frequencies that are drawn once at initialization and
+            fixed.
+    """
 
     has_lengthscale = True
 
-    def __init__(self, num_dims, num_samples, **kwargs):
+    def __init__(self, num_samples: int, num_dims: Optional[int] = None, **kwargs):
         super().__init__(**kwargs)
         self.num_samples = num_samples
-        self.num_dims = num_dims
+        if num_dims is not None:
+            self._init_weights(num_dims, num_samples)
 
-        d = num_dims
-        D = num_samples
-        randn_shape = torch.Size([d, D])
-        randn_weights = torch.randn(randn_shape, dtype=self.raw_lengthscale.dtype, device=self.raw_lengthscale.device)
+    def _init_weights(
+            self,
+            num_dims: Optional[int] = None,
+            num_samples: Optional[int] = None,
+            randn_weights: Optional[Tensor] = None
+    ):
+        if num_dims is not None and num_samples is not None:
+            d = num_dims
+            D = num_samples
+        if randn_weights is None:
+            randn_shape = torch.Size([*self._batch_shape, d, D])
+            randn_weights = torch.randn(
+                randn_shape,
+                dtype=self.raw_lengthscale.dtype,
+                device=self.raw_lengthscale.device
+            )
         self.register_buffer("randn_weights", randn_weights)
 
-    def forward(self, x1, x2, diag=False, last_dim_is_batch=False, **kwargs):
+    def forward(self, x1: Tensor, x2: Tensor, diag: bool = False, last_dim_is_batch: bool = False, **kwargs) -> Tensor:
         if last_dim_is_batch:
-            raise RuntimeError("last_dim_is_batch not implemented for RFF")
+            x1 = x1.transpose(-1, -2).unsqueeze(-1)
+            x2 = x2.transpose(-1, -2).unsqueeze(-1)
+        num_dims = x1.size(-1)
+        if not hasattr(self, "randn_weights"):
+            self._init_weights(num_dims, self.num_samples)
         x1_eq_x2 = torch.equal(x1, x2)
         z1 = self._featurize(x1, normalize=False)
         if not x1_eq_x2:
@@ -38,7 +83,7 @@ class RFFKernel(Kernel):
         else:
             return MatmulLazyTensor(z1 / D, z2.transpose(-1, -2))
 
-    def _featurize(self, x, normalize=False):
+    def _featurize(self, x: Tensor, normalize: bool = False) -> Tensor:
         # Recompute division each time to allow backprop through lengthscale
         # Transpose lengthscale to allow for ARD
         x = x.matmul(self.randn_weights / self.lengthscale.transpose(-1, -2))

--- a/gpytorch/models/pyro/_pyro_mixin.py
+++ b/gpytorch/models/pyro/_pyro_mixin.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-import pyro
 import torch
+
+import pyro
 
 
 class _PyroMixin(object):

--- a/test/kernels/test_rff_kernel.py
+++ b/test/kernels/test_rff_kernel.py
@@ -3,6 +3,7 @@
 import unittest
 
 import torch
+
 from gpytorch.kernels import RFFKernel
 from gpytorch.test.base_kernel_test_case import BaseKernelTestCase
 

--- a/test/kernels/test_rff_kernel.py
+++ b/test/kernels/test_rff_kernel.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+from gpytorch.kernels import RFFKernel
+from gpytorch.test.base_kernel_test_case import BaseKernelTestCase
+
+
+class TestRFFKernel(unittest.TestCase, BaseKernelTestCase):
+    def create_kernel_no_ard(self, **kwargs):
+        return RFFKernel(num_samples=5, **kwargs)
+
+    def create_kernel_ard(self, num_dims, **kwargs):
+        return RFFKernel(num_dims=num_dims, num_samples=7, ard_num_dims=num_dims, **kwargs)
+
+    def test_active_dims_list(self):
+        kernel = self.create_kernel_no_ard(active_dims=[0, 2, 4, 6])
+        x = self.create_data_no_batch()
+        covar_mat = kernel(x).evaluate_kernel().evaluate()
+        randn_weights = kernel.randn_weights
+        kernel_basic = self.create_kernel_no_ard()
+        kernel_basic._init_weights(randn_weights=randn_weights)
+        covar_mat_actual = kernel_basic(x[:, [0, 2, 4, 6]]).evaluate_kernel().evaluate()
+
+        self.assertLess(torch.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(), 1e-4)
+
+    def test_active_dims_range(self):
+        active_dims = list(range(3, 9))
+        kernel = self.create_kernel_no_ard(active_dims=active_dims)
+        x = self.create_data_no_batch()
+        covar_mat = kernel(x).evaluate_kernel().evaluate()
+        randn_weights = kernel.randn_weights
+        kernel_basic = self.create_kernel_no_ard()
+        kernel_basic._init_weights(randn_weights=randn_weights)
+        covar_mat_actual = kernel_basic(x[:, active_dims]).evaluate_kernel().evaluate()
+
+        self.assertLess(torch.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(), 1e-4)
+
+    def test_kernel_getitem_single_batch(self):
+        kernel = self.create_kernel_no_ard(batch_shape=torch.Size([2]))
+        x = self.create_data_single_batch()
+
+        res1 = kernel(x).evaluate()[0]  # Result of first kernel on first batch of data
+        randn_weights = kernel.randn_weights
+
+        new_kernel = kernel[0]
+        new_kernel._init_weights(randn_weights=randn_weights[0])
+        res2 = new_kernel(x[0]).evaluate()  # Should also be result of first kernel on first batch of data.
+
+        self.assertLess(torch.norm(res1 - res2) / res1.norm(), 1e-4)
+
+    def test_kernel_getitem_double_batch(self):
+        # TODO: Fix randomization
+        kernel = self.create_kernel_no_ard(batch_shape=torch.Size([3, 2]))
+        x = self.create_data_double_batch()
+
+        res1 = kernel(x).evaluate()[0, 1]  # Result of first kernel on first batch of data
+        randn_weights = kernel.randn_weights
+
+        new_kernel = kernel[0, 1]
+        new_kernel._init_weights(randn_weights=randn_weights[0, 1])
+        res2 = new_kernel(x[0, 1]).evaluate()  # Should also be result of first kernel on first batch of data.
+
+        self.assertLess(torch.norm(res1 - res2) / res1.norm(), 1e-4)


### PR DESCRIPTION
This is a PR for `RFFKernel` which implements random Fourier features for the RBFKernel as described by https://papers.nips.cc/paper/3182-random-features-for-large-scale-kernel-machines.

Note that I use sine and cosine features which has lower variance as shown in https://arxiv.org/abs/1506.02785. 

I also did [some profiling](https://github.com/cornellius-gp/gpytorch/files/4749309/alexwang-rff-profiling.pdf) of the RFF Kernel on UCI datasets for a course project last semester, showing
1. the speedups as a function of number of data points versus an exact GP
2. the computation time as a linear function of the number of features, as expected
3. the quality of kernel approximation error as a function of number of features
4. the speedups per optimization iteration
5. the regression performance as a function of the number of features
