### PR TITLE
Remove inplace operation on lengthscale from RBFKernelGrad (Fixes #1389)

### DIFF
--- a/gpytorch/kernels/rbf_kernel_grad.py
+++ b/gpytorch/kernels/rbf_kernel_grad.py
@@ -108,7 +108,7 @@ class RBFKernelGrad(RBFKernel):
                 raise RuntimeError("diag=True only works when x1 == x2")
 
             kernel_diag = super(RBFKernelGrad, self).forward(x1, x2, diag=True)
-            grad_diag = torch.ones(*batch_shape, n2, d, device=x1.device, dtype=x1.dtype) / self.lengthscale.pow_(2)
+            grad_diag = torch.ones(*batch_shape, n2, d, device=x1.device, dtype=x1.dtype) / self.lengthscale.pow(2)
             grad_diag = grad_diag.transpose(-1, -2).reshape(*batch_shape, n2 * d)
             k_diag = torch.cat((kernel_diag, grad_diag), dim=-1)
             pi = torch.arange(n2 * (d + 1)).view(d + 1, n2).t().reshape((n2 * (d + 1)))


### PR DESCRIPTION
This fixes the issue in #1389 that breaks backward on the RBFKernelGrad when `diag=True` by replacing the inplace operation with a not-in-place operation. The code snippet in the issue runs without error after this change.