### PR TITLE
Doc fixes

### DIFF
--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -23,7 +23,7 @@ class MaternKernel(Kernel):
 
     where
 
-    * :math:`d = (\mathbf{x_1} - \mathbf{x_2})^\top \Theta^{-1} (\mathbf{x_1} - \mathbf{x_2})`
+    * :math:`d = (\mathbf{x_1} - \mathbf{x_2})^\top \Theta^{-2} (\mathbf{x_1} - \mathbf{x_2})`
       is the distance between
       :math:`x_1` and :math:`x_2` scaled by the :attr:`lengthscale` parameter :math:`\Theta`.
     * :math:`\nu` is a smoothness parameter (takes values 1/2, 3/2, or 5/2). Smaller values are less smooth.

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -471,7 +471,7 @@ class max_preconditioner_size(_value_context):
     """
     The maximum size of preconditioner to use. 0 corresponds to turning
     preconditioning off. When enabled, usually a value of around ~10 works fairly well.
-    Default: 0
+    Default: 15
     """
 
     _global_value = 15


### PR DESCRIPTION
1. Fix typo in docstring about the default for `max_preconditioner_size`
2. Fix typo in docstring about the Matern kernel. Closes #1266 