### PR TITLE
Add ConstantDiagLazyTensor

### DIFF
--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -9,7 +9,7 @@ from .cached_cg_lazy_tensor import CachedCGLazyTensor
 from .cat_lazy_tensor import CatLazyTensor, cat
 from .chol_lazy_tensor import CholLazyTensor
 from .constant_mul_lazy_tensor import ConstantMulLazyTensor
-from .diag_lazy_tensor import DiagLazyTensor
+from .diag_lazy_tensor import ConstantDiagLazyTensor, DiagLazyTensor
 from .interpolated_lazy_tensor import InterpolatedLazyTensor
 from .keops_lazy_tensor import KeOpsLazyTensor
 from .kronecker_product_added_diag_lazy_tensor import KroneckerProductAddedDiagLazyTensor
@@ -40,6 +40,7 @@ __all__ = [
     "CachedCGLazyTensor",
     "CatLazyTensor",
     "CholLazyTensor",
+    "ConstantDiagLazyTensor",
     "ConstantMulLazyTensor",
     "DiagLazyTensor",
     "InterpolatedLazyTensor",

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -176,7 +176,7 @@ class DiagLazyTensor(LazyTensor):
 
 
 class ConstantDiagLazyTensor(DiagLazyTensor):
-    def __init__(self, diag_values, n):
+    def __init__(self, diag_values, diag_shape):
         """
         Diagonal lazy tensor with constant entries. Supports arbitrary batch sizes.
         Used e.g. for adding jitter to matrices.
@@ -188,5 +188,5 @@ class ConstantDiagLazyTensor(DiagLazyTensor):
                 A `b1 x ... x bk x 1` Tensor, representing a `b1 x ... x bk`-sized batch
                 of `n x n` diagonal matrices
         """
-        super(DiagLazyTensor, self).__init__(diag_values, n)
-        self._diag = diag_values.expand(*diag_values.shape[:-1], n)
+        super(DiagLazyTensor, self).__init__(diag_values, diag_shape=diag_shape)
+        self._diag = diag_values.expand(*diag_values.shape[:-1], diag_shape)

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -173,3 +173,20 @@ class DiagLazyTensor(LazyTensor):
     def zero_mean_mvn_samples(self, num_samples):
         base_samples = torch.randn(num_samples, *self._diag.shape, dtype=self.dtype, device=self.device)
         return base_samples * self._diag.sqrt()
+
+
+class ConstantDiagLazyTensor(DiagLazyTensor):
+    def __init__(self, diag_values, n):
+        """
+        Diagonal lazy tensor with constant entries. Supports arbitrary batch sizes.
+        Used e.g. for adding jitter to matrices.
+
+        Args:
+            :attr:`n` (int):
+                The (non-batch) dimension of the (square) matrix
+            :attr:`diag_values` (Tensor):
+                A `b1 x ... x bk x 1` Tensor, representing a `b1 x ... x bk`-sized batch
+                of `n x n` diagonal matrices
+        """
+        super(DiagLazyTensor, self).__init__(diag_values, n)
+        self._diag = diag_values.expand(*diag_values.shape[:-1], n)

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -69,6 +69,9 @@ class DiagLazyTensor(LazyTensor):
 
     def _quad_form_derivative(self, left_vecs, right_vecs):
         # TODO: Use proper batching for input vectors (prepand to shape rathern than append)
+        if not self._diag.requires_grad:
+            return (None,)
+
         res = left_vecs * right_vecs
         if res.ndimension() > self._diag.ndimension():
             res = res.sum(-1)

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -189,4 +189,11 @@ class ConstantDiagLazyTensor(DiagLazyTensor):
                 of `n x n` diagonal matrices
         """
         super(DiagLazyTensor, self).__init__(diag_values, diag_shape=diag_shape)
+        self.diag_shape = diag_shape
         self._diag = diag_values.expand(*diag_values.shape[:-1], diag_shape)
+
+    def _expand_batch(self, batch_shape):
+        return self.__class__(self._diag.expand(*batch_shape, self._diag.size(-1)), diag_shape=self.diag_shape)
+
+    def _sum_batch(self, dim):
+        return self.__class__(self._diag.sum(dim), diag_shape=self.diag_shape)

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -165,7 +165,7 @@ class KroneckerProductLazyTensor(LazyTensor):
         diag_shape = diag.shape
         if len(diag_shape) == 0 or diag_shape[-1] == 1:
             # interpret scalar tensor or single-trailing element as constant diag
-            diag_tensor = ConstantDiagLazyTensor(diag, self.shape[-1])
+            diag_tensor = ConstantDiagLazyTensor(diag, diag_shape=self.shape[-1])
         else:
             try:
                 expanded_diag = diag.expand(self.shape[:-1])

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -695,7 +695,7 @@ class LazyTensor(ABC):
         diag_shape = diag.shape
         if len(diag_shape) == 0 or diag_shape[-1] == 1:
             # interpret scalar tensor or single-trailing element as constant diag
-            diag_tensor = ConstantDiagLazyTensor(diag, self.shape[-1])
+            diag_tensor = ConstantDiagLazyTensor(diag, diag_shape=self.shape[-1])
         else:
             try:
                 expanded_diag = diag.expand(self.shape[:-1])

--- a/test/lazy/test_mul_lazy_tensor.py
+++ b/test/lazy/test_mul_lazy_tensor.py
@@ -4,7 +4,7 @@ import unittest
 
 import torch
 
-from gpytorch.lazy import RootLazyTensor
+from gpytorch.lazy import LazyTensor, RootLazyTensor
 from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase
 
 
@@ -30,6 +30,20 @@ class TestMulLazyTensor(LazyTensorTestCase, unittest.TestCase):
         res = res + diag_tensor
         return res
 
+    def test_quad_form_derivative(self):
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor._diag_tensor.requires_grad_(False)
+        lazy_tensor_clone = lazy_tensor.clone().detach_().requires_grad_(True)
+        lazy_tensor_clone._diag_tensor.requires_grad_(False)
+        left_vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-2), 2)
+        right_vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 2)
+        deriv_custom = lazy_tensor._quad_form_derivative(left_vecs, right_vecs)
+        deriv_auto = LazyTensor._quad_form_derivative(lazy_tensor_clone, left_vecs, right_vecs)
+
+        for dc, da in zip(deriv_custom, deriv_auto):
+            if dc is not None or da is not None:
+                self.assertAllClose(dc, da)
+
 
 class TestMulLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
     seed = 2
@@ -47,6 +61,20 @@ class TestMulLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
         )
         res = res + diag_tensor
         return res
+
+    def test_quad_form_derivative(self):
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor._diag_tensor.requires_grad_(False)
+        lazy_tensor_clone = lazy_tensor.clone().detach_().requires_grad_(True)
+        lazy_tensor_clone._diag_tensor.requires_grad_(False)
+        left_vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-2), 2)
+        right_vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 2)
+        deriv_custom = lazy_tensor._quad_form_derivative(left_vecs, right_vecs)
+        deriv_auto = LazyTensor._quad_form_derivative(lazy_tensor_clone, left_vecs, right_vecs)
+
+        for dc, da in zip(deriv_custom, deriv_auto):
+            if dc is not None or da is not None:
+                self.assertAllClose(dc, da)
 
 
 class TestMulLazyTensorMultiBatch(LazyTensorTestCase, unittest.TestCase):
@@ -69,6 +97,20 @@ class TestMulLazyTensorMultiBatch(LazyTensorTestCase, unittest.TestCase):
 
     def test_inv_quad_logdet(self):
         pass
+
+    def test_quad_form_derivative(self):
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor._diag_tensor.requires_grad_(False)
+        lazy_tensor_clone = lazy_tensor.clone().detach_().requires_grad_(True)
+        lazy_tensor_clone._diag_tensor.requires_grad_(False)
+        left_vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-2), 2)
+        right_vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 2)
+        deriv_custom = lazy_tensor._quad_form_derivative(left_vecs, right_vecs)
+        deriv_auto = LazyTensor._quad_form_derivative(lazy_tensor_clone, left_vecs, right_vecs)
+
+        for dc, da in zip(deriv_custom, deriv_auto):
+            if dc is not None or da is not None:
+                self.assertAllClose(dc, da)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a `ConstantDiagLazyTensor` to deal with some of the gradient issues that came up in #1105. 

This fails miserably b/c of how the args are handled in the representation tree, but I'm not sure how to fix that. I tried tensorizing the n arg, but then the lazies are trying to compute gradients w.r.t. n. Any thoughts how to properly deal with this?

cc @wjmaddox 