### PR TITLE
Add jitter option to psd_safe_cholesky in RFFPredictionStrategy

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -629,7 +629,7 @@ class RFFPredictionStrategy(DefaultPredictionStrategy):
             torch.eye(train_factor.size(-1), dtype=train_factor.dtype, device=train_factor.device)
             - (train_factor.transpose(-1, -2) @ train_train_covar.inv_matmul(train_factor)) * constant
         )
-        return psd_safe_cholesky(inner_term)
+        return psd_safe_cholesky(inner_term, jitter=settings.cholesky_jitter.value())
 
     def exact_prediction(self, joint_mean, joint_covar):
         # Find the components of the distribution that contain test data


### PR DESCRIPTION
The inner term in the RFF Prediction strategy can become singular when `n >> num_features` (https://github.com/cornellius-gp/gpytorch/blob/57fa992e2bb3292b27a08c419ea6af9ad139ff1e/gpytorch/models/exact_prediction_strategies.py#L628).

Enforcing that the `psd_safe_cholesky` can use the gpytorch cholesky_jitter setting makes it more stable.

This example currently fails, but passes in the PR.
```
import torch
import gpytorch

from botorch.optim.fit import fit_gpytorch_torch

# We will use the simplest form of GP model, exact inference
class ExactGPModel(gpytorch.models.ExactGP):
    def __init__(self, train_x, train_y, likelihood):
        super(ExactGPModel, self).__init__(train_x, train_y, likelihood)
        self.mean_module = gpytorch.means.ConstantMean()
        self.covar_module = gpytorch.kernels.RFFKernel(num_samples=100, num_dims=3)
    
    def forward(self, x):
        mean_x = self.mean_module(x)
        covar_x = self.covar_module(x)
        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)

train_x = torch.randn(15000, 3)
train_y = torch.randn(15000)

likelihood = gpytorch.likelihoods.GaussianLikelihood()
model = ExactGPModel(train_x, train_y, likelihood)

mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, model)
fit_gpytorch_torch(mll);

model.eval()
test_x = torch.randn(3000, 3)
with gpytorch.settings.cholesky_jitter(1e-3):
    pred = model(test_x)
```