### PR TITLE
Fix bad cache invalidation in variational strategies

### DIFF
--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -32,6 +32,14 @@ def pop_from_cache(obj, name, *args, **kwargs):
         raise CachingError("Object does not have item {} stored in cache.".format(name))
 
 
+def pop_from_cache_ignore_args(obj, name):
+    """Pop an item from the cache (honoring calling args)."""
+    try:
+        return obj._memoize_cache.pop(name)
+    except (KeyError, AttributeError):
+        raise CachingError("Object does not have item {} stored in cache.".format(name))
+
+
 def clear_cache_hook(module, *args, **kwargs):
     module._memoize_cache = {}
 

--- a/gpytorch/variational/batch_decoupled_variational_strategy.py
+++ b/gpytorch/variational/batch_decoupled_variational_strategy.py
@@ -5,7 +5,8 @@ from torch.distributions.kl import kl_divergence
 
 from ..distributions import Delta, MultivariateNormal
 from ..lazy import MatmulLazyTensor, SumLazyTensor
-from ..utils.memoize import pop_from_cache
+from ..utils.errors import CachingError
+from ..utils.memoize import pop_from_cache_ignore_args
 from .delta_variational_distribution import DeltaVariationalDistribution
 from .variational_strategy import VariationalStrategy
 
@@ -186,7 +187,10 @@ class BatchDecoupledVariationalStrategy(VariationalStrategy):
         if L.shape != induc_induc_covar.shape:
             # Aggressive caching can cause nasty shape incompatibilies when evaluating with different batch shapes
             # TODO: Use a hook to make this cleaner
-            pop_from_cache(self, "cholesky_factor")
+            try:
+                pop_from_cache_ignore_args(self, "cholesky_factor")
+            except CachingError:
+                pass
             L = self._cholesky_factor(induc_induc_covar)
         interp_term = L.inv_matmul(induc_data_covar.double()).to(full_inputs.dtype)
         mean_interp_term = interp_term.select(mean_var_batch_dim - 2, 0)


### PR DESCRIPTION
This got overlooked in #1102. This fix is not the most elegant one, we really should use some kind of hook (as the code states). This only occurred when batch-evaluating with different batch sizes. That logic generally could be improved..