### PR TITLE
More efficient root decomposition for KPLT

### DIFF
--- a/gpytorch/lazy/kronecker_product_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_added_diag_lazy_tensor.py
@@ -2,7 +2,6 @@
 
 import torch
 
-from ..settings import skip_logdet_forward
 from .added_diag_lazy_tensor import AddedDiagLazyTensor
 from .diag_lazy_tensor import DiagLazyTensor
 
@@ -28,25 +27,21 @@ class KroneckerProductAddedDiagLazyTensor(AddedDiagLazyTensor):
     def inv_quad_logdet(self, inv_quad_rhs=None, logdet=False, reduce_inv_quad=True):
         # we want to call the standard InvQuadLogDet to easily get the probe vectors and do the
         # solve but we only want to cache the probe vectors for the backwards
-        with skip_logdet_forward(True):
-            inv_quad_term, func_logdet_term = super().inv_quad_logdet(
-                inv_quad_rhs=inv_quad_rhs, logdet=logdet, reduce_inv_quad=reduce_inv_quad
-            )
+        # with skip_logdet_forward(True):
+        inv_quad_term, _ = super().inv_quad_logdet(
+            inv_quad_rhs=inv_quad_rhs, logdet=False, reduce_inv_quad=reduce_inv_quad
+        )
 
         if logdet is not None:
-            if skip_logdet_forward.off():
-                # we use the InvQuadLogDet backwards call to get the gradient
-                logdet_term = self._logdet().detach()
-                logdet_term = logdet_term + func_logdet_term
-            else:
-                logdet_term = func_logdet_term
+            logdet_term = self._logdet()
         else:
             logdet_term = None
 
         return inv_quad_term, logdet_term
 
     def _logdet(self):
-        evals, _ = self.lazy_tensor.symeig(eigenvectors=False)
+        # symeig requires computing the eigenvectors so that it's differentiable
+        evals, _ = self.lazy_tensor.symeig(eigenvectors=True)
         evals_plus_diag = evals + self.diag_tensor.diag()
         return torch.log(evals_plus_diag).sum(dim=-1)
 


### PR DESCRIPTION
The current "symeig" root decomposition for `KroneckerProductLazyTensor` uses a Hadamard product of a KPLT and a dense vector, which is quite memory intensive for large kronecker products. This PR adds in a lazy option for returning the eigenvalues (maybe this should be done throughout the LT framework instead of returning solely the vector?), which allows writing the KPLT root decomposition as a Kronecker product of the product of the eigenvectors and eigenvalues of the components of the KP.

```python

kernels = [MaternKernel()] * 4
xlist = [torch.randn(x, 1) for x in [10, 30, 50, 100]]

kplt = KroneckerProductLazyTensor(*[kernel(x) for kernel, x in zip(kernels, xlist)])

kplt.root_decomposition(method = "symeig")
```