### PR TITLE
Leave one out cross-validation 

### DIFF
--- a/gpytorch/mlls/__init__.py
+++ b/gpytorch/mlls/__init__.py
@@ -8,6 +8,7 @@ from .deep_predictive_log_likelihood import DeepPredictiveLogLikelihood
 from .exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from .gamma_robust_variational_elbo import GammaRobustVariationalELBO
 from .inducing_point_kernel_added_loss_term import InducingPointKernelAddedLossTerm
+from .leave_one_out_likelihood import LeaveOneOutLikelihood
 from .marginal_log_likelihood import MarginalLogLikelihood
 from .noise_model_added_loss_term import NoiseModelAddedLossTerm
 from .predictive_log_likelihood import PredictiveLogLikelihood
@@ -38,6 +39,7 @@ __all__ = [
     "DeepPredictiveLogLikelihood",
     "ExactMarginalLogLikelihood",
     "InducingPointKernelAddedLossTerm",
+    "LeaveOneOutLikelihood",
     "MarginalLogLikelihood",
     "NoiseModelAddedLossTerm",
     "PredictiveLogLikelihood",

--- a/gpytorch/mlls/__init__.py
+++ b/gpytorch/mlls/__init__.py
@@ -8,7 +8,7 @@ from .deep_predictive_log_likelihood import DeepPredictiveLogLikelihood
 from .exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from .gamma_robust_variational_elbo import GammaRobustVariationalELBO
 from .inducing_point_kernel_added_loss_term import InducingPointKernelAddedLossTerm
-from .leave_one_out_likelihood import LeaveOneOutLikelihood
+from .leave_one_out_pseudo_likelihood import LeaveOneOutPseudoLikelihood
 from .marginal_log_likelihood import MarginalLogLikelihood
 from .noise_model_added_loss_term import NoiseModelAddedLossTerm
 from .predictive_log_likelihood import PredictiveLogLikelihood
@@ -39,7 +39,7 @@ __all__ = [
     "DeepPredictiveLogLikelihood",
     "ExactMarginalLogLikelihood",
     "InducingPointKernelAddedLossTerm",
-    "LeaveOneOutLikelihood",
+    "LeaveOneOutPseudoLikelihood",
     "MarginalLogLikelihood",
     "NoiseModelAddedLossTerm",
     "PredictiveLogLikelihood",

--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -60,7 +60,7 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
         # Get the log prob of the marginal distribution
         output = self.likelihood(function_dist, *params)
         res = output.log_prob(target)
-        self._add_other_terms(res, params)
+        res = self._add_other_terms(res, params)
 
         # Scale by the amount of data we have
         num_data = target.size(-1)

--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -33,7 +33,7 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
             raise RuntimeError("Likelihood must be Gaussian for exact inference")
         super(ExactMarginalLogLikelihood, self).__init__(likelihood, model)
 
-    def _add_other_terms(self, res):
+    def _add_other_terms(self, res, params):
         # Add additional terms (SGPR / learned inducing points, heteroskedastic likelihood models)
         for added_loss_term in self.model.added_loss_terms():
             res = res.add(added_loss_term.loss(*params))
@@ -60,7 +60,7 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
         # Get the log prob of the marginal distribution
         output = self.likelihood(function_dist, *params)
         res = output.log_prob(target)
-        self._add_other_terms(res)
+        self._add_other_terms(res, params)
 
         # Scale by the amount of data we have
         num_data = target.size(-1)

--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -33,6 +33,17 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
             raise RuntimeError("Likelihood must be Gaussian for exact inference")
         super(ExactMarginalLogLikelihood, self).__init__(likelihood, model)
 
+    def _add_other_terms(self, res):
+        # Add additional terms (SGPR / learned inducing points, heteroskedastic likelihood models)
+        for added_loss_term in self.model.added_loss_terms():
+            res = res.add(added_loss_term.loss(*params))
+
+        # Add log probs of priors on the (functions of) parameters
+        for _, prior, closure, _ in self.named_priors():
+            res.add_(prior.log_prob(closure()).sum())
+
+        return res
+
     def forward(self, function_dist, target, *params):
         r"""
         Computes the MLL given :math:`p(\mathbf f)` and :math:`\mathbf y`.
@@ -49,14 +60,7 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
         # Get the log prob of the marginal distribution
         output = self.likelihood(function_dist, *params)
         res = output.log_prob(target)
-
-        # Add additional terms (SGPR / learned inducing points, heteroskedastic likelihood models)
-        for added_loss_term in self.model.added_loss_terms():
-            res = res.add(added_loss_term.loss(*params))
-
-        # Add log probs of priors on the (functions of) parameters
-        for _, prior, closure, _ in self.named_priors():
-            res.add_(prior.log_prob(closure()).sum())
+        self._add_other_terms(res)
 
         # Scale by the amount of data we have
         num_data = target.size(-1)

--- a/gpytorch/mlls/leave_one_out_likelihood.py
+++ b/gpytorch/mlls/leave_one_out_likelihood.py
@@ -1,0 +1,66 @@
+import math
+
+import torch
+from torch import Tensor
+
+from ..distributions import MultivariateNormal
+from .exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+
+
+class LeaveOneOutLikelihood(ExactMarginalLogLikelihood):
+    """
+    The leave one out cross-validation (LOO-CV) likelihood from RW 5.4.2 for an exact Gaussian process with a
+    Gaussian likelihood. This offers an alternative to the exact marginal log likelihood where we
+    instead maximize the sum of the leave one out log probabilities :math:`\log p(y_i | X, y_{-i}, \theta)`.
+
+    Naively, this will be O(n^4) with Cholesky as we need to compute `n` Cholesky factorizations. Fortunately,
+    given the Cholesky factorization of the full kernel matrix (without any points removed), we can compute
+    both the mean and variance of each removed point via a bordered system formulation making the total
+    complexity O(n^3).
+
+    The LOO-CV approach can be more robust against model mis-specification as it gives an estimate for the
+    (log) predictive probability, whether or not the assumptions of the model is fulfilled.
+
+    .. note::
+        This module will not work with anything other than a :obj:`~gpytorch.likelihoods.GaussianLikelihood`
+        and a :obj:`~gpytorch.models.ExactGP`. It also cannot be used in conjunction with
+        stochastic optimization.
+
+    :param ~gpytorch.likelihoods.GaussianLikelihood likelihood: The Gaussian likelihood for the model
+    :param ~gpytorch.models.ExactGP model: The exact GP model
+
+    Example:
+        >>> # model is a gpytorch.models.ExactGP
+        >>> # likelihood is a gpytorch.likelihoods.Likelihood
+        >>> loocv = gpytorch.mlls.LeaveOneOutLikelihood(likelihood, model)
+        >>>
+        >>> output = model(train_x)
+        >>> loss = -loocv(output, train_y)
+        >>> loss.backward()
+    """
+
+    def __init__(self, likelihood, model):
+        super().__init__(likelihood=likelihood, model=model)
+        self.likelihood = likelihood
+        self.model = model
+
+    def forward(self, function_dist: MultivariateNormal, target: Tensor, *params) -> Tensor:
+        r"""
+        Computes the leave one out likelihood given :math:`p(\mathbf f)` and `\mathbf y`
+
+        :param ~gpytorch.distributions.MultivariateNormal output: the outputs of the latent function
+            (the :obj:`~gpytorch.models.GP`)
+        :param torch.Tensor target: :math:`\mathbf y` The target values
+        :param dict kwargs: Additional arguments to pass to the likelihood's :attr:`forward` function.
+        """
+        output = self.likelihood(function_dist, *params)
+        m, K = output.mean, output.covariance_matrix
+        m = m.reshape(*target.shape)
+        L = torch.cholesky(K, upper=False)
+        I = torch.eye(*K.shape[-2:], dtype=K.dtype, device=K.device)
+        sigma2 = 1.0 / torch.cholesky_solve(I, L, upper=False).diagonal(dim1=-1, dim2=-2)  # 1 / diag(inv(K))
+        mu = target - torch.cholesky_solve((target - m).unsqueeze(-1), L, upper=False).squeeze(-1) * sigma2
+        term1 = -0.5 * torch.log(sigma2)
+        term2 = -0.5 * (target - mu).pow(2.0) / sigma2
+        log_loocv = term1 + term2 - 0.5 * math.log(2 * math.pi)
+        return log_loocv.sum(dim=-1)

--- a/gpytorch/mlls/leave_one_out_likelihood.py
+++ b/gpytorch/mlls/leave_one_out_likelihood.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import math
 
 import torch

--- a/gpytorch/mlls/leave_one_out_pseudo_likelihood.py
+++ b/gpytorch/mlls/leave_one_out_pseudo_likelihood.py
@@ -66,13 +66,7 @@ class LeaveOneOutPseudoLikelihood(ExactMarginalLogLikelihood):
         log_loocv = term1 + term2 - 0.5 * math.log(2 * math.pi)
         res = log_loocv.sum(dim=-1)
 
-        # Add additional terms (SGPR / learned inducing points, heteroskedastic likelihood models)
-        for added_loss_term in self.model.added_loss_terms():
-            res = res.add(added_loss_term.loss(*params))
-
-        # Add log probs of priors on the (functions of) parameters
-        for _, prior, closure, _ in self.named_priors():
-            res.add_(prior.log_prob(closure()).sum())
+        res = self._add_other_terms(res)
 
         # Scale by the amount of data we have
         num_data = target.size(-1)

--- a/test/mlls/__init__.py
+++ b/test/mlls/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/test/mlls/test_leave_one_out_pseudo_likelihood.py
+++ b/test/mlls/test_leave_one_out_pseudo_likelihood.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import math
+import unittest
+
+import torch
+
+import gpytorch
+
+
+class ExactGPModel(gpytorch.models.ExactGP):
+    def __init__(self, train_x, train_y, likelihood):
+        super().__init__(train_x, train_y, likelihood)
+        self.mean_module = gpytorch.means.ConstantMean(batch_shape=train_x.shape[:-2])
+        self.covar_module = gpytorch.kernels.ScaleKernel(gpytorch.kernels.RBFKernel())
+
+    def forward(self, x):
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
+        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+
+
+class TestLeaveOneOutPseudoLikelihood(unittest.TestCase):
+    def get_data(self, shapes, dtype=None, device=None):
+        train_x = torch.rand(*shapes, dtype=dtype, device=device, requires_grad=True)
+        train_y = torch.sin(train_x[..., 0]) + torch.cos(train_x[..., 1])
+        likelihood = gpytorch.likelihoods.GaussianLikelihood().to(dtype=dtype, device=device)
+        model = ExactGPModel(train_x, train_y, likelihood).to(dtype=dtype, device=device)
+        loocv = gpytorch.mlls.LeaveOneOutPseudoLikelihood(likelihood=likelihood, model=model)
+        return train_x, train_y, loocv
+
+    def test_smoke(self):
+        """Make sure the loocv works without batching."""
+        train_x, train_y, loocv = self.get_data([5, 2])
+        output = loocv.model(train_x)
+        loss = -loocv(output, train_y)
+        loss.backward()
+        self.assertTrue(train_x.grad is not None)
+
+    def test_smoke_batch(self):
+        """Make sure the loocv works without batching."""
+        train_x, train_y, loocv = self.get_data([3, 3, 3, 5, 2])
+        output = loocv.model(train_x)
+        loss = -loocv(output, train_y)
+        assert loss.shape == (3, 3, 3)
+        loss.sum().backward()
+        self.assertTrue(train_x.grad is not None)
+
+    def test_check_bordered_system(self):
+        """Make sure that the bordered system solves match the naive solution."""
+        n = 5
+        # Compute the pseudo-likelihood via the bordered systems in O(n^3)
+        train_x, train_y, loocv = self.get_data([n, 2], dtype=torch.float64)
+        output = loocv.model(train_x)
+        loocv_1 = loocv(output, train_y)
+
+        # Compute the pseudo-likelihood by fitting n independent models O(n^4)
+        loocv_2 = 0.0
+        for i in range(n):
+            inds = torch.cat((torch.arange(0, i), torch.arange(i + 1, n)))
+            likelihood = gpytorch.likelihoods.GaussianLikelihood()
+            model = ExactGPModel(train_x[inds, :], train_y[inds], likelihood)
+            model.eval()
+            with torch.no_grad():
+                preds = likelihood(model(train_x[i, :].unsqueeze(0)))
+                mean, var = preds.mean, preds.variance
+                loocv_2 += -0.5 * var.log() - 0.5 * (train_y[i] - mean).pow(2.0) / var - 0.5 * math.log(2 * math.pi)
+        loocv_2 /= n
+
+        self.assertAlmostEqual(
+            loocv_1.item(),
+            loocv_2.item(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/mlls/test_leave_one_out_pseudo_likelihood.py
+++ b/test/mlls/test_leave_one_out_pseudo_likelihood.py
@@ -68,8 +68,7 @@ class TestLeaveOneOutPseudoLikelihood(unittest.TestCase):
         loocv_2 /= n
 
         self.assertAlmostEqual(
-            loocv_1.item(),
-            loocv_2.item(),
+            loocv_1.item(), loocv_2.item(),
         )
 
 


### PR DESCRIPTION
This is an implementation of the leave one out cross-validation (pseudo likelihood), from RW 5.4.2.  The objective is to maximize the sum of the leave-one-out log probabilities, which we can do in `O(n^3)` via a bordered system formulation. I explicitly use Cholesky as I think this is mostly interesting in the small-data regime, where incorrect model assumptions may influence the resulting model a lot. 

The two computationally expensive pieces are:
1) Computing `diag(inv(K))`, which we can do `O(n^3)` via Cholesky.  We can potentially do diagonal estimation, see, e.g., https://www-users.cs.umn.edu/~saad/PDF/umsi-2005-082.pdf, but it requires working with inv(K) rather than K, so we probably need a pretty large number of points to beat Cholesky as we have a CG step in the inner loop.
2) Solve `K x = target - mean`, which is trivial with either CG or Cholesky.

I've verified that the los function works in both the `Simple_GP_regression.ipynb` and `Simple_Batch_Mode_GP_Regression.ipynb`, so hopefully I got the batching right. There are no specific tests as this is an isolated piece, but I can add some if you want.

I probably need some pointers and thoughts on what to do with the `pyro_factor`, `named_priors`, `added_loss_terms`, that are being added to the loss in `exact_marginal_log_likelihood.py`.