### PR TITLE
Use trace estimation for logdet backwards in KPAddedDiagLT

### DIFF
--- a/gpytorch/lazy/kronecker_product_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_added_diag_lazy_tensor.py
@@ -30,7 +30,7 @@ class KroneckerProductAddedDiagLazyTensor(AddedDiagLazyTensor):
         # solve but we only want to cache the probe vectors for the backwards
         with skip_logdet_forward(True):
             inv_quad_term, func_logdet_term = super().inv_quad_logdet(
-                inv_quad_rhs=inv_quad_rhs, logdet=logdet is not None, reduce_inv_quad=reduce_inv_quad
+                inv_quad_rhs=inv_quad_rhs, logdet=logdet, reduce_inv_quad=reduce_inv_quad
             )
 
         if logdet is not None:

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -151,7 +151,6 @@ class KroneckerProductLazyTensor(LazyTensor):
     @cached(name="symeig")
     def _symeig(self, eigenvectors=True):
         # eigenvectors may not get zeroed if called w/o eigenvectors after initialization
-        from torch import zeros_like
 
         evals, evecs = [], []
         for lazy_tensor in self.lazy_tensors:
@@ -164,9 +163,7 @@ class KroneckerProductLazyTensor(LazyTensor):
             evals_, evecs_ = eval_tensor.double().symeig(eigenvectors=eigenvectors)
 
             # we chop any negative eigenvalues
-            neg_evals = zeros_like(evals_)
-            neg_evals[evals_.data < 0] = -evals_.data[evals_.data < 0]
-            evals_ = evals_ + neg_evals
+            evals_.clamp_min_(0.0)
 
             evals_ = evals_.type(tensor_dtype)
             evecs_ = evecs_.type(tensor_dtype)


### PR DESCRIPTION
This PR should fix any possible bugs with the logdet backwards in KPAddedDiagLazyTensor --- that I would have introduced.

Basically, the gradients aren't well defined for the log det if there are repeated eigenvalues and backpropagating through `symeig` is known to be unstable. Instead, we can use stochastic trace estimation to estimate the gradient, which is easy in this case because solves are cheap and can be done in batch with the original solve.

The trick I used here is to skip the logdet forward Lanczos call in the `inv_quad_logdet` function while detaching the `_logdet()` so that we add zero to the correctly computed forwards pass in the logdet while also propagating the gradients.