### PR TITLE
Fix issues with eigenvectors=False in symeig

### DIFF
--- a/gpytorch/lazy/block_diag_lazy_tensor.py
+++ b/gpytorch/lazy/block_diag_lazy_tensor.py
@@ -129,5 +129,8 @@ class BlockDiagLazyTensor(BlockLazyTensor):
         evals, evecs = self.base_lazy_tensor.symeig(eigenvectors=eigenvectors)
         # Doesn't make much sense to sort here, o/w we lose the structure
         evals = evals.reshape(*evals.shape[:-2], evals.shape[-2:].numel())
-        evecs = self.__class__(evecs)  # can assume that block_dim is -3 here
+        if eigenvectors:
+            evecs = self.__class__(evecs)  # can assume that block_dim is -3 here
+        else:
+            evecs = None
         return evals, evecs

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1589,7 +1589,8 @@ class LazyTensor(ABC):
                 contains the orthonormal eigenvectors of the matrix.
         """
         try:
-            return pop_from_cache(self, "symeig", eigenvectors=True)
+            evals, evecs = pop_from_cache(self, "symeig", eigenvectors=True)
+            return evals, None
         except CachingError:
             pass
         return self._symeig(eigenvectors=eigenvectors)

--- a/gpytorch/test/lazy_tensor_test_case.py
+++ b/gpytorch/test/lazy_tensor_test_case.py
@@ -632,6 +632,10 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
                 if arg_copy.requires_grad and arg_copy.is_leaf and arg_copy.grad is not None:
                     self.assertAllClose(arg.grad, arg_copy.grad, rtol=1e-4, atol=1e-3)
 
+        # Test with eigenvectors=False
+        _, evecs = lazy_tensor.symeig(eigenvectors=False)
+        self.assertIsNone(evecs)
+
     def test_svd(self):
         lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
         lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)


### PR DESCRIPTION
This fixes two issues:
1. calling `symeig` with `eigenvectors=False` after calling it with `eigenvectors=True` would return the eigenvectors (because we avoid recomputing the evals). This now propertly returns `None` instead.
2. calling `symeig` of any `BlockLazyTensor` with `eigenvectors=False` woudl raise a `RuntimeError` (#1281)

This PR also adds a unit test testing the behavior.