### PR TITLE
Add special-cased diag operation for KroneckerProductLazyTensor

### DIFF
--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -5,11 +5,22 @@ from functools import reduce
 
 from torch import Size, Tensor
 
+from .. import settings
 from ..utils.broadcasting import _matmul_broadcast_shape
 from ..utils.memoize import cached
 from .diag_lazy_tensor import DiagLazyTensor
 from .lazy_tensor import LazyTensor
 from .non_lazy_tensor import lazify
+
+
+def _kron_diag(*lts) -> Tensor:
+    """Compute diagonal of a KroneckerProductLazyTensor from the diagonals of the constituiting tensors"""
+    lead_diag = lts[0].diag()
+    if len(lts) == 1:  # base case:
+        return lead_diag
+    trail_diag = _kron_diag(*lts[1:])
+    diag = lead_diag.unsqueeze(-2) * trail_diag.unsqueeze(-1)
+    return diag.transpose(-1, -2).reshape(*diag.shape[:-2], -1)
 
 
 def _prod(iterable):
@@ -72,6 +83,20 @@ class KroneckerProductLazyTensor(LazyTensor):
             return self.add_diag(other.diag())
         else:
             return super().__add__(other)
+
+    def diag(self):
+        r"""
+        As :func:`torch.diag`, returns the diagonal of the matrix :math:`K` this LazyTensor represents as a vector.
+
+        :rtype: torch.tensor
+        :return: The diagonal of :math:`K`. If :math:`K` is :math:`n \times n`, this will be a length
+            n vector. If this LazyTensor represents a batch (e.g., is :math:`b \times n \times n`), this will be a
+            :math:`b \times n` matrix of diagonals, one for each matrix in the batch.
+        """
+        if settings.debug.on():
+            if not self.is_square:
+                raise RuntimeError("Diag works on square matrices (or batches)")
+        return _kron_diag(*self.lazy_tensors)
 
     def _get_indices(self, row_index, col_index, *batch_indices):
         row_factor = self.size(-2)


### PR DESCRIPTION
This is quite a bit faster. Not a big deal in the grand scheme of things, but let's take what we can get.

Will add unit tests.

```
ns = list(range(10, 60, 10))

data = []
for n in ns:
    
    A = torch.rand(2, n, n)
    B = torch.rand(2, n, n)
    C = torch.rand(2, n, n)
    K = KroneckerProductLazyTensor(A, B, C)
    
    res = %timeit -o K.diag()
    res_master = %timeit -o LazyTensor.diag(K)
    
    assert torch.allclose(K.diag(), LazyTensor.diag(K))
    
    data.append({
        "n": n,
        "this_diff": 1000 * res.average,
        "master": 1000 * res_master.average,
    })
```

![kron_diag_perf](https://user-images.githubusercontent.com/1605878/86377291-015b2980-bc3d-11ea-927e-e8d67ea3ca9d.png)


