### PR TITLE
Clear precomputed caches when training or loading from state dict

### DIFF
--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -61,15 +61,14 @@ class GridKernel(Kernel):
         if not self.interpolation_mode:
             self.register_buffer("full_grid", create_data_from_grid(grid))
 
+    def _clear_cache(self):
+        if hasattr(self, "_cached_kernel_mat"):
+            del self._cached_kernel_mat
+
     def register_buffer_list(self, base_name, tensors):
         """Helper to register several buffers at once under a single base name"""
         for i, tensor in enumerate(tensors):
             self.register_buffer(base_name + "_" + str(i), tensor)
-
-    def train(self, mode=True):
-        if hasattr(self, "_cached_kernel_mat"):
-            del self._cached_kernel_mat
-        return super(GridKernel, self).train(mode)
 
     @property
     def grid(self):
@@ -91,8 +90,7 @@ class GridKernel(Kernel):
         if not self.interpolation_mode:
             self.full_grid = create_data_from_grid(self.grid)
 
-        if hasattr(self, "_cached_kernel_mat"):
-            del self._cached_kernel_mat
+        self._clear_cache()
         return self
 
     @property

--- a/gpytorch/kernels/inducing_point_kernel.py
+++ b/gpytorch/kernels/inducing_point_kernel.py
@@ -25,10 +25,9 @@ class InducingPointKernel(Kernel):
         self.register_parameter(name="inducing_points", parameter=torch.nn.Parameter(inducing_points))
         self.register_added_loss_term("inducing_point_loss_term")
 
-    def train(self, mode=True):
+    def _clear_cache(self):
         if hasattr(self, "_cached_kernel_mat"):
             del self._cached_kernel_mat
-        return super(InducingPointKernel, self).train(mode)
 
     @property
     def _inducing_mat(self):

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -85,6 +85,10 @@ class ExactGP(GP):
             self.train_targets = fn(self.train_targets)
         return super(ExactGP, self)._apply(fn)
 
+    def _clear_cache(self):
+        # The precomputed caches from test time live in prediction_strategy
+        self.prediction_strategy = None
+
     def local_load_samples(self, samples_dict, memo, prefix):
         """
         Replace the model's learned hyperparameters with samples from a posterior distribution.
@@ -235,19 +239,6 @@ class ExactGP(GP):
         new_model.train_targets = full_targets
 
         return new_model
-
-    def train(self, mode=True):
-        if mode:
-            self.prediction_strategy = None
-        return super(ExactGP, self).train(mode)
-
-    def _load_from_state_dict(
-        self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
-    ):
-        self.prediction_strategy = None
-        super()._load_from_state_dict(
-            state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
-        )
 
     def __call__(self, *args, **kwargs):
         train_inputs = list(self.train_inputs) if self.train_inputs is not None else []


### PR DESCRIPTION
There are a few modules that use precomputed caches (ExactGPs, _VariatianalStrategy, GridKernel, etc.). We should be clearing these caches in two scenarios:
1. Entering `train` mode after being in `eval` mode
2. When calling `load_state_dict`

This introduces a `_clear_cache()` method to the `gpytorch.Module` super class, which is overwritten by any modules with caches. `Module#train` and `Module#_load_from_state_dict` both call `_clear_cache`.

[Fixes #1308]