### PR TITLE
Explicitly cast constraint bounds to float

### DIFF
--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -21,8 +21,8 @@ class Interval(Module):
             lower_bound (float or torch.Tensor): The lower bound on the parameter.
             upper_bound (float or torch.Tensor): The upper bound on the parameter.
         """
-        lower_bound = torch.as_tensor(lower_bound)
-        upper_bound = torch.as_tensor(upper_bound)
+        lower_bound = torch.as_tensor(lower_bound).float()
+        upper_bound = torch.as_tensor(upper_bound).float()
 
         if torch.any(torch.ge(lower_bound, upper_bound)):
             raise RuntimeError("Got parameter bounds with empty intervals.")

--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -29,8 +29,8 @@ class Interval(Module):
 
         super().__init__()
 
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
+        self.register_buffer("lower_bound", lower_bound)
+        self.register_buffer("upper_bound", upper_bound)
 
         self._transform = transform
         self._inv_transform = inv_transform

--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -44,6 +44,22 @@ class Interval(Module):
         self.upper_bound = fn(self.upper_bound)
         return super()._apply(fn)
 
+    def _load_from_state_dict(
+        self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
+    ):
+        result = super()._load_from_state_dict(
+            state_dict=state_dict,
+            prefix=prefix,
+            local_metadata=local_metadata,
+            strict=False,
+            missing_keys=missing_keys,
+            unexpected_keys=unexpected_keys,
+            error_msgs=error_msgs,
+        )
+        # The lower_bound and upper_bound buffers are new, and so may not be present in older state dicts
+        # Because of this, we won't have strict-mode on when loading this module
+        return result
+
     @property
     def enforced(self):
         return self._transform is not None


### PR DESCRIPTION
Fixes #1305 

Note that `.float` is the correct cast and not a half baked decision on my part -- all of the `Constraint` methods use operations that can mix dtypes, but we only want the output tensors of each method to be fp64 if the input tensor was, not because the bounds are (also note that in the current implementation on master, `Interval(4., 5.)` would result in fp32 bound tensors).