### PR TITLE
[Bug] In place _symeig clamping fails to have correct backwards.

### DIFF
--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -188,7 +188,7 @@ class KroneckerProductLazyTensor(LazyTensor):
             evals_, evecs_ = eval_tensor.double().symeig(eigenvectors=eigenvectors)
 
             # we chop any negative eigenvalues
-            evals_.clamp_min_(0.0)
+            evals_ = evals_.clamp_min(0.0)
 
             evals_ = evals_.type(tensor_dtype)
             evecs_ = evecs_.type(tensor_dtype)


### PR DESCRIPTION
The in-place version of `clamp_min_` fails to have a correct backwards call, so this replaces that with a non-in place version. I don't know why the unit tests didn't catch this issue.