### PR TITLE
Fix whitened SVGP for non-zero prior means.

### DIFF
--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -114,12 +114,7 @@ class VariationalStrategy(_VariationalStrategy):
 
         # Compute the mean of q(f)
         # k_XZ K_ZZ^{-1/2} (m - K_ZZ^{-1/2} \mu_Z) + \mu_X
-        predictive_mean = (
-            torch.matmul(
-                interp_term.transpose(-1, -2), (inducing_values - self.prior_distribution.mean).unsqueeze(-1)
-            ).squeeze(-1)
-            + test_mean
-        )
+        predictive_mean = (interp_term.transpose(-1, -2) @ inducing_values.unsqueeze(-1)).squeeze(-1) + test_mean
 
         # Compute the covariance of q(f)
         # K_XX + k_XZ K_ZZ^{-1/2} (S - I) K_ZZ^{-1/2} k_ZX


### PR DESCRIPTION
The whitened inducing points `\tilde u` are given by the following deterministic transformation of the unwhitened inducing points `u`:

`\tilde u = K^{-1/2} ( u - \mu )`

where `K` and `\mu` are the prior covariance/mean of `u`.

The (predictive) posterior mean of an SVGP model evaluated at `x` is given by:

` k_x^T K^{-1} (m - \mu) + \mean_x `

where `k_x` is the cross-covariance between `x` and the inducing points, `\mean_x` is the GP prior mean evaluated at `x`, and `m` is the *unwhitened* inducing variational mean. By the deterministic transformation above, the whitened variational mean is equal to `\tilde m = K^{-1/2} (m - \mu)`. Therefore, we have that the (predictive) posterior mean is:

` k_x^T K^{-1/2} \tilde m + \mean_x `

In variational_strategy.py, `interp_term` is equal to `K^{-1/2} k_x`, and `inducing_values` is equal to `\tilde m`. Therefore, line 121 should be changed to:

```python
predictive_mean = (interp_term.transpose(-1, -2) @ inducing_values.unsqueeze(-1)).squeeze(-1) + test_mean
```

[Fixes #1402]