### PR TITLE
Fix type of elements of ZeroLazyTensor._args

### DIFF
--- a/gpytorch/lazy/zero_lazy_tensor.py
+++ b/gpytorch/lazy/zero_lazy_tensor.py
@@ -14,7 +14,14 @@ class ZeroLazyTensor(LazyTensor):
     """
 
     def __init__(self, *sizes, dtype=None, device=None):
-        super(ZeroLazyTensor, self).__init__(*sizes)
+        if len(sizes) == 1 and (
+                torch.is_tensor(sizes[0])
+                or isinstance(sizes[0], torch.Size)
+        ):
+            sizes = sizes[0]
+        else:
+            sizes = torch.tensor(sizes)
+        super(ZeroLazyTensor, self).__init__(sizes)
         self.sizes = list(sizes)
 
         self._dtype = dtype or torch.get_default_dtype()

--- a/test/lazy/test_zero_lazy_tensor.py
+++ b/test/lazy/test_zero_lazy_tensor.py
@@ -15,6 +15,11 @@ class TestZeroLazyTensor(unittest.TestCase):
         res = lv.evaluate()
         self.assertLess(torch.norm(res - actual), 1e-4)
 
+    def test_representation(self):
+        lv = ZeroLazyTensor(5, 4, 3)
+        representation = lv.representation()
+        self.assertIsInstance(representation, torch.Tensor)
+
     def test_getitem(self):
         lv = ZeroLazyTensor(5, 4, 3)
 


### PR DESCRIPTION
Fixes https://github.com/cornellius-gp/gpytorch/issues/1292.
Adds a unittest to check that the representation of a `ZeroLazyTensor` can be computed.

The constructor of `ZeroLazyTensor` now accepts three types of parameters: some integers (same as before), a `torch.Tensor` object, or a `torch.Size` object.