### PR TITLE
Fix shape issue for MMVN with broadcasted means

### DIFF
--- a/gpytorch/distributions/multitask_multivariate_normal.py
+++ b/gpytorch/distributions/multitask_multivariate_normal.py
@@ -36,7 +36,11 @@ class MultitaskMultivariateNormal(MultivariateNormal):
 
         batch_shape = _mul_broadcast_shape(mean.shape[:-2], covariance_matrix.shape[:-2])
         if mean.shape[-2:].numel() != covariance_matrix.size(-1):
-            if mean.size(-2) == 1:
+            if covariance_matrix.size(-1) % mean.shape[-2:].numel():
+                raise RuntimeError(
+                    f"mean shape {mean.shape} is incompatible with covariance shape {covariance_matrix.shape}"
+                )
+            elif mean.size(-2) == 1:
                 mean = mean.expand(*batch_shape, covariance_matrix.size(-1) // mean.size(-1), mean.size(-1))
             elif mean.size(-1) == 1:
                 mean = mean.expand(*batch_shape, mean.size(-2), covariance_matrix.size(-2) // mean.size(-2))

--- a/gpytorch/distributions/multitask_multivariate_normal.py
+++ b/gpytorch/distributions/multitask_multivariate_normal.py
@@ -34,6 +34,8 @@ class MultitaskMultivariateNormal(MultivariateNormal):
         if mean.dim() < 2:
             raise RuntimeError("mean should be a matrix or a batch matrix (batch mode)")
 
+        # Ensure that shapes are broadcasted appropriately across the mean and covariance
+        # Means can have singleton dimensions for either the `n` or `t` dimensions
         batch_shape = _mul_broadcast_shape(mean.shape[:-2], covariance_matrix.shape[:-2])
         if mean.shape[-2:].numel() != covariance_matrix.size(-1):
             if covariance_matrix.size(-1) % mean.shape[-2:].numel():

--- a/test/distributions/test_multitask_multivariate_normal.py
+++ b/test/distributions/test_multitask_multivariate_normal.py
@@ -274,6 +274,25 @@ class TestMultiTaskMultivariateNormal(BaseTestCase, unittest.TestCase):
             with least_used_cuda_device():
                 self.test_from_independent_mvns(cuda=True)
 
+    def test_multitask_multivariate_normal_broadcasting(self):
+        mean = torch.randn(5, 1, 3)
+        _covar = torch.randn(6, 6)
+        covar = _covar @ _covar.transpose(-1, -2)
+        sample = MultitaskMultivariateNormal(mean, covar).rsample()
+        self.assertEqual(sample.shape, torch.Size([5, 2, 3]))
+
+        mean = torch.randn(5, 1)
+        _covar = torch.randn(3, 10, 10)
+        covar = _covar @ _covar.transpose(-1, -2)
+        sample = MultitaskMultivariateNormal(mean, covar).rsample()
+        self.assertEqual(sample.shape, torch.Size([3, 5, 2]))
+
+        with self.assertRaises(RuntimeError):
+            mean = torch.randn(5, 1)
+            _covar = torch.randn(12, 12)
+            covar = _covar @ _covar.transpose(-1, -2)
+            MultitaskMultivariateNormal(mean, covar)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If I have a MMVN with `mean.shape = [1 x d]` and `cover.shape = `[nd x nd]`, I would expect the singleton dimension in the mean to broadcast. Similarly for `mean.shape = [n x 1]` and `cover.shape = `[nd x nd]`.

This PR fixes a small bug and allows for this broadcasting.