### PR TITLE
ZeroMean can now take batch_shape

### DIFF
--- a/gpytorch/means/zero_mean.py
+++ b/gpytorch/means/zero_mean.py
@@ -2,9 +2,18 @@
 
 import torch
 
+from ..utils.broadcasting import _mul_broadcast_shape
 from .mean import Mean
 
 
 class ZeroMean(Mean):
+    def __init__(self, batch_shape=torch.Size(), **kwargs):
+        super(ZeroMean, self).__init__()
+        self.batch_shape = batch_shape
+
     def forward(self, input):
-        return torch.zeros(input.shape[:-1], dtype=input.dtype, device=input.device)
+        mean = torch.zeros(*self.batch_shape, 1, dtype=input.dtype, device=input.device)
+        if input.shape[:-2] == self.batch_shape:
+            return mean.expand(input.shape[:-1])
+        else:
+            return mean.expand(_mul_broadcast_shape(input.shape[:-1], mean.shape))


### PR DESCRIPTION
Right now, ZeroMean doesn't work at all for batch / multitask GPs if the input data doesn't have the batch dimension (e.g., I have multiple GPs I am evaluating on the same data `x`).

`ZeroMean` now takes a `batch_shape` upon initialization like our other means / kernels to fix this.

Fixes #1364 by allowing one to define `self.mean_module = gpytorch.means.ZeroMean(batch_shape=torch.Size([2]))` in the standard `BatchIndependentMultitaskGPModel` from the example notebook, which is not currently possible.

cc/ @adamhall