### PR TITLE
Update Affiliations

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ From then on, this will automatically run flake8, isort, black and other tools o
 ## The Team
 
 GPyTorch is primarily maintained by:
-- [Jake Gardner](http://github.com/jacobrgardner) (Uber AI Labs)
-- [Geoff Pleiss](http://github.com/gpleiss) (Cornell University)
+- [Jake Gardner](https://www.cis.upenn.edu/~jacobrg/index.html) (University of Pennsylvania)
+- [Geoff Pleiss](http://github.com/gpleiss) (Columbia University)
 - [Kilian Weinberger](http://kilian.cs.cornell.edu/) (Cornell University)
-- [Andrew Gordon Wilson](https://people.orie.cornell.edu/andrew/) (Cornell University)
+- [Andrew Gordon Wilson](https://cims.nyu.edu/~andrewgw/) (New York University)
 - [Max Balandat](https://research.fb.com/people/balandat-max/) (Facebook)
 
 <img width="300" src=https://brand.cornell.edu/assets/images/downloads/logos/cornell_logo_simple/cornell_logo_simple.svg alt="Cornell Logo" />

--- a/README.md
+++ b/README.md
@@ -98,9 +98,6 @@ GPyTorch is primarily maintained by:
 - [Andrew Gordon Wilson](https://cims.nyu.edu/~andrewgw/) (New York University)
 - [Max Balandat](https://research.fb.com/people/balandat-max/) (Facebook)
 
-<img width="300" src=https://brand.cornell.edu/assets/images/downloads/logos/cornell_logo_simple/cornell_logo_simple.svg alt="Cornell Logo" />
-<img width="300" src=https://raw.githubusercontent.com/cornellius-gp/cornellius-gp.github.io/master/static/media/facebook_logo.2835357a.png alt="Facebook Logo" />
-<img width="300" src=https://gpytorch.ai/static/media/uber_ai_horizontal.fe9ab653.png alt="Uber AI Logo" />
 We would like to thank our other contributors including (but not limited to)  David Arbour, Eytan Bakshy, David Eriksson, Jared Frank, Sam Stanton, Bram Wallace, Ke Alexander Wang, Ruihan Wu.
 
 ## Acknowledgements


### PR DESCRIPTION
Quick README book keeping. 

- Update affiliations
- Remove logos (if we kept adding them we'd be up from 1 to like 5+, which starts to look more like NASCAR than open source).