### PR TITLE
Fix issue in Multitask likelihood

### DIFF
--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -92,8 +92,10 @@ class _MultitaskGaussianLikelihoodBase(_GaussianLikelihoodBase):
             task_covar_blocks = MatmulLazyTensor(MatmulLazyTensor(noise_sem, task_corr_exp), noise_sem)
         else:
             # otherwise tasks are uncorrelated
+            if isinstance(noise_covar, DiagLazyTensor):
+                flattened_diag = noise_covar._diag.view(*noise_covar._diag.shape[:-2], -1)
+                return DiagLazyTensor(flattened_diag)
             task_covar_blocks = noise_covar
-
         if len(batch_shape) == 1:
             # TODO: Properly support general batch shapes in BlockDiagLazyTensor (no shape arithmetic)
             tcb_eval = task_covar_blocks.evaluate()


### PR DESCRIPTION
Right now, MultitaskGaussianLikelihood creates a BlockDiagLazyTensor regardless of whether the noise covariance is fully diagonal. This is bad, because it will always result in `full_covar` (e.g., from a `likelihood(model(X))` call) being a `SumLazyTensor` instead of an `AddedDiagLazyTensor`.

One issue this doesn't fix: since `covar` is usually still a `LazyEvaluatedKernelTensor` by the time it gets to the likelihood, if it would be a `KroneckerProductLazyTensor` after evaluation, we will end up with an `AddedDiagLazyTensor` from the likelihood instead of the new `KroneckerProductPlusDiagLazyTensor`.