### PR TITLE
[WIP] Remove _quad_form_deriv methods from TriangularLT and RootLt

### DIFF
--- a/gpytorch/lazy/root_lazy_tensor.py
+++ b/gpytorch/lazy/root_lazy_tensor.py
@@ -59,18 +59,6 @@ class RootLazyTensor(LazyTensor):
         # Matrix is symmetric
         return self._matmul(rhs)
 
-    def _quad_form_derivative(self, left_vecs, right_vecs):
-        right_vecs_times_rhs = self.root._t_matmul(right_vecs)
-        left_vecs_times_lhs_t = self.root._t_matmul(left_vecs)
-
-        deriv_part_1 = self.root._quad_form_derivative(left_vecs, right_vecs_times_rhs)
-        deriv_part_2 = self.root._quad_form_derivative(right_vecs, left_vecs_times_lhs_t)
-
-        deriv = []
-        for item_part_1, item_part_2 in zip(deriv_part_1, deriv_part_2):
-            deriv.append(item_part_1 + item_part_2)
-        return tuple(deriv)
-
     def root_decomposition(self):
         return self
 

--- a/gpytorch/lazy/triangular_lazy_tensor.py
+++ b/gpytorch/lazy/triangular_lazy_tensor.py
@@ -80,10 +80,6 @@ class TriangularLazyTensor(LazyTensor):
     def _mul_constant(self, constant: Tensor) -> "TriangularLazyTensor":
         return TriangularLazyTensor(self._tensor * constant.unsqueeze(-1), upper=self.upper)
 
-    def _quad_form_derivative(self, left_vecs, right_vecs):
-        res = left_vecs.matmul(right_vecs.transpose(-1, -2))
-        return (res,)
-
     def _root_decomposition(self) -> Allsor:
         raise NotPSDError("TriangularLazyTensor does not allow a root decomposition")
 


### PR DESCRIPTION
I'm not entirely sure what's going on here. Motivated by upstream Ax test failures caused by TriangularLT, https://github.com/pytorch/botorch/issues/513, and #1247.

Removing the explicit `_quad_form_derivative` method from `TriangularLazyTensor` seems to resolve those issues, but creates some test failures in `CholLazyTensor` that are resolved by removing the `_quad_form_derivative` method from `RootLazyTensor`. 