### PR TITLE
VariationalStrategy objects take **kwargs

### DIFF
--- a/gpytorch/models/approximate_gp.py
+++ b/gpytorch/models/approximate_gp.py
@@ -78,4 +78,4 @@ class ApproximateGP(GP, _PyroMixin):
     def __call__(self, inputs, prior=False, **kwargs):
         if inputs.dim() == 1:
             inputs = inputs.unsqueeze(-1)
-        return self.variational_strategy(inputs, prior=prior)
+        return self.variational_strategy(inputs, prior=prior, **kwargs)

--- a/gpytorch/variational/_variational_strategy.py
+++ b/gpytorch/variational/_variational_strategy.py
@@ -65,7 +65,7 @@ class _VariationalStrategy(Module, ABC):
     def variational_distribution(self):
         return self._variational_distribution()
 
-    def forward(self, x, inducing_points, inducing_values, variational_inducing_covar=None):
+    def forward(self, x, inducing_points, inducing_values, variational_inducing_covar=None, **kwargs):
         r"""
         The :func:`~gpytorch.variational.VariationalStrategy.forward` method determines how to marginalize out the
         inducing point function values. Specifically, forward defines how to transform a variational distribution
@@ -97,10 +97,10 @@ class _VariationalStrategy(Module, ABC):
             kl_divergence = torch.distributions.kl.kl_divergence(self.variational_distribution, self.prior_distribution)
         return kl_divergence
 
-    def __call__(self, x, prior=False):
+    def __call__(self, x, prior=False, **kwargs):
         # If we're in prior mode, then we're done!
         if prior:
-            return self.model.forward(x)
+            return self.model.forward(x, **kwargs)
 
         # Delete previously cached items from the training distribution
         if self.training:
@@ -126,10 +126,11 @@ class _VariationalStrategy(Module, ABC):
                 inducing_points,
                 inducing_values=variational_dist_u.mean,
                 variational_inducing_covar=variational_dist_u.lazy_covariance_matrix,
+                **kwargs,
             )
         elif isinstance(variational_dist_u, Delta):
             return super().__call__(
-                x, inducing_points, inducing_values=variational_dist_u.mean, variational_inducing_covar=None
+                x, inducing_points, inducing_values=variational_dist_u.mean, variational_inducing_covar=None, **kwargs
             )
         else:
             raise RuntimeError(

--- a/gpytorch/variational/batch_decoupled_variational_strategy.py
+++ b/gpytorch/variational/batch_decoupled_variational_strategy.py
@@ -162,7 +162,7 @@ class BatchDecoupledVariationalStrategy(VariationalStrategy):
             x = x.unsqueeze(self.mean_var_batch_dim - 2)
         return super()._expand_inputs(x, inducing_points)
 
-    def forward(self, x, inducing_points, inducing_values, variational_inducing_covar=None):
+    def forward(self, x, inducing_points, inducing_values, variational_inducing_covar=None, **kwargs):
         # We'll compute the covariance, and cross-covariance terms for both the
         # pred-mean and pred-covar, using their different inducing points (and maybe kernel hypers)
 
@@ -170,7 +170,7 @@ class BatchDecoupledVariationalStrategy(VariationalStrategy):
 
         # Compute full prior distribution
         full_inputs = torch.cat([inducing_points, x], dim=-2)
-        full_output = self.model.forward(full_inputs)
+        full_output = self.model.forward(full_inputs, **kwargs)
         full_covar = full_output.lazy_covariance_matrix
 
         # Covariance terms

--- a/gpytorch/variational/independent_multitask_variational_strategy.py
+++ b/gpytorch/variational/independent_multitask_variational_strategy.py
@@ -43,8 +43,8 @@ class IndependentMultitaskVariationalStrategy(_VariationalStrategy):
     def kl_divergence(self):
         return super().kl_divergence().sum(dim=-1)
 
-    def __call__(self, x, prior=False):
-        function_dist = self.base_variational_strategy(x, prior=prior)
+    def __call__(self, x, prior=False, **kwargs):
+        function_dist = self.base_variational_strategy(x, prior=prior, **kwargs)
         if (
             self.task_dim > 0
             and self.task_dim > len(function_dist.batch_shape)

--- a/gpytorch/variational/lmc_variational_strategy.py
+++ b/gpytorch/variational/lmc_variational_strategy.py
@@ -120,8 +120,8 @@ class LMCVariationalStrategy(_VariationalStrategy):
     def kl_divergence(self):
         return super().kl_divergence().sum(dim=self.latent_dim)
 
-    def __call__(self, x, prior=False):
-        function_dist = self.base_variational_strategy(x, prior=prior)
+    def __call__(self, x, prior=False, **kwargs):
+        function_dist = self.base_variational_strategy(x, prior=prior, **kwargs)
         lmc_coefficients = self.lmc_coefficients.expand(*function_dist.batch_shape, self.lmc_coefficients.size(-1))
         num_batch = len(function_dist.batch_shape)
         num_dim = num_batch + len(function_dist.event_shape)

--- a/gpytorch/variational/orthogonally_decoupled_variational_strategy.py
+++ b/gpytorch/variational/orthogonally_decoupled_variational_strategy.py
@@ -64,14 +64,14 @@ class OrthogonallyDecoupledVariationalStrategy(_VariationalStrategy):
         res = MultivariateNormal(out.mean, out.lazy_covariance_matrix.add_jitter())
         return res
 
-    def forward(self, x, inducing_points, inducing_values, variational_inducing_covar=None):
+    def forward(self, x, inducing_points, inducing_values, variational_inducing_covar=None, **kwargs):
         if variational_inducing_covar is not None:
             raise NotImplementedError(
                 "OrthogonallyDecoupledVariationalStrategy currently works with DeltaVariationalDistribution"
             )
 
         num_data = x.size(-2)
-        full_output = self.model(torch.cat([x, inducing_points], dim=-2))
+        full_output = self.model(torch.cat([x, inducing_points], dim=-2), **kwargs)
         full_mean = full_output.mean
         full_covar = full_output.lazy_covariance_matrix
 

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -81,10 +81,10 @@ class VariationalStrategy(_VariationalStrategy):
         res = MultivariateNormal(zeros, DiagLazyTensor(ones))
         return res
 
-    def forward(self, x, inducing_points, inducing_values, variational_inducing_covar=None):
+    def forward(self, x, inducing_points, inducing_values, variational_inducing_covar=None, **kwargs):
         # Compute full prior distribution
         full_inputs = torch.cat([inducing_points, x], dim=-2)
-        full_output = self.model.forward(full_inputs)
+        full_output = self.model.forward(full_inputs, **kwargs)
         full_covar = full_output.lazy_covariance_matrix
 
         # Covariance terms
@@ -137,7 +137,7 @@ class VariationalStrategy(_VariationalStrategy):
         # Return the distribution
         return MultivariateNormal(predictive_mean, predictive_covar)
 
-    def __call__(self, x, prior=False):
+    def __call__(self, x, prior=False, **kwargs):
         if not self.updated_strategy.item() and not prior:
             with torch.no_grad():
                 # Get unwhitened p(u)
@@ -167,4 +167,4 @@ class VariationalStrategy(_VariationalStrategy):
                 # Mark that we have updated the variational strategy
                 self.updated_strategy.fill_(True)
 
-        return super().__call__(x, prior=prior)
+        return super().__call__(x, prior=prior, **kwargs)


### PR DESCRIPTION
Right now, approximate GPs don't get extra kwargs to the user defined `forward` method. In most other places in the package, this works.