### PR TITLE
Skip Posterior Variances under skip_posterior_vars settings for RFFPredStrat

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -648,6 +648,9 @@ class RFFPredictionStrategy(DefaultPredictionStrategy):
         )
 
     def exact_predictive_covar(self, test_test_covar, test_train_covar):
+        if settings.skip_posterior_variances.on():
+            return ZeroLazyTensor(*test_test_covar.size())
+
         if isinstance(test_test_covar, ConstantMulLazyTensor):
             constant = test_test_covar.expanded_constant
             test_test_covar = test_test_covar.base_lazy_tensor


### PR DESCRIPTION
Fixes #1232 . 

That being said, I'm not entirely confident the other specialized prediction strategies even have this option so might want to expand the scope.