### PR TITLE
Fix Matern KeOps tests

### DIFF
--- a/test/kernels/keops/test_matern_kernel.py
+++ b/test/kernels/keops/test_matern_kernel.py
@@ -19,7 +19,7 @@ try:
             return MaternKernel(nu=2.5, ard_num_dims=num_dims, **kwargs)
 
     class TestMaternKeOpsKernel(unittest.TestCase):
-        def test_forward_x1_eq_x2(self, nu):
+        def forward_x1_eq_x2(self, nu):
             if not torch.cuda.is_available():
                 return
 
@@ -33,7 +33,7 @@ try:
 
             self.assertLess(torch.norm(k1 - k2), 1e-4)
 
-        def test_forward_x1_neq_x2(self, nu):
+        def forward_x1_neq_x2(self, nu):
             if not torch.cuda.is_available():
                 return
 
@@ -49,22 +49,22 @@ try:
             self.assertLess(torch.norm(k1 - k2), 1e-4)
 
         def test_forward_nu25_x1_eq_x2(self):
-            return self.test_forward_x1_eq_x2(nu=2.5)
+            return self.forward_x1_eq_x2(nu=2.5)
 
         def test_forward_nu25_x1_neq_x2(self):
-            return self.test_forward_nu05_x1_neq_x2(nu=2.5)
+            return self.forward_x1_neq_x2(nu=2.5)
 
         def test_forward_nu15_x1_eq_x2(self):
-            return self.test_forward_x1_eq_x2(nu=1.5)
+            return self.forward_x1_eq_x2(nu=1.5)
 
         def test_forward_nu15_x1_neq_x2(self):
-            return self.test_forward_x1_neq_x2(nu=1.5)
+            return self.forward_x1_neq_x2(nu=1.5)
 
         def test_forward_nu05_x1_eq_x2(self):
-            return self.test_forward_x1_eq_x2(nu=0.5)
+            return self.forward_x1_eq_x2(nu=0.5)
 
         def test_forward_nu05_x1_neq_x2(self):
-            return self.test_forward_x1_neq_x2(nu=0.5)
+            return self.forward_x1_neq_x2(nu=0.5)
 
         def test_batch_matmul(self):
             if not torch.cuda.is_available():


### PR DESCRIPTION
It looks like the Matern KeOps tests are currently broken on master and return the error:

```
======================================================================
ERROR: test_forward_nu25_x1_neq_x2 (kernels.keops.test_matern_kernel.TestMaternKeOpsKernel)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/deriksson/Documents/GitHub/gpytorch/test/kernels/keops/test_matern_kernel.py", line 55, in test_forward_nu25_x1_neq_x2
    return self.test_forward_nu05_x1_neq_x2(nu=2.5)
TypeError: test_forward_nu05_x1_neq_x2() got an unexpected keyword argument 'nu'
```

The following PR fixes the naming so the helper functions aren't being called as independent tests.