### PR TITLE
Improve batching/unit testing of SpectralMixtureKernel

### DIFF
--- a/gpytorch/kernels/distributional_input_kernel.py
+++ b/gpytorch/kernels/distributional_input_kernel.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import torch
+
 from .kernel import Kernel
 
 
@@ -34,4 +36,7 @@ class DistributionalInputKernel(Kernel):
         if not diag:
             return res
         else:
-            return res.diag()
+            if torch.is_tensor(res):
+                return res.diagonal(dim1=-1, dim2=-2)
+            else:
+                return res.diag()  # For LazyTensor

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -2,10 +2,12 @@
 
 import logging
 import math
+from typing import Tuple, Union
 
 import torch
 
-from ..constraints import Positive
+from ..constraints import Interval, Positive
+from ..priors import Prior
 from .kernel import Kernel
 
 logger = logging.getLogger()
@@ -14,42 +16,48 @@ logger = logging.getLogger()
 class SpectralMixtureKernel(Kernel):
     r"""
     Computes a covariance matrix based on the Spectral Mixture Kernel
-    between inputs :math:`\mathbf{x_1}` and :math:`\mathbf{x_2}`:
+    between inputs :math:`\mathbf{x_1}` and :math:`\mathbf{x_2}`.
+
     It was proposed in `Gaussian Process Kernels for Pattern Discovery and Extrapolation`_.
 
     .. note::
-
         Unlike other kernels,
-        * :attr:`ard_num_dims` **must equal** the number of dimensions of the data
-        * :attr:`batch_shape` **must equal** the batch size of the data (torch.Size([1]) if the data is not batched)
-        * :attr:`batch_shape` **cannot** contain more than one batch dimension.
-        * This kernel should not be combined with a :class:`gpytorch.kernels.ScaleKernel`.
 
-    Args:
-        :attr:`num_mixtures` (int, optional):
-            The number of components in the mixture.
-        :attr:`ard_num_dims` (int, optional):
-            Set this to match the dimensionality of the input.
-            It should be `d` if :attr:`x1` is a `n x d` matrix. Default: `1`
-        :attr:`batch_shape` (torch.Size, optional):
-            Set this if the data is
-             batch of input data. It should be `b` if :attr:`x1` is a `b x n x d` tensor. Default: `torch.Size([1])`
-        :attr:`active_dims` (tuple of ints, optional):
-            Set this if you want to compute the covariance of only a few input dimensions. The ints
-            corresponds to the indices of the dimensions. Default: `None`.
-        :attr:`eps` (float):
-            The minimum value that the lengthscale can take (prevents divide by zero errors). Default: `1e-6`.
+            * :attr:`ard_num_dims` **must equal** the number of dimensions of the data.
+            * This kernel should not be combined with a :class:`gpytorch.kernels.ScaleKernel`.
 
-    Attributes:
-        :attr:`mixture_lengthscale` (Tensor):
-            The lengthscale parameter. Given `k` mixture components, and `b x n x d` data, this will be of
-            size `b x k x 1 x d`.
-        :attr:`mixture_means` (Tensor):
-            The mixture mean parameters (`b x k x 1 x d`).
-        :attr:`mixture_weights` (Tensor):
-            The mixture weight parameters (`b x k`).
+    :param int num_mixtures: The number of components in the mixture.
+    :param int ard_num_dims: Set this to match the dimensionality of the input.
+        It should be `d` if :attr:`x1` is a `... x n x d` matrix. (Default: `1`.)
+    :param batch_shape: Set this if the data is batch of input data. It should
+        be `b_1 x ... x b_j` if :attr:`x1` is a `b_1 x ... x b_j x n x d` tensor. (Default: `torch.Size([])`.)
+    :type batch_shape: torch.Size, optional
+    :param active_dims: Set this if you want to compute the covariance of only
+        a few input dimensions. The ints corresponds to the indices of the dimensions. (Default: `None`.)
+    :type active_dims: float, optional
+    :param eps: The minimum value that the lengthscale can take (prevents divide by zero errors). (Default: `1e-6`.)
+    :type eps: float, optional
+
+    :param mixture_scales_prior: A prior to set on the :attr:`mixture_scales` parameter
+    :type mixture_scales_prior: ~gpytorch.priors.Prior, optional
+    :param mixture_scales_constraint: A constraint to set on the :attr:`mixture_scales` parameter
+    :type mixture_scales_constraint: ~gpytorch.constraints.Interval, optional
+    :param mixture_means_prior: A prior to set on the :attr:`mixture_means` parameter
+    :type mixture_means_prior: ~gpytorch.priors.Prior, optional
+    :param mixture_means_constraint: A constraint to set on the :attr:`mixture_means` parameter
+    :type mixture_means_constraint: ~gpytorch.constraints.Interval, optional
+    :param mixture_weights_prior: A prior to set on the :attr:`mixture_weights` parameter
+    :type mixture_weights_prior: ~gpytorch.priors.Prior, optional
+    :param mixture_weights_constraint: A constraint to set on the :attr:`mixture_weights` parameter
+    :type mixture_weights_constraint: ~gpytorch.constraints.Interval, optional
+
+    :ivar torch.Tensor mixture_scales: The lengthscale parameter. Given
+        `k` mixture components, and `... x n x d` data, this will be of size `... x k x 1 x d`.
+    :ivar torch.Tensor mixture_means: The mixture mean parameters (`... x k x 1 x d`).
+    :ivar torch.Tensor mixture_weights: The mixture weight parameters (`... x k`).
 
     Example:
+
         >>> # Non-batch
         >>> x = torch.randn(10, 5)
         >>> covar_module = gpytorch.kernels.SpectralMixtureKernel(num_mixtures=4, ard_num_dims=5)
@@ -60,7 +68,6 @@ class SpectralMixtureKernel(Kernel):
         >>> covar_module = gpytorch.kernels.SpectralMixtureKernel(num_mixtures=4, batch_size=2, ard_num_dims=5)
         >>> covar = covar_module(x)  # Output: LazyVariable of size (10 x 10)
 
-
     .. _Gaussian Process Kernels for Pattern Discovery and Extrapolation:
         https://arxiv.org/pdf/1302.4245.pdf
     """
@@ -69,15 +76,15 @@ class SpectralMixtureKernel(Kernel):
 
     def __init__(
         self,
-        num_mixtures=None,
-        ard_num_dims=1,
-        batch_shape=torch.Size([]),
-        mixture_scales_prior=None,
-        mixture_scales_constraint=None,
-        mixture_means_prior=None,
-        mixture_means_constraint=None,
-        mixture_weights_prior=None,
-        mixture_weights_constraint=None,
+        num_mixtures: int = None,
+        ard_num_dims: int = 1,
+        batch_shape: torch.Size = torch.Size([]),
+        mixture_scales_prior: Prior = None,
+        mixture_scales_constraint: Interval = None,
+        mixture_means_prior: Prior = None,
+        mixture_means_constraint: Interval = None,
+        mixture_weights_prior: Prior = None,
+        mixture_weights_constraint: Interval = None,
         **kwargs,
     ):
         if num_mixtures is None:
@@ -114,10 +121,10 @@ class SpectralMixtureKernel(Kernel):
         return self.raw_mixture_scales_constraint.transform(self.raw_mixture_scales)
 
     @mixture_scales.setter
-    def mixture_scales(self, value):
+    def mixture_scales(self, value: Union[torch.Tensor, float]):
         self._set_mixture_scales(value)
 
-    def _set_mixture_scales(self, value):
+    def _set_mixture_scales(self, value: Union[torch.Tensor, float]):
         if not torch.is_tensor(value):
             value = torch.as_tensor(value).to(self.raw_mixture_scales)
         self.initialize(raw_mixture_scales=self.raw_mixture_scales_constraint.inverse_transform(value))
@@ -127,10 +134,10 @@ class SpectralMixtureKernel(Kernel):
         return self.raw_mixture_means_constraint.transform(self.raw_mixture_means)
 
     @mixture_means.setter
-    def mixture_means(self, value):
+    def mixture_means(self, value: Union[torch.Tensor, float]):
         self._set_mixture_means(value)
 
-    def _set_mixture_means(self, value):
+    def _set_mixture_means(self, value: Union[torch.Tensor, float]):
         if not torch.is_tensor(value):
             value = torch.as_tensor(value).to(self.raw_mixture_means)
         self.initialize(raw_mixture_means=self.raw_mixture_means_constraint.inverse_transform(value))
@@ -140,109 +147,148 @@ class SpectralMixtureKernel(Kernel):
         return self.raw_mixture_weights_constraint.transform(self.raw_mixture_weights)
 
     @mixture_weights.setter
-    def mixture_weights(self, value):
+    def mixture_weights(self, value: Union[torch.Tensor, float]):
         self._set_mixture_weights(value)
 
-    def _set_mixture_weights(self, value):
+    def _set_mixture_weights(self, value: Union[torch.Tensor, float]):
         if not torch.is_tensor(value):
             value = torch.as_tensor(value).to(self.raw_mixture_weights)
         self.initialize(raw_mixture_weights=self.raw_mixture_weights_constraint.inverse_transform(value))
 
-    def initialize_from_data_empspect(self, train_x, train_y):
+    def initialize_from_data_empspect(self, train_x: torch.Tensor, train_y: torch.Tensor):
         """
         Initialize mixture components based on the empirical spectrum of the data.
-
         This will often be better than the standard initialize_from_data method.
+
+        :param torch.Tensor train_x: Training inputs
+        :param torch.Tensor train_y: Training outputs
         """
+
         import numpy as np
         from scipy.fftpack import fft
         from scipy.integrate import cumtrapz
 
-        if not torch.is_tensor(train_x) or not torch.is_tensor(train_y):
-            raise RuntimeError("train_x and train_y should be tensors")
-        if train_x.ndimension() == 1:
-            train_x = train_x.unsqueeze(-1)
+        with torch.no_grad():
+            if not torch.is_tensor(train_x) or not torch.is_tensor(train_y):
+                raise RuntimeError("train_x and train_y should be tensors")
+            if train_x.ndimension() == 1:
+                train_x = train_x.unsqueeze(-1)
+            if self.active_dims is not None:
+                train_x = train_x[..., self.active_dims]
 
-        N = train_x.size(-2)
-        emp_spect = np.abs(fft(train_y.cpu().detach().numpy())) ** 2 / N
-        M = math.floor(N / 2)
+            # Flatten batch dimensions
+            train_x = train_x.view(-1, train_x.size(-1))
+            train_y = train_y.view(-1)
 
-        freq1 = np.arange(M + 1)
-        freq2 = np.arange(-M + 1, 0)
-        freq = np.hstack((freq1, freq2)) / N
-        freq = freq[: M + 1]
-        emp_spect = emp_spect[: M + 1]
+            N = train_x.size(-2)
+            emp_spect = np.abs(fft(train_y.cpu().detach().numpy())) ** 2 / N
+            M = math.floor(N / 2)
 
-        total_area = np.trapz(emp_spect, freq)
-        spec_cdf = np.hstack((np.zeros(1), cumtrapz(emp_spect, freq)))
-        spec_cdf = spec_cdf / total_area
+            freq1 = np.arange(M + 1)
+            freq2 = np.arange(-M + 1, 0)
+            freq = np.hstack((freq1, freq2)) / N
+            freq = freq[: M + 1]
+            emp_spect = emp_spect[: M + 1]
 
-        a = np.random.rand(1000, self.ard_num_dims)
-        p, q = np.histogram(a, spec_cdf)
-        bins = np.digitize(a, q)
-        slopes = (spec_cdf[bins] - spec_cdf[bins - 1]) / (freq[bins] - freq[bins - 1])
-        intercepts = spec_cdf[bins - 1] - slopes * freq[bins - 1]
-        inv_spec = (a - intercepts) / slopes
+            total_area = np.trapz(emp_spect, freq)
+            spec_cdf = np.hstack((np.zeros(1), cumtrapz(emp_spect, freq)))
+            spec_cdf = spec_cdf / total_area
 
-        from sklearn.mixture import GaussianMixture
+            a = np.random.rand(1000, self.ard_num_dims)
+            p, q = np.histogram(a, spec_cdf)
+            bins = np.digitize(a, q)
+            slopes = (spec_cdf[bins] - spec_cdf[bins - 1]) / (freq[bins] - freq[bins - 1])
+            intercepts = spec_cdf[bins - 1] - slopes * freq[bins - 1]
+            inv_spec = (a - intercepts) / slopes
 
-        GMM = GaussianMixture(n_components=self.num_mixtures, covariance_type="diag").fit(inv_spec)
-        means = GMM.means_
-        varz = GMM.covariances_
-        weights = GMM.weights_
+            from sklearn.mixture import GaussianMixture
 
-        self.mixture_means = means
-        self.mixture_scales = varz
-        self.mixture_weights = weights
+            GMM = GaussianMixture(n_components=self.num_mixtures, covariance_type="diag").fit(inv_spec)
+            means = GMM.means_
+            varz = GMM.covariances_
+            weights = GMM.weights_
 
-    def initialize_from_data(self, train_x, train_y, **kwargs):
-        if not torch.is_tensor(train_x) or not torch.is_tensor(train_y):
-            raise RuntimeError("train_x and train_y should be tensors")
-        if train_x.ndimension() == 1:
-            train_x = train_x.unsqueeze(-1)
-        if train_x.ndimension() == 2:
-            train_x = train_x.unsqueeze(0)
+            dtype = self.raw_mixture_means.dtype
+            device = self.raw_mixture_means.device
+            self.mixture_means = torch.tensor(means, dtype=dtype, device=device).unsqueeze(-2)
+            self.mixture_scales = torch.tensor(varz, dtype=dtype, device=device).unsqueeze(-2)
+            self.mixture_weights = torch.tensor(weights, dtype=dtype, device=device)
 
-        train_x_sort = train_x.sort(1)[0]
-        max_dist = train_x_sort[:, -1, :] - train_x_sort[:, 0, :]
-        min_dist_sort = (train_x_sort[:, 1:, :] - train_x_sort[:, :-1, :]).squeeze(0)
-        min_dist = torch.zeros(1, self.ard_num_dims, dtype=train_x.dtype, device=train_x.device)
-        for ind in range(self.ard_num_dims):
-            min_dist[:, ind] = min_dist_sort[((min_dist_sort[:, ind]).nonzero(as_tuple=False))[0], ind]
+    def initialize_from_data(self, train_x: torch.Tensor, train_y: torch.Tensor, **kwargs):
+        """
+        Initialize mixture components based on batch statistics of the data.
 
-        # Inverse of lengthscales should be drawn from truncated Gaussian | N(0, max_dist^2) |
-        self.raw_mixture_scales.data.normal_().mul_(max_dist).abs_().pow_(-1)
-        self.raw_mixture_scales.data = self.raw_mixture_scales_constraint.inverse_transform(
-            self.raw_mixture_scales.data
-        )
-        # Draw means from Unif(0, 0.5 / minimum distance between two points)
-        self.raw_mixture_means.data.uniform_().mul_(0.5).div_(min_dist)
-        self.raw_mixture_means.data = self.raw_mixture_means_constraint.inverse_transform(self.raw_mixture_means.data)
-        # Mixture weights should be roughly the stdv of the y values divided by the number of mixtures
-        self.raw_mixture_weights.data.fill_(train_y.std() / self.num_mixtures)
-        self.raw_mixture_weights.data = self.raw_mixture_weights_constraint.inverse_transform(
-            self.raw_mixture_weights.data
-        )
+        :param torch.Tensor train_x: Training inputs
+        :param torch.Tensor train_y: Training outputs
+        """
 
-    def _create_input_grid(self, x1, x2, diag=False, last_dim_is_batch=False, **params):
+        with torch.no_grad():
+            if not torch.is_tensor(train_x) or not torch.is_tensor(train_y):
+                raise RuntimeError("train_x and train_y should be tensors")
+            if train_x.ndimension() == 1:
+                train_x = train_x.unsqueeze(-1)
+            if self.active_dims is not None:
+                train_x = train_x[..., self.active_dims]
+
+            # Compute maximum distance between points in each dimension
+            train_x_sort = train_x.sort(dim=-2)[0]
+            max_dist = train_x_sort[..., -1, :] - train_x_sort[..., 0, :]
+
+            # Compute the minimum distance between points in each dimension
+            dists = train_x_sort[..., 1:, :] - train_x_sort[..., :-1, :]
+            # We don't want the minimum distance to be zero, so fill zero values with some large number
+            dists = torch.where(dists.eq(0.0), torch.tensor(1.0e10, dtype=train_x.dtype, device=train_x.device), dists)
+            sorted_dists = dists.sort(dim=-2)[0]
+            min_dist = sorted_dists[..., 0, :]
+
+            # Reshape min_dist and max_dist to match the shape of parameters
+            # First add a singleton data dimension (-2) and a dimension for the mixture components (-3)
+            min_dist = min_dist.unsqueeze_(-2).unsqueeze_(-3)
+            max_dist = max_dist.unsqueeze_(-2).unsqueeze_(-3)
+            # Compress any dimensions in min_dist/max_dist that correspond to singletons in the SM parameters
+            dim = -3
+            while -dim <= min_dist.dim():
+                if -dim > self.raw_mixture_scales.dim():
+                    min_dist = min_dist.min(dim=dim)[0]
+                    max_dist = max_dist.max(dim=dim)[0]
+                elif self.raw_mixture_scales.size(dim) == 1:
+                    min_dist = min_dist.min(dim=dim, keepdim=True)[0]
+                    max_dist = max_dist.max(dim=dim, keepdim=True)[0]
+                    dim -= 1
+                else:
+                    dim -= 1
+
+            # Inverse of lengthscales should be drawn from truncated Gaussian | N(0, max_dist^2) |
+            self.mixture_scales = torch.randn_like(self.raw_mixture_scales).mul_(max_dist).abs_().reciprocal_()
+            # Draw means from Unif(0, 0.5 / minimum distance between two points)
+            self.mixture_means = torch.rand_like(self.raw_mixture_means).mul_(0.5).div(min_dist)
+            # Mixture weights should be roughly the stdv of the y values divided by the number of mixtures
+            self.mixture_weights = train_y.std().div(self.num_mixtures)
+
+    def _create_input_grid(
+        self, x1: torch.Tensor, x2: torch.Tensor, diag: bool = False, last_dim_is_batch: bool = False, **params
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         This is a helper method for creating a grid of the kernel's inputs.
         Use this helper rather than maually creating a meshgrid.
 
         The grid dimensions depend on the kernel's evaluation mode.
 
-        Args:
-            :attr:`x1` (Tensor `n x d` or `b x n x d`)
-            :attr:`x2` (Tensor `m x d` or `b x m x d`) - for diag mode, these must be the same inputs
+        :param torch.Tensor x1: ... x n x d
+        :param torch.Tensor x2: ... x m x d (for diag mode, these must be the same inputs)
+        :param diag: Should the Kernel compute the whole kernel, or just the diag? (Default: True.)
+        :type diag: bool, optional
+        :param last_dim_is_batch: If this is true, it treats the last dimension
+            of the data as another batch dimension.  (Useful for additive
+            structure over the dimensions). (Default: False.)
+        :type last_dim_is_batch: bool, optional
 
-        Returns:
-            (:class:`Tensor`, :class:`Tensor) corresponding to the gridded `x1` and `x2`.
-            The shape depends on the kernel's mode
-
-            * `full_covar`: (`b x n x 1 x d` and `b x 1 x m x d`)
-            * `full_covar` with `last_dim_is_batch=True`: (`b x k x n x 1 x 1` and `b x k x 1 x m x 1`)
-            * `diag`: (`b x n x d` and `b x n x d`)
-            * `diag` with `last_dim_is_batch=True`: (`b x k x n x 1` and `b x k x n x 1`)
+        :rtype: torch.Tensor, torch.Tensor
+        :return: Grid corresponding to x1 and x2. The shape depends on the kernel's mode:
+            * `full_covar`: (`... x n x 1 x d` and `... x 1 x m x d`)
+            * `full_covar` with `last_dim_is_batch=True`: (`... x k x n x 1 x 1` and `... x k x 1 x m x 1`)
+            * `diag`: (`... x n x d` and `... x n x d`)
+            * `diag` with `last_dim_is_batch=True`: (`... x k x n x 1` and `... x k x n x 1`)
         """
         x1_, x2_ = x1, x2
         if last_dim_is_batch:
@@ -257,7 +303,9 @@ class SpectralMixtureKernel(Kernel):
         else:
             return x1_.unsqueeze(-2), x2_.unsqueeze(-3)
 
-    def forward(self, x1, x2, diag=False, last_dim_is_batch=False, **params):
+    def forward(
+        self, x1: torch.Tensor, x2: torch.Tensor, diag: bool = False, last_dim_is_batch: bool = False, **params
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         n, num_dims = x1.shape[-2:]
 
         if not num_dims == self.ard_num_dims:

--- a/test/examples/test_spectral_mixture_gp_regression.py
+++ b/test/examples/test_spectral_mixture_gp_regression.py
@@ -72,7 +72,7 @@ class TestSpectralMixtureGPRegression(BaseTestCase, unittest.TestCase):
         # Optimize the model
         gp_model.train()
         likelihood.train()
-        optimizer = optim.SGD(list(gp_model.parameters()), lr=0.1)
+        optimizer = optim.Adam(list(gp_model.parameters()), lr=0.01)
         optimizer.n_iter = 0
 
         if not empspect:

--- a/test/kernels/test_matern_kernel.py
+++ b/test/kernels/test_matern_kernel.py
@@ -19,10 +19,14 @@ class TestMatern25BaseKernel(unittest.TestCase, BaseKernelTestCase):
 
 class TestMatern05BaseKernel(unittest.TestCase, BaseKernelTestCase):
     def create_kernel_no_ard(self, **kwargs):
-        return MaternKernel(nu=0.5, **kwargs)
+        kernel = MaternKernel(nu=0.5, **kwargs)
+        kernel.initialize(lengthscale=5.0)
+        return kernel
 
     def create_kernel_ard(self, num_dims, **kwargs):
-        return MaternKernel(nu=0.5, ard_num_dims=num_dims, **kwargs)
+        kernel = MaternKernel(nu=0.5, ard_num_dims=num_dims, **kwargs)
+        kernel.initialize(lengthscale=5.0)
+        return kernel
 
 
 class TestMaternKernel(unittest.TestCase, BaseKernelTestCase):

--- a/test/kernels/test_spectral_mixture_kernel.py
+++ b/test/kernels/test_spectral_mixture_kernel.py
@@ -23,8 +23,15 @@ class TestSpectralMixtureKernel(unittest.TestCase):
     def test_active_dims_list(self):
         x = self.create_data_no_batch()
         kernel = self.create_kernel(num_dims=4, active_dims=[0, 2, 4, 6])
+        y = torch.randn_like(x[..., 0])
+        kernel.initialize_from_data(x, y)
+        kernel.initialize_from_data_empspect(x, y)
+
         covar_mat = kernel(x).evaluate_kernel().evaluate()
         kernel_basic = self.create_kernel(num_dims=4)
+        kernel_basic.raw_mixture_weights.data = kernel.raw_mixture_weights
+        kernel_basic.raw_mixture_means.data = kernel.raw_mixture_means
+        kernel_basic.raw_mixture_scales.data = kernel.raw_mixture_scales
         covar_mat_actual = kernel_basic(x[:, [0, 2, 4, 6]]).evaluate_kernel().evaluate()
 
         self.assertLess(torch.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(), 1e-4)
@@ -33,8 +40,15 @@ class TestSpectralMixtureKernel(unittest.TestCase):
         active_dims = list(range(3, 9))
         x = self.create_data_no_batch()
         kernel = self.create_kernel(num_dims=6, active_dims=active_dims)
+        y = torch.randn_like(x[..., 0])
+        kernel.initialize_from_data(x, y)
+        kernel.initialize_from_data_empspect(x, y)
+
         covar_mat = kernel(x).evaluate_kernel().evaluate()
         kernel_basic = self.create_kernel(num_dims=6)
+        kernel_basic.raw_mixture_weights.data = kernel.raw_mixture_weights
+        kernel_basic.raw_mixture_means.data = kernel.raw_mixture_means
+        kernel_basic.raw_mixture_scales.data = kernel.raw_mixture_scales
         covar_mat_actual = kernel_basic(x[:, active_dims]).evaluate_kernel().evaluate()
 
         self.assertLess(torch.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(), 1e-4)
@@ -42,6 +56,9 @@ class TestSpectralMixtureKernel(unittest.TestCase):
     def test_no_batch_kernel_single_batch_x(self):
         x = self.create_data_single_batch()
         kernel = self.create_kernel(num_dims=x.size(-1))
+        y = torch.randn_like(x[..., 0])
+        kernel.initialize_from_data(x, y)
+        kernel.initialize_from_data_empspect(x, y)
         batch_covar_mat = kernel(x).evaluate_kernel().evaluate()
 
         actual_mat_1 = kernel(x[0]).evaluate_kernel().evaluate()
@@ -58,6 +75,9 @@ class TestSpectralMixtureKernel(unittest.TestCase):
     def test_single_batch_kernel_single_batch_x(self):
         x = self.create_data_single_batch()
         kernel = self.create_kernel(num_dims=x.size(-1), batch_shape=torch.Size([]))
+        y = torch.randn_like(x[..., 0])
+        kernel.initialize_from_data(x, y)
+        kernel.initialize_from_data_empspect(x, y)
         batch_covar_mat = kernel(x).evaluate_kernel().evaluate()
 
         actual_mat_1 = kernel(x[0]).evaluate_kernel().evaluate()
@@ -74,6 +94,10 @@ class TestSpectralMixtureKernel(unittest.TestCase):
     def test_smoke_double_batch_kernel_double_batch_x(self):
         x = self.create_data_double_batch()
         kernel = self.create_kernel(num_dims=x.size(-1), batch_shape=torch.Size([3, 2]))
+        y = torch.randn_like(x[..., 0])
+        kernel.initialize_from_data(x, y)
+        kernel.initialize_from_data_empspect(x, y)
+
         batch_covar_mat = kernel(x).evaluate_kernel().evaluate()
         kernel_diag = kernel(x, diag=True)
         return batch_covar_mat, kernel_diag


### PR DESCRIPTION
[Fixes #1329]

The SpectralMixtureKernel was woefully incompatible with multi batch / broadcasted operations. This PR fixes that.
It also adds missing unit tests for kernel diagonals.

- [x] Add more SM unit tests
- [x] Make SM kernel multi-batch/broadcasting compatible
- [x] Fix initialization code
- [x] Add unit tests for kernel diagonals