### PR TITLE
Make kernels pickleable

### DIFF
--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -9,7 +9,6 @@ from torch.nn import Module
 from .. import settings
 from ..utils.transforms import _get_inv_param_transform, inv_sigmoid, inv_softplus
 
-
 # define softplus here instead of using torch.nn.functional.softplus because the functional version can't be pickled
 softplus = torch.nn.Softplus()
 

--- a/gpytorch/constraints/constraints.py
+++ b/gpytorch/constraints/constraints.py
@@ -5,10 +5,13 @@ import math
 import torch
 from torch import sigmoid
 from torch.nn import Module
-from torch.nn.functional import softplus
 
 from .. import settings
 from ..utils.transforms import _get_inv_param_transform, inv_sigmoid, inv_softplus
+
+
+# define softplus here instead of using torch.nn.functional.softplus because the functional version can't be pickled
+softplus = torch.nn.Softplus()
 
 
 class Interval(Module):

--- a/gpytorch/test/base_kernel_test_case.py
+++ b/gpytorch/test/base_kernel_test_case.py
@@ -4,6 +4,8 @@ from abc import abstractmethod
 
 import torch
 
+import pickle
+
 
 class BaseKernelTestCase(object):
     @abstractmethod
@@ -137,3 +139,7 @@ class BaseKernelTestCase(object):
         res2 = new_kernel(x[0, 1]).evaluate()  # Should also be result of first kernel on first batch of data.
 
         self.assertLess(torch.norm(res1 - res2) / res1.norm(), 1e-4)
+
+    def test_kernel_pickle_unpickle(self):
+        kernel = self.create_kernel_no_ard(batch_shape=torch.Size([]))
+        pickle.loads(pickle.dumps(kernel)) # Should be able to pickle and unpickle a kernel

--- a/gpytorch/test/base_kernel_test_case.py
+++ b/gpytorch/test/base_kernel_test_case.py
@@ -142,4 +142,4 @@ class BaseKernelTestCase(object):
 
     def test_kernel_pickle_unpickle(self):
         kernel = self.create_kernel_no_ard(batch_shape=torch.Size([]))
-        pickle.loads(pickle.dumps(kernel)) # Should be able to pickle and unpickle a kernel
+        pickle.loads(pickle.dumps(kernel))  # Should be able to pickle and unpickle a kernel

--- a/gpytorch/test/base_kernel_test_case.py
+++ b/gpytorch/test/base_kernel_test_case.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 
+import pickle
 from abc import abstractmethod
 
 import torch
-
-import pickle
 
 
 class BaseKernelTestCase(object):


### PR DESCRIPTION
This solves issue #907 by using an instance of the module `torch.nn.Softplus` instead of `torch.nn.functional.softplus` because the functional version can't be pickled. Also added a test case for this.