### PR TITLE
Add arg_constraints attribute to Delta distribution

### DIFF
--- a/gpytorch/distributions/delta.py
+++ b/gpytorch/distributions/delta.py
@@ -28,7 +28,8 @@ except ImportError:
             under differentiable transformation.
         :param int event_dim: Optional event dimension, defaults to zero.
         """
-        arg_constraints = {'v': constraints.real, 'log_density': constraints.real}
+
+        arg_constraints = {"v": constraints.real, "log_density": constraints.real}
         has_rsample = True
 
         def __init__(self, v, log_density=0.0, event_dim=0, validate_args=None):

--- a/gpytorch/distributions/delta.py
+++ b/gpytorch/distributions/delta.py
@@ -3,6 +3,7 @@
 import numbers
 
 import torch
+from torch.distributions import constraints
 from torch.distributions.kl import register_kl
 
 from .distribution import Distribution
@@ -27,7 +28,7 @@ except ImportError:
             under differentiable transformation.
         :param int event_dim: Optional event dimension, defaults to zero.
         """
-
+        arg_constraints = {'v': constraints.real, 'log_density': constraints.real}
         has_rsample = True
 
         def __init__(self, v, log_density=0.0, event_dim=0, validate_args=None):


### PR DESCRIPTION
Some of the tests in `test/examples` are failing after https://github.com/pytorch/pytorch/pull/48743 was merged turned on distributions validation. This adds the `arg_constraints` attribute that was missing in `distributions.Delta` which is needed for generic parameter support validation. Note that this failure only happens if Pyro isn't installed (since Pyro's implementation has this attribute). 

cc. @Balandat 