### PR TITLE
add lazy evals option to kplt symeig + root

### DIFF
--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -233,6 +233,9 @@ class KroneckerProductLazyTensor(LazyTensor):
     def _symeig(
         self, eigenvectors: bool = False, return_evals_as_lazy: bool = False
     ) -> Tuple[Tensor, Optional[LazyTensor]]:
+        # return_evals_as_lazy is a flag to return the eigenvalues as a lazy tensor
+        # which is useful for root decompositions here (see the root_decomposition
+        # method above)
         evals, evecs = [], []
         for lt in self.lazy_tensors:
             evals_, evecs_ = lt.symeig(eigenvectors=eigenvectors)

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -199,7 +199,7 @@ class KroneckerProductLazyTensor(LazyTensor):
     def root_decomposition(self, method: Optional[str] = None):
         from gpytorch.lazy import RootLazyTensor
 
-        if method == "symeig":
+        if method == "symeig" or method is None:
             evals, evecs = self._symeig(eigenvectors=True, return_evals_as_lazy=True)
             # TODO: only use non-zero evals (req. dealing w/ batches...)
             f_list = [

--- a/test/lazy/test_kronecker_product_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_lazy_tensor.py
@@ -20,6 +20,7 @@ def kron(a, b):
 
 class TestKroneckerProductLazyTensor(LazyTensorTestCase, unittest.TestCase):
     seed = 0
+    should_call_lanczos = False
 
     def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
@@ -39,6 +40,7 @@ class TestKroneckerProductLazyTensor(LazyTensorTestCase, unittest.TestCase):
 
 class TestKroneckerProductLazyTensorBatch(TestKroneckerProductLazyTensor):
     seed = 0
+    should_call_lanczos = False
 
     def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float).repeat(3, 1, 1)


### PR DESCRIPTION
The current "symeig" root decomposition for `KroneckerProductLazyTensor` uses a Hadamard product of a KPLT and a dense vector https://github.com/cornellius-gp/gpytorch/blob/8f9b44fc57dbb0a13b568946f07a37e9332f92c4/gpytorch/lazy/lazy_tensor.py#L1366, which is quite memory intensive for large kronecker products. This PR adds in a lazy option for returning the eigenvalues (maybe this should be done throughout the LT framework instead of returning solely the vector?), which allows writing the KPLT root decomposition as a Kronecker product of the product of the eigenvectors and eigenvalues of the components of the KP.

Example usage that should now be possible:

```python

kernels = [MaternKernel()] * 4
xlist = [torch.randn(x, 1) for x in [10, 30, 50, 100]]

kplt = KroneckerProductLazyTensor(*[kernel(x) for kernel, x in zip(kernels, xlist)])

kplt.root_decomposition(method = "symeig")
```