### PR TITLE
Add LowRankRootLazyTensor / LowRankRootAddedDiagLazyTensor, refactor SGPR

### DIFF
--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -137,6 +137,7 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
                 )
 
         # Get log determininat and first part of quadratic form
+        covar = covar.evaluate_kernel()
         inv_quad, logdet = covar.inv_quad_logdet(inv_quad_rhs=diff.unsqueeze(-1), logdet=True)
 
         res = -0.5 * sum([inv_quad, logdet, diff.size(-1) * math.log(2 * math.pi)])

--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -16,6 +16,8 @@ from .kronecker_product_added_diag_lazy_tensor import KroneckerProductAddedDiagL
 from .kronecker_product_lazy_tensor import KroneckerProductLazyTensor, KroneckerProductTriangularLazyTensor
 from .lazy_evaluated_kernel_tensor import LazyEvaluatedKernelTensor
 from .lazy_tensor import LazyTensor, delazify
+from .low_rank_root_added_diag_lazy_tensor import LowRankRootAddedDiagLazyTensor
+from .low_rank_root_lazy_tensor import LowRankRootLazyTensor
 from .matmul_lazy_tensor import MatmulLazyTensor
 from .mul_lazy_tensor import MulLazyTensor
 from .non_lazy_tensor import NonLazyTensor, lazify
@@ -49,6 +51,8 @@ __all__ = [
     "KroneckerProductLazyTensor",
     "KroneckerProductAddedDiagLazyTensor",
     "KroneckerProductTriangularLazyTensor",
+    "LowRankRootAddedDiagLazyTensor",
+    "LowRankRootLazyTensor",
     "MatmulLazyTensor",
     "MulLazyTensor",
     "NonLazyTensor",

--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -168,3 +168,17 @@ class AddedDiagLazyTensor(SumLazyTensor):
             evals = evals_ + self._diag_tensor.diag()
             return evals, evecs
         return super()._symeig(eigenvectors=eigenvectors)
+
+    def evaluate_kernel(self):
+        """
+        Overriding this is currently necessary to allow for subclasses of AddedDiagLT to be created. For example,
+        consider the following:
+
+            >>> covar1 = covar_module(x).add_diag(torch.tensor(1.)).evaluate_kernel()
+            >>> covar2 = covar_module(x).evaluate_kernel().add_diag(torch.tensor(1.))
+
+        Unless we override this method (or find a better solution), covar1 and covar2 might not be the same type.
+        In particular, covar1 would *always* be a standard AddedDiagLazyTensor, but covar2 might be a subtype.
+        """
+        added_diag_lazy_tsr = self.representation_tree()(*self.representation())
+        return added_diag_lazy_tsr._lazy_tensor + added_diag_lazy_tsr._diag_tensor

--- a/gpytorch/lazy/added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/added_diag_lazy_tensor.py
@@ -57,15 +57,15 @@ class AddedDiagLazyTensor(SumLazyTensor):
         return torch.addcmul(self._lazy_tensor._matmul(rhs), self._diag_tensor._diag.unsqueeze(-1), rhs)
 
     def add_diag(self, added_diag):
-        return AddedDiagLazyTensor(self._lazy_tensor, self._diag_tensor.add_diag(added_diag))
+        return self.__class__(self._lazy_tensor, self._diag_tensor.add_diag(added_diag))
 
     def __add__(self, other):
         from .diag_lazy_tensor import DiagLazyTensor
 
         if isinstance(other, DiagLazyTensor):
-            return AddedDiagLazyTensor(self._lazy_tensor, self._diag_tensor + other)
+            return self.__class__(self._lazy_tensor, self._diag_tensor + other)
         else:
-            return AddedDiagLazyTensor(self._lazy_tensor + other, self._diag_tensor)
+            return self.__class__(self._lazy_tensor + other, self._diag_tensor)
 
     def _preconditioner(self):
         r"""

--- a/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
@@ -6,7 +6,7 @@ from ..utils.cholesky import psd_safe_cholesky
 from ..utils.memoize import cached
 from . import delazify
 from .added_diag_lazy_tensor import AddedDiagLazyTensor
-from .diag_lazy_tensor import DiagLazyTensor, ConstantDiagLazyTensor
+from .diag_lazy_tensor import ConstantDiagLazyTensor, DiagLazyTensor
 from .low_rank_root_lazy_tensor import LowRankRootLazyTensor
 
 
@@ -28,7 +28,7 @@ class LowRankRootAddedDiagLazyTensor(AddedDiagLazyTensor):
         A_inv = self._diag_tensor.inverse()  # This is fine since it's a DiagLazyTensor
         U = self._lazy_tensor.root
         V = self._lazy_tensor.root.transpose(-2, -1)
-        C = ConstantDiagLazyTensor(torch.ones(*V.batch_shape, device=V.device, dtype=V.dtype), V.shape[-1])
+        C = ConstantDiagLazyTensor(torch.ones(V.batch_shape, device=V.device, dtype=V.dtype), V.shape[-2])
 
         cap_mat = delazify(C + V.matmul(A_inv.matmul(U)))
         chol_cap_mat = psd_safe_cholesky(cap_mat)
@@ -56,7 +56,6 @@ class LowRankRootAddedDiagLazyTensor(AddedDiagLazyTensor):
         logdet_term = logdet_cap_mat + logdet_A
 
         return logdet_term
-
 
     def __add__(self, other):
         from .diag_lazy_tensor import DiagLazyTensor

--- a/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
@@ -2,12 +2,12 @@
 
 import torch
 
+from ..utils.cholesky import psd_safe_cholesky
+from ..utils.memoize import cached
 from . import delazify
 from .added_diag_lazy_tensor import AddedDiagLazyTensor
 from .diag_lazy_tensor import DiagLazyTensor
 from .low_rank_root_lazy_tensor import LowRankRootLazyTensor
-from ..utils.cholesky import psd_safe_cholesky
-from ..utils.memoize import cached
 
 
 class LowRankRootAddedDiagLazyTensor(AddedDiagLazyTensor):

--- a/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import torch
+
+from . import delazify
+from .added_diag_lazy_tensor import AddedDiagLazyTensor
+from .diag_lazy_tensor import DiagLazyTensor
+from .low_rank_root_lazy_tensor import LowRankRootLazyTensor
+from ..utils.cholesky import psd_safe_cholesky
+from ..utils.memoize import cached
+
+
+class LowRankRootAddedDiagLazyTensor(AddedDiagLazyTensor):
+    def __init__(self, *lazy_tensors, preconditioner_override=None):
+        if len(lazy_tensors) > 2:
+            raise RuntimeError("An AddedDiagLazyTensor can only have two components")
+
+        if isinstance(lazy_tensors[0], DiagLazyTensor) and not isinstance(lazy_tensors[1], LowRankRootLazyTensor):
+            raise RuntimeError("A LowRankRootAddedDiagLazyTensor can only be created with a LowRankLazyTensor base!")
+        elif isinstance(lazy_tensors[1], DiagLazyTensor) and not isinstance(lazy_tensors[0], LowRankRootLazyTensor):
+            raise RuntimeError("A LowRankRootAddedDiagLazyTensor can only be created with a LowRankLazyTensor base!")
+
+        super().__init__(*lazy_tensors, preconditioner_override=preconditioner_override)
+
+    @cached(name="chol_cap_mat")
+    def chol_cap_mat(self):
+        A_inv = self._diag_tensor.inverse()  # This is fine since it's a DiagLazyTensor
+        U = self._lazy_tensor.root
+        V = self._lazy_tensor.root.transpose(-2, -1)
+        C = DiagLazyTensor(torch.ones(*V.batch_shape, V.shape[-2], V.shape[-2], device=V.device, dtype=V.dtype))
+
+        cap_mat = delazify(C + V.matmul(A_inv.matmul(U)))
+        chol_cap_mat = psd_safe_cholesky(cap_mat)
+
+        return chol_cap_mat
+
+    def _solve(self, rhs, preconditioner=None, num_tridiag=0):
+        A_inv = self._diag_tensor.inverse()  # This is fine since it's a DiagLazyTensor
+        U = self._lazy_tensor.root
+        V = self._lazy_tensor.root.transpose(-2, -1)
+        chol_cap_mat = self.chol_cap_mat
+
+        res = V.matmul(A_inv.matmul(rhs))
+        res = torch.cholesky_solve(res, chol_cap_mat)
+        res = A_inv.matmul(U.matmul(res))
+
+        solve = A_inv.matmul(rhs) - res
+
+        return solve
+
+    def _logdet(self):
+        chol_cap_mat = self.chol_cap_mat
+        logdet_cap_mat = 2 * chol_cap_mat.diag().log().sum(-1)
+        logdet_A = self._diag_tensor.logdet()
+        logdet_term = logdet_cap_mat + logdet_A
+
+        return logdet_term
+
+    def inv_quad_logdet(self, inv_quad_rhs=None, logdet=False, reduce_inv_quad=True):
+        if not self.is_square:
+            raise RuntimeError(
+                "inv_quad_logdet only operates on (batches of) square (positive semi-definite) LazyTensors. "
+                "Got a {} of size {}.".format(self.__class__.__name__, self.size())
+            )
+
+        if inv_quad_rhs is not None:
+            if self.dim() == 2 and inv_quad_rhs.dim() == 1:
+                if self.shape[-1] != inv_quad_rhs.numel():
+                    raise RuntimeError(
+                        "LazyTensor (size={}) cannot be multiplied with right-hand-side Tensor (size={}).".format(
+                            self.shape, inv_quad_rhs.shape
+                        )
+                    )
+            elif self.dim() != inv_quad_rhs.dim():
+                raise RuntimeError(
+                    "LazyTensor (size={}) and right-hand-side Tensor (size={}) should have the same number "
+                    "of dimensions.".format(self.shape, inv_quad_rhs.shape)
+                )
+            elif self.batch_shape != inv_quad_rhs.shape[:-2] or self.shape[-1] != inv_quad_rhs.shape[-2]:
+                raise RuntimeError(
+                    "LazyTensor (size={}) cannot be multiplied with right-hand-side Tensor (size={}).".format(
+                        self.shape, inv_quad_rhs.shape
+                    )
+                )
+
+        inv_quad_term, logdet_term = None, None
+
+        if inv_quad_rhs is not None:
+            self_inv_rhs = self._solve(inv_quad_rhs)
+            inv_quad_term = inv_quad_rhs.transpose(-2, -1).matmul(self_inv_rhs)
+
+        if logdet:
+            logdet_term = self._logdet
+
+        return inv_quad_term, logdet_term

--- a/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
@@ -6,7 +6,7 @@ from ..utils.cholesky import psd_safe_cholesky
 from ..utils.memoize import cached
 from . import delazify
 from .added_diag_lazy_tensor import AddedDiagLazyTensor
-from .diag_lazy_tensor import DiagLazyTensor
+from .diag_lazy_tensor import DiagLazyTensor, ConstantDiagLazyTensor
 from .low_rank_root_lazy_tensor import LowRankRootLazyTensor
 
 
@@ -28,7 +28,7 @@ class LowRankRootAddedDiagLazyTensor(AddedDiagLazyTensor):
         A_inv = self._diag_tensor.inverse()  # This is fine since it's a DiagLazyTensor
         U = self._lazy_tensor.root
         V = self._lazy_tensor.root.transpose(-2, -1)
-        C = DiagLazyTensor(torch.ones(*V.batch_shape, V.shape[-2], device=V.device, dtype=V.dtype))
+        C = ConstantDiagLazyTensor(torch.ones(*V.batch_shape, device=V.device, dtype=V.dtype), V.shape[-1])
 
         cap_mat = delazify(C + V.matmul(A_inv.matmul(U)))
         chol_cap_mat = psd_safe_cholesky(cap_mat)
@@ -57,8 +57,6 @@ class LowRankRootAddedDiagLazyTensor(AddedDiagLazyTensor):
 
         return logdet_term
 
-    def add_diag(self, added_diag):
-        return self.__class__(self._lazy_tensor, self._diag_tensor.add_diag(added_diag))
 
     def __add__(self, other):
         from .diag_lazy_tensor import DiagLazyTensor

--- a/gpytorch/lazy/low_rank_root_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_lazy_tensor.py
@@ -5,7 +5,7 @@ from .root_lazy_tensor import RootLazyTensor
 
 class LowRankRootLazyTensor(RootLazyTensor):
     """
-    Very thin wrapper around MatmulLazyTensor that denotes that the matmul specifically represents a low rank
+    Very thin wrapper around RootLazyTensor that denotes that the tensor specifically represents a low rank
     decomposition of a full rank matrix.
 
     The rationale for this class existing is that we can create LowRankAddedDiagLazyTensor without having to

--- a/gpytorch/lazy/low_rank_root_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_lazy_tensor.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+from .root_lazy_tensor import RootLazyTensor
+
+
+class LowRankRootLazyTensor(RootLazyTensor):
+    """
+    Very thin wrapper around MatmulLazyTensor that denotes that the matmul specifically represents a low rank
+    decomposition of a full rank matrix.
+
+    The rationale for this class existing is that we can create LowRankAddedDiagLazyTensor without having to
+    write custom _getitem, _get_indices, etc, leading to much better code reuse.
+    """
+    def add_diag(self, diag):
+        """
+        Adds an element to the diagonal of the matrix.
+
+        Args:
+            - diag (Scalar Tensor)
+        """
+        from .diag_lazy_tensor import ConstantDiagLazyTensor, DiagLazyTensor
+        from .low_rank_root_added_diag_lazy_tensor import LowRankRootAddedDiagLazyTensor
+
+        if not self.is_square:
+            raise RuntimeError("add_diag only defined for square matrices")
+
+        diag_shape = diag.shape
+        if len(diag_shape) == 0 or diag_shape[-1] == 1:
+            # interpret scalar tensor or single-trailing element as constant diag
+            diag_tensor = ConstantDiagLazyTensor(diag, diag_shape=self.shape[-1])
+        else:
+            try:
+                expanded_diag = diag.expand(self.shape[:-1])
+            except RuntimeError:
+                raise RuntimeError(
+                    "add_diag for LazyTensor of size {} received invalid diagonal of size {}.".format(
+                        self.shape, diag_shape
+                    )
+                )
+            diag_tensor = DiagLazyTensor(expanded_diag)
+
+        return LowRankRootAddedDiagLazyTensor(self, diag_tensor)

--- a/gpytorch/lazy/low_rank_root_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_lazy_tensor.py
@@ -11,6 +11,7 @@ class LowRankRootLazyTensor(RootLazyTensor):
     The rationale for this class existing is that we can create LowRankAddedDiagLazyTensor without having to
     write custom _getitem, _get_indices, etc, leading to much better code reuse.
     """
+
     def add_diag(self, diag):
         """
         Adds an element to the diagonal of the matrix.
@@ -44,6 +45,7 @@ class LowRankRootLazyTensor(RootLazyTensor):
     def __add__(self, other):
         from .diag_lazy_tensor import DiagLazyTensor
         from .low_rank_root_added_diag_lazy_tensor import LowRankRootAddedDiagLazyTensor
+
         if isinstance(other, DiagLazyTensor):
             return LowRankRootAddedDiagLazyTensor(self, other)
         else:

--- a/gpytorch/lazy/low_rank_root_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_lazy_tensor.py
@@ -40,3 +40,11 @@ class LowRankRootLazyTensor(RootLazyTensor):
             diag_tensor = DiagLazyTensor(expanded_diag)
 
         return LowRankRootAddedDiagLazyTensor(self, diag_tensor)
+
+    def __add__(self, other):
+        from .diag_lazy_tensor import DiagLazyTensor
+        from .low_rank_root_added_diag_lazy_tensor import LowRankRootAddedDiagLazyTensor
+        if isinstance(other, DiagLazyTensor):
+            return LowRankRootAddedDiagLazyTensor(self, other)
+        else:
+            return super().__add__(self, other)

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -281,7 +281,7 @@ class DefaultPredictionStrategy(object):
         train_mean, train_train_covar = mvn.loc, mvn.lazy_covariance_matrix
 
         train_labels_offset = (self.train_labels - train_mean).unsqueeze(-1)
-        mean_cache = train_train_covar.inv_matmul(train_labels_offset).squeeze(-1)
+        mean_cache = train_train_covar.evaluate_kernel().inv_matmul(train_labels_offset).squeeze(-1)
 
         if settings.detach_test_caches.on():
             mean_cache = mean_cache.detach()


### PR DESCRIPTION
Adds two new LTs that allow for the use of Woodbury on matrices of the form `UV + diag(a)` for which `U` and `V` are low rank enough that we believe this will be faster. 

SGPR is an obvious use case here, where `U = V^{T} = K_{XU}K_{UU}^{-1/2}`.

The motivation for this PR is to solve #1349, and it does so pretty well. The example code that @monabf included in that issue now trains 5 times faster on the GPU and now has prediction times on the CPU that are in line with GPy.

@gpleiss -- this PR also fixes one other GPyTorch bug in a slightly hacky way (see the new `AddedDiagLazyTensor.evaluate_kernel` where I describe the problem), but in a way that will go away when we switch over to linear operators that don't use representation trees. If you're not happy with this fix as a temporary one, we'll need to do some thinking about how to redesign the representation tree. Probably it will like need the option to optionally pass in `_cls` or something to `LazyTensorRepresentationTree`. I'm not 100% sure.