### PR TITLE
Fix docstring of NGD

### DIFF
--- a/gpytorch/optim/ngd.py
+++ b/gpytorch/optim/ngd.py
@@ -17,7 +17,7 @@ class NGD(torch.optim.Optimizer):
           for use instructions.
 
     Example:
-        >>> ngd_optimizer = torch.optim.NGD(model.variational_parameters(), lr=0.1, momentum=0.9)
+        >>> ngd_optimizer = torch.optim.NGD(model.variational_parameters(), num_data=train_y.size(0), lr=0.1)
         >>> ngd_optimizer.zero_grad()
         >>> mll(gp_model(input), target).backward()
         >>> ngd_optimizer.step()

--- a/gpytorch/optim/ngd.py
+++ b/gpytorch/optim/ngd.py
@@ -28,7 +28,7 @@ class NGD(torch.optim.Optimizer):
         super().__init__(params, defaults=dict(lr=lr))
 
     @torch.no_grad()
-    def step(self) -> torch.Tensor:
+    def step(self) -> None:
         """Performs a single optimization step.
         """
         for group in self.param_groups:


### PR DESCRIPTION
NGD example has `momentum` argument while this is not supported. It also lacks the required `num_data` argument. This PR fixes both.

Also fix incorrect type hint on the `step()` function.