### PR TITLE
Improvements to Unit Tests for KroneckerProductAddedDiagLazyTensor

### DIFF
--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -13,7 +13,7 @@ from .diag_lazy_tensor import ConstantDiagLazyTensor, DiagLazyTensor
 from .interpolated_lazy_tensor import InterpolatedLazyTensor
 from .keops_lazy_tensor import KeOpsLazyTensor
 from .kronecker_product_added_diag_lazy_tensor import KroneckerProductAddedDiagLazyTensor
-from .kronecker_product_lazy_tensor import KroneckerProductLazyTensor, KroneckerProductTriangularLazyTensor
+from .kronecker_product_lazy_tensor import KroneckerProductLazyTensor, KroneckerProductTriangularLazyTensor, KroneckerProductDiagLazyTensor
 from .lazy_evaluated_kernel_tensor import LazyEvaluatedKernelTensor
 from .lazy_tensor import LazyTensor, delazify
 from .low_rank_root_added_diag_lazy_tensor import LowRankRootAddedDiagLazyTensor

--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -13,6 +13,7 @@ from .diag_lazy_tensor import ConstantDiagLazyTensor, DiagLazyTensor
 from .interpolated_lazy_tensor import InterpolatedLazyTensor
 from .keops_lazy_tensor import KeOpsLazyTensor
 from .kronecker_product_added_diag_lazy_tensor import KroneckerProductAddedDiagLazyTensor
+from .kronecker_sum_lazy_tensor import KroneckerSumLazyTensor
 from .kronecker_product_lazy_tensor import KroneckerProductLazyTensor, KroneckerProductTriangularLazyTensor, KroneckerProductDiagLazyTensor
 from .lazy_evaluated_kernel_tensor import LazyEvaluatedKernelTensor
 from .lazy_tensor import LazyTensor, delazify

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -226,10 +226,14 @@ class ConstantDiagLazyTensor(DiagLazyTensor):
 
     def __add__(self, other):
         if isinstance(other, ConstantDiagLazyTensor):
-            assert other.shape[-1] == self.shape[-1]
-            return ConstantDiagLazyTensor(self.diag_values + other.diag_values, self.diag_shape)
+            if other.shape[-1] == self.shape[-1]:
+                return ConstantDiagLazyTensor(self.diag_values + other.diag_values, self.diag_shape)
+            raise RuntimeError(
+                f"Trailing batch shapes must match for adding two ConstantDiagLazyTensors. "
+                f"Instead, got shapes of {other.shape} and {self.shape}."
+            )
         return super().__add__(other)
-        
+
     @property
     def _diag(self):
         return self.diag_values.expand(*self.diag_values.shape[:-1], self.diag_shape)

--- a/gpytorch/lazy/diag_lazy_tensor.py
+++ b/gpytorch/lazy/diag_lazy_tensor.py
@@ -224,6 +224,12 @@ class ConstantDiagLazyTensor(DiagLazyTensor):
         self.diag_values = diag_values
         self.diag_shape = diag_shape
 
+    def __add__(self, other):
+        if isinstance(other, ConstantDiagLazyTensor):
+            assert other.shape[-1] == self.shape[-1]
+            return ConstantDiagLazyTensor(self.diag_values + other.diag_values, self.diag_shape)
+        return super().__add__(other)
+        
     @property
     def _diag(self):
         return self.diag_values.expand(*self.diag_values.shape[:-1], self.diag_shape)

--- a/gpytorch/lazy/kronecker_product_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_added_diag_lazy_tensor.py
@@ -86,7 +86,7 @@ class KroneckerProductAddedDiagLazyTensor(AddedDiagLazyTensor):
                 diag_term = self.diag_tensor.logdet()
                 return diag_term + evals_plus_i.logdet()
 
-        return super().logdet()
+        return super().inv_quad_logdet(logdet=True)[1]
 
     def _preconditioner(self):
         # solves don't use CG so don't waste time computing it

--- a/gpytorch/lazy/kronecker_product_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_added_diag_lazy_tensor.py
@@ -72,21 +72,6 @@ class KroneckerProductAddedDiagLazyTensor(AddedDiagLazyTensor):
                     raise(
                         NotImplementedError("KPADLT + ConstDiagLT log dets not implemented.")
                     )
-                    # here we need to compute (K+a I)'(K+a I)
-                    # = D^{-1} K^2 D^{-1} + 2 a D^{-1} K D^{-1} + a^2 D^{-2}
-                    # kron_times_diag_list = [
-                    #     tfull.matmul(tdiag.inverse()) for tfull, tdiag in zip(
-                    #         lt.lazy_tensor.lazy_tensors, dlt.lazy_tensors
-                    #     )
-                    # ]
-                    # const = lt.diag_tensor.diag_values
-
-                    # kron_symm = [
-                    #     k.matmul(k.transpose(-1, -2)) + 2. * const * tdiag.inv_matmul(k) + \
-                    #         const**2 * tdiag.inverse() * tdiag.inverse() for k, tdiag in zip(
-                    #             kron_times_diag_list, dlt.lazy_tensors
-                    #         )]
-                    # kron_times_diag_symm = KroneckerProductLazyTensor(*kron_symm)
                 else:
                     dlt_inv_root = dlt.sqrt().inverse()
                     symm_prod = KroneckerProductLazyTensor(

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -336,6 +336,9 @@ class KroneckerProductDiagLazyTensor(DiagLazyTensor, KroneckerProductTriangularL
     def _diag(self):
         return _kron_diag(*self.lazy_tensors)
 
+    def _quad_form_derivative(self, left_vecs, right_vecs):
+        return KroneckerProductTriangularLazyTensor._quad_form_derivative(self, left_vecs, right_vecs)
+        
     def _symeig(
         self, eigenvectors: bool = False, return_evals_as_lazy: bool = False
     ) -> Tuple[Tensor, Optional[LazyTensor]]:

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -82,7 +82,7 @@ class KroneckerProductLazyTensor(LazyTensor):
         self.lazy_tensors = lazy_tensors
 
     def __add__(self, other):
-        if isinstance(other, KroneckerProductDiagLazyTensor):
+        if isinstance(other, (KroneckerProductDiagLazyTensor, ConstantDiagLazyTensor)):
             from .kronecker_product_added_diag_lazy_tensor import KroneckerProductAddedDiagLazyTensor
             return KroneckerProductAddedDiagLazyTensor(self, other)
         if isinstance(other, KroneckerProductLazyTensor):

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -84,13 +84,13 @@ class KroneckerProductLazyTensor(LazyTensor):
     def __add__(self, other):
         if isinstance(other, KroneckerProductDiagLazyTensor):
             from .kronecker_product_added_diag_lazy_tensor import KroneckerProductAddedDiagLazyTensor
-
             return KroneckerProductAddedDiagLazyTensor(self, other)
-
-        elif isinstance(other, DiagLazyTensor):
+        if isinstance(other, KroneckerProductLazyTensor):
+            from .kronecker_sum_lazy_tensor import KroneckerSumLazyTensor
+            return KroneckerSumLazyTensor(self, other)
+        if isinstance(other, DiagLazyTensor):
             return self.add_diag(other.diag())
-        else:
-            return super().__add__(other)
+        return super().__add__(other)
 
     def add_diag(self, diag):
         r"""

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -332,7 +332,6 @@ class KroneckerProductDiagLazyTensor(DiagLazyTensor, KroneckerProductTriangularL
         return KroneckerProductDiagLazyTensor(*chol_factors)
 
     @property
-    @cached
     def _diag(self):
         return _kron_diag(*self.lazy_tensors)
 

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -82,7 +82,12 @@ class KroneckerProductLazyTensor(LazyTensor):
         self.lazy_tensors = lazy_tensors
 
     def __add__(self, other):
-        if isinstance(other, DiagLazyTensor):
+        if isinstance(other, KroneckerProductDiagLazyTensor):
+            from .kronecker_product_added_diag_lazy_tensor import KroneckerProductAddedDiagLazyTensor
+
+            return KroneckerProductAddedDiagLazyTensor(self, other)
+
+        elif isinstance(other, DiagLazyTensor):
             return self.add_diag(other.diag())
         else:
             return super().__add__(other)

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -336,9 +336,18 @@ class KroneckerProductDiagLazyTensor(DiagLazyTensor, KroneckerProductTriangularL
     def _diag(self):
         return _kron_diag(*self.lazy_tensors)
 
+    def _expand_batch(self, batch_shape):
+        return KroneckerProductTriangularLazyTensor._expand_batch(self, batch_shape)
+
+    def _mul_constant(self, constant):
+        return DiagLazyTensor(self._diag * constant.unsqueeze(-1))
+
     def _quad_form_derivative(self, left_vecs, right_vecs):
         return KroneckerProductTriangularLazyTensor._quad_form_derivative(self, left_vecs, right_vecs)
-        
+
+    def sqrt(self):
+        return self.__class__(*[lt.sqrt() for lt in self.lazy_tensors])
+
     def _symeig(
         self, eigenvectors: bool = False, return_evals_as_lazy: bool = False
     ) -> Tuple[Tensor, Optional[LazyTensor]]:

--- a/gpytorch/lazy/kronecker_sum_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_sum_lazy_tensor.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+from typing import Optional
+
+from .sum_lazy_tensor import SumLazyTensor
+from .kronecker_product_lazy_tensor import KroneckerProductLazyTensor
+from .. import settings
+from ..utils.memoize import cached
+
+class KroneckerSumLazyTensor(SumLazyTensor):
+    r"""
+    Returns the sum of two Kronecker product lazy tensors. Solves and log-determinants
+    are computed using the eigen-decomposition of the right lazy tensor; that is,
+    (A \kron B + C \kron D) = (C^{1/2} \kron D^{1/2})
+        (C^{-1/2}AC^{-1/2} \kron D^{-1/2} B D^{-1/2} + I_|C| \kron I_|D|)(C^{1/2} \kron D^{1/2})^{T}
+    where .^{1/2} = Q_.\Lambda_.^{1/2} (e.g. an eigen-decomposition.)
+
+    This formulation emits efficient solves and log determinants.
+
+    The original reference is [https://papers.nips.cc/paper/2013/file/59c33016884a62116be975a9bb8257e3-Paper.pdf].
+
+    Args:
+        :`lazy_tensors`: List of lazy tensors
+    """
+
+    @property
+    def _sum_formulation(self):
+         # where M = (C^{-1/2}AC^{-1/2} \kron D^{-1/2} B D^{-1/2} + I_|C| \kron I_|D|)
+        lt1 = self.lazy_tensors[0]
+        lt2 = self.lazy_tensors[1]
+        
+        lt2_inv_roots = [lt.root_inv_decomposition().root for lt in lt2.lazy_tensors]
+        
+        lt2_inv_root_mm_lt2 = [
+            rm.transpose(-1,-2).matmul(lt).matmul(rm) for rm, lt in zip(lt2_inv_roots, lt1.lazy_tensors)
+        ]
+        inv_root_times_lt1 = KroneckerProductLazyTensor(*lt2_inv_root_mm_lt2).add_jitter(1.)
+        return inv_root_times_lt1
+
+    def _solve(self, rhs, preconditioner=None, num_tridiag=0):
+        if self.shape[-1] <= settings.max_cholesky_size.value():
+            return super()._solve(rhs=rhs, preconditioner=preconditioner, num_tridiag=num_tridiag)
+
+        inner_mat = self._sum_formulation
+        # root decomposition may not be trustworthy if it uses a different method than
+        # root_inv_decomposition. so ensure that we call this locally
+        lt2_inv_roots = [lt.root_inv_decomposition().root for lt in self.lazy_tensors[1].lazy_tensors]
+        lt2_inv_root = KroneckerProductLazyTensor(*lt2_inv_roots)
+
+        # now we compute L^{-1} M L^{-T} z
+        # where M = (C^{-1/2}AC^{-1/2} \kron D^{-1/2} B D^{-1/2} + I_|C| \kron I_|D|)
+        res = lt2_inv_root.transpose(-1, -2).matmul(rhs)
+        res = inner_mat.inv_matmul(res)
+        res = lt2_inv_root.matmul(res)
+
+        return res
+
+    def _logdet(self):
+        inner_mat = self._sum_formulation
+        lt2_logdet = self.lazy_tensors[1].logdet()
+        return inner_mat._logdet() + lt2_logdet
+
+    @cached(name="root_decomposition")
+    def root_decomposition(self, method: Optional[str] = None):
+        from gpytorch.lazy import RootLazyTensor
+
+        # return a dense root decomposition if the matrix is small
+        if self.shape[-1] <= settings.max_cholesky_size.value():
+            return super().root_decomposition(method=method)
+
+        inner_mat = self._sum_formulation
+        lt2_root = self.lazy_tensors[1].root_decomposition(method=method).root
+        inner_mat_root = inner_mat.root_decomposition(method=method).root
+        root = lt2_root.matmul(inner_mat_root)
+        return RootLazyTensor(root)
+
+    @cached(name="root_inv_decomposition")
+    def root_inv_decomposition(self, initial_vectors=None, test_vectors=None):
+        from gpytorch.lazy import RootLazyTensor
+
+        # return a dense root decomposition if the matrix is small
+        if self.shape[-1] <= settings.max_cholesky_size.value():
+            return super().root_inv_decomposition(initial_vectors=initial_vectors, test_vectors=test_vectors)
+
+        inner_mat = self._sum_formulation
+        lt2_root_inv = self.lazy_tensors[1].root_inv_decomposition(
+            initial_vectors=initial_vectors, test_vectors=test_vectors
+        ).root
+        inner_mat_root_inv = inner_mat.root_inv_decomposition(
+            initial_vectors=initial_vectors, test_vectors=test_vectors
+        ).root
+        inv_root = lt2_root_inv.matmul(inner_mat_root_inv)
+        return RootLazyTensor(inv_root)

--- a/gpytorch/lazy/kronecker_sum_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_sum_lazy_tensor.py
@@ -15,7 +15,7 @@ class KroneckerSumLazyTensor(SumLazyTensor):
         (C^{-1/2}AC^{-1/2} \kron D^{-1/2} B D^{-1/2} + I_|C| \kron I_|D|)(C^{1/2} \kron D^{1/2})^{T}
     where .^{1/2} = Q_.\Lambda_.^{1/2} (e.g. an eigen-decomposition.)
 
-    This formulation emits efficient solves and log determinants.
+    This formulation admits efficient solves and log determinants.
 
     The original reference is [https://papers.nips.cc/paper/2013/file/59c33016884a62116be975a9bb8257e3-Paper.pdf].
 

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -251,7 +251,11 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
         if noise_constraint is None:
             noise_constraint = GreaterThan(1e-4)
         
-        assert has_task_noise or has_global_noise
+        if not has_task_noise and not has_global_noise:
+            raise(
+                ValueError("At least one of has_task_noise or has_global_noise must be specified." + \
+                    "Attempting to specify a likelihood that has no noise terms.")
+            )
 
         if has_task_noise:
             if rank == 0:
@@ -352,9 +356,9 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
         )
         task_var_lt = task_var_lt.expand(*shape[:-2], *task_var_lt.matrix_shape)
        
-        # to add the latent noise we exploit the fact that 
+        # to add the latent noise we exploit the fact that
         # I \kron D_T + \sigma^2 I_{NT} = I \kron (D_T + \sigma^2 I)
-        # which allows us to move the latent noise inside the task dependent noise 
+        # which allows us to move the latent noise inside the task dependent noise
         # thereby allowing exploitation of Kronecker structure in this likelihood.
         if add_noise and self.has_global_noise:
             noise = ConstantDiagLazyTensor(self.noise, diag_shape=task_var_lt.shape[-1])

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -329,9 +329,8 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
         """
         mean, covar = function_dist.mean, function_dist.lazy_covariance_matrix
 
-        if self.has_task_noise:
-            covar_kron_lt = self._shaped_noise_covar(mean.shape, add_noise=self.has_global_noise)
-            covar = covar + covar_kron_lt
+        covar_kron_lt = self._shaped_noise_covar(mean.shape, add_noise=self.has_global_noise)
+        covar = covar + covar_kron_lt
 
         return function_dist.__class__(mean, covar)
 

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -274,7 +274,11 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
     @noise.setter
     def noise(self, value):
         self._set_noise(value)
-
+    
+    @property
+    def task_noises(self):
+        return self.raw_task_noises_constraint.transform(self.raw_task_noises)
+    
     def _set_noise(self, value):
         self.initialize(raw_noise=self.raw_noise_constraint.inverse_transform(value))
 
@@ -309,7 +313,7 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
         """
         mean, covar = function_dist.mean, function_dist.lazy_covariance_matrix
 
-        covar_kron_lt = self._shaped_noise_covar(covar.shape, add_noise=False)
+        covar_kron_lt = self._shaped_noise_covar(mean.shape, add_noise=False)
         covar = covar + covar_kron_lt
 
         if self.has_second_noise:

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -252,9 +252,10 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
             noise_constraint = GreaterThan(1e-4)
         
         if not has_task_noise and not has_global_noise:
-            raise(
-                ValueError("At least one of has_task_noise or has_global_noise must be specified." + \
-                    "Attempting to specify a likelihood that has no noise terms.")
+            raise ValueError(
+                "At least one of has_task_noise or has_global_noise must be specified. "
+                "Attempting to specify a likelihood that has no noise terms."
+            )
             )
 
         if has_task_noise:

--- a/gpytorch/likelihoods/noise_models.py
+++ b/gpytorch/likelihoods/noise_models.py
@@ -9,7 +9,7 @@ from torch.nn import Parameter
 from .. import settings
 from ..constraints import GreaterThan
 from ..distributions import MultivariateNormal
-from ..lazy import DiagLazyTensor, ZeroLazyTensor
+from ..lazy import DiagLazyTensor, ZeroLazyTensor, ConstantDiagLazyTensor
 from ..module import Module
 from ..utils.broadcasting import _mul_broadcast_shape
 
@@ -73,10 +73,10 @@ class _HomoskedasticNoiseBase(Noise):
         num_tasks = noise.shape[-1]
         batch_shape = _mul_broadcast_shape(noise_batch_shape, batch_shape)
         noise = noise.unsqueeze(-2)
-        noise_diag = noise.expand(*batch_shape, n, num_tasks).contiguous()
+        noise_diag = noise.expand(*batch_shape, 1, num_tasks).contiguous()
         if num_tasks == 1:
-            noise_diag = noise_diag.view(*batch_shape, n)
-        return DiagLazyTensor(noise_diag)
+            noise_diag = noise_diag.view(*batch_shape, 1)
+        return ConstantDiagLazyTensor(noise_diag, diag_shape=(n * num_tasks))
 
 
 class HomoskedasticNoise(_HomoskedasticNoiseBase):

--- a/gpytorch/likelihoods/noise_models.py
+++ b/gpytorch/likelihoods/noise_models.py
@@ -76,7 +76,7 @@ class _HomoskedasticNoiseBase(Noise):
         noise_diag = noise.expand(*batch_shape, 1, num_tasks).contiguous()
         if num_tasks == 1:
             noise_diag = noise_diag.view(*batch_shape, 1)
-        return ConstantDiagLazyTensor(noise_diag, diag_shape=(n * num_tasks))
+        return ConstantDiagLazyTensor(noise_diag, diag_shape=n * num_tasks)
 
 
 class HomoskedasticNoise(_HomoskedasticNoiseBase):

--- a/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
@@ -19,10 +19,8 @@ from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase
 class TestKroneckerProductAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestCase):
     # this lazy tensor has an explicit inverse so we don't need to run these
     skip_slq_tests = True
-    should_call_lanczos = False
-    should_call_cg = False
 
-    def create_lazy_tensor(self, constant_diag=True):
+    def create_lazy_tensor(self, constant_diag=False):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
         c = torch.tensor([[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float)
@@ -43,6 +41,13 @@ class TestKroneckerProductAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestC
         diag = lazy_tensor._diag_tensor._diag
         return tensor + diag.diag()
 
+class TestKroneckerProductAddedConstDiagLazyTensor(TestKroneckerProductAddedDiagLazyTensor):
+    should_call_lanczos = False
+    should_call_cg = False
+
+    def create_lazy_tensor(self):
+        return super().create_lazy_tensor(constant_diag=True)
+
     def test_if_cholesky_used(self):
         lazy_tensor = self.create_lazy_tensor()
         rhs = torch.randn(lazy_tensor.size(-1))
@@ -62,7 +67,6 @@ class TestKroneckerProductAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestC
                 actual = torch.solve(test_mat, lazy_tensor.evaluate()).solution
                 self.assertAllClose(res, actual, rtol=0.05, atol=0.02)
                 chol_mock.assert_not_called()
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
@@ -42,6 +42,7 @@ class TestKroneckerProductAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestC
 class TestKroneckerProductAddedKroneckerDiagLazyTensor(TestKroneckerProductAddedDiagLazyTensor):
     # this lazy tensor has an explicit inverse so we don't need to run these
     skip_slq_tests = True
+    should_call_cg = False
 
     def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
@@ -100,34 +101,34 @@ class TestKroneckerProductAddedConstDiagLazyTensor(TestKroneckerProductAddedDiag
                 self.assertAllClose(res, actual, rtol=0.05, atol=0.02)
                 chol_mock.assert_not_called()
 
-class TestKroneckerProductAddedDiagAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestCase):
-    # this lazy tensor has an explicit inverse so we don't need to run these
-    skip_slq_tests = True
+# class TestKroneckerProductAddedDiagAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestCase):
+#     # this lazy tensor has an explicit inverse so we don't need to run these
+#     skip_slq_tests = True
 
-    def create_lazy_tensor(self):
-        a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
-        b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
-        d = torch.tensor([2, 1, 3], dtype=torch.float)
-        e = torch.tensor([5], dtype=torch.float)
-        f = torch.tensor([0.25], dtype=torch.float)
-        a.requires_grad_(True)
-        b.requires_grad_(True)
-        d.requires_grad_(True)
-        e.requires_grad_(True)
-        f.requires_grad_(True)
+#     def create_lazy_tensor(self):
+#         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
+#         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
+#         d = torch.tensor([2, 1, 3], dtype=torch.float)
+#         e = torch.tensor([5], dtype=torch.float)
+#         f = torch.tensor([0.25], dtype=torch.float)
+#         a.requires_grad_(True)
+#         b.requires_grad_(True)
+#         d.requires_grad_(True)
+#         e.requires_grad_(True)
+#         f.requires_grad_(True)
 
-        kp_lazy_tensor = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b))
-        diag_lazy_tensor = KroneckerProductDiagLazyTensor(
-            DiagLazyTensor(d), ConstantDiagLazyTensor(e, diag_shape=2)
-        )
-        second_diag_lazy_tensor = ConstantDiagLazyTensor(f, diag_shape=6)
-        kpadlt1 = KroneckerProductAddedDiagLazyTensor(kp_lazy_tensor, second_diag_lazy_tensor)
-        return KroneckerProductAddedDiagLazyTensor(kpadlt1, diag_lazy_tensor)
+#         kp_lazy_tensor = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b))
+#         diag_lazy_tensor = KroneckerProductDiagLazyTensor(
+#             DiagLazyTensor(d), ConstantDiagLazyTensor(e, diag_shape=2)
+#         )
+#         second_diag_lazy_tensor = ConstantDiagLazyTensor(f, diag_shape=6)
+#         kpadlt1 = KroneckerProductAddedDiagLazyTensor(kp_lazy_tensor, second_diag_lazy_tensor)
+#         return KroneckerProductAddedDiagLazyTensor(kpadlt1, diag_lazy_tensor)
 
-    def evaluate_lazy_tensor(self, lazy_tensor):
-        lt1_eval = lazy_tensor.lazy_tensor.evaluate()
-        lt2_eval = lazy_tensor.diag_tensor._diag.diag()
-        return lt1_eval + lt2_eval
+#     def evaluate_lazy_tensor(self, lazy_tensor):
+#         lt1_eval = lazy_tensor.lazy_tensor.evaluate()
+#         lt2_eval = lazy_tensor.diag_tensor._diag.diag()
+#         return lt1_eval + lt2_eval
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
@@ -43,6 +43,7 @@ class TestKroneckerProductAddedKroneckerDiagLazyTensor(TestKroneckerProductAdded
     # this lazy tensor has an explicit inverse so we don't need to run these
     skip_slq_tests = True
     should_call_cg = False
+    should_call_lanczos = False
 
     def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)

--- a/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
@@ -10,6 +10,7 @@ from gpytorch.lazy import (
     ConstantDiagLazyTensor,
     DiagLazyTensor,
     KroneckerProductAddedDiagLazyTensor,
+    KroneckerProductDiagLazyTensor,
     KroneckerProductLazyTensor,
     NonLazyTensor,
 )
@@ -24,17 +25,43 @@ class TestKroneckerProductAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestC
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
         c = torch.tensor([[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float)
+        d = 0.5 * torch.rand(24, dtype=torch.float)
         a.requires_grad_(True)
         b.requires_grad_(True)
         c.requires_grad_(True)
+        d.requires_grad_(True)
         kp_lazy_tensor = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b), NonLazyTensor(c))
-        diag_lazy_tensor = DiagLazyTensor(0.5 * torch.rand(kp_lazy_tensor.shape[-1], dtype=torch.float))
+        diag_lazy_tensor = DiagLazyTensor(d)
         return KroneckerProductAddedDiagLazyTensor(kp_lazy_tensor, diag_lazy_tensor)
 
     def evaluate_lazy_tensor(self, lazy_tensor):
         tensor = lazy_tensor._lazy_tensor.evaluate()
         diag = lazy_tensor._diag_tensor._diag
         return tensor + diag.diag()
+
+class TestKroneckerProductAddedKroneckerDiagLazyTensor(TestKroneckerProductAddedDiagLazyTensor):
+    # this lazy tensor has an explicit inverse so we don't need to run these
+    skip_slq_tests = True
+
+    def create_lazy_tensor(self):
+        a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
+        b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
+        c = torch.tensor([[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float)
+        d = torch.tensor([2, 1, 3], dtype=torch.float)
+        e = torch.tensor([5], dtype=torch.float) 
+        f = torch.tensor([2.5], dtype=torch.float)
+        a.requires_grad_(True)
+        b.requires_grad_(True)
+        c.requires_grad_(True)
+        d.requires_grad_(True)
+        e.requires_grad_(True)
+        f.requires_grad_(True)
+        kp_lazy_tensor = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b), NonLazyTensor(c))
+        diag_lazy_tensor = KroneckerProductDiagLazyTensor(
+            DiagLazyTensor(d), ConstantDiagLazyTensor(e, diag_shape=2), ConstantDiagLazyTensor(f, diag_shape=4)
+        )       
+        return KroneckerProductAddedDiagLazyTensor(kp_lazy_tensor, diag_lazy_tensor)
+
 
 class TestKroneckerProductAddedConstDiagLazyTensor(TestKroneckerProductAddedDiagLazyTensor):
     should_call_lanczos = False
@@ -49,7 +76,7 @@ class TestKroneckerProductAddedConstDiagLazyTensor(TestKroneckerProductAddedDiag
         c.requires_grad_(True)
         kp_lazy_tensor = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b), NonLazyTensor(c))
         diag_lazy_tensor = ConstantDiagLazyTensor(
-            torch.tensor([0.25], dtype=torch.float), kp_lazy_tensor.shape[-1],
+            torch.tensor([0.25], dtype=torch.float, requires_grad=True), kp_lazy_tensor.shape[-1],
         )
         return KroneckerProductAddedDiagLazyTensor(kp_lazy_tensor, diag_lazy_tensor)
 
@@ -72,6 +99,35 @@ class TestKroneckerProductAddedConstDiagLazyTensor(TestKroneckerProductAddedDiag
                 actual = torch.solve(test_mat, lazy_tensor.evaluate()).solution
                 self.assertAllClose(res, actual, rtol=0.05, atol=0.02)
                 chol_mock.assert_not_called()
+
+class TestKroneckerProductAddedDiagAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestCase):
+    # this lazy tensor has an explicit inverse so we don't need to run these
+    skip_slq_tests = True
+
+    def create_lazy_tensor(self):
+        a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
+        b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
+        d = torch.tensor([2, 1, 3], dtype=torch.float)
+        e = torch.tensor([5], dtype=torch.float)
+        f = torch.tensor([0.25], dtype=torch.float)
+        a.requires_grad_(True)
+        b.requires_grad_(True)
+        d.requires_grad_(True)
+        e.requires_grad_(True)
+        f.requires_grad_(True)
+
+        kp_lazy_tensor = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b))
+        diag_lazy_tensor = KroneckerProductDiagLazyTensor(
+            DiagLazyTensor(d), ConstantDiagLazyTensor(e, diag_shape=2)
+        )
+        second_diag_lazy_tensor = ConstantDiagLazyTensor(f, diag_shape=6)
+        kpadlt1 = KroneckerProductAddedDiagLazyTensor(kp_lazy_tensor, second_diag_lazy_tensor)
+        return KroneckerProductAddedDiagLazyTensor(kpadlt1, diag_lazy_tensor)
+
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        lt1_eval = lazy_tensor.lazy_tensor.evaluate()
+        lt2_eval = lazy_tensor.diag_tensor._diag.diag()
+        return lt1_eval + lt2_eval
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
@@ -39,6 +39,7 @@ class TestKroneckerProductAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestC
         diag = lazy_tensor._diag_tensor._diag
         return tensor + diag.diag()
 
+
 class TestKroneckerProductAddedKroneckerDiagLazyTensor(TestKroneckerProductAddedDiagLazyTensor):
     # this lazy tensor has an explicit inverse so we don't need to run these
     skip_slq_tests = True
@@ -50,7 +51,7 @@ class TestKroneckerProductAddedKroneckerDiagLazyTensor(TestKroneckerProductAdded
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
         c = torch.tensor([[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float)
         d = torch.tensor([2, 1, 3], dtype=torch.float)
-        e = torch.tensor([5], dtype=torch.float) 
+        e = torch.tensor([5], dtype=torch.float)
         f = torch.tensor([2.5], dtype=torch.float)
         a.requires_grad_(True)
         b.requires_grad_(True)
@@ -61,7 +62,7 @@ class TestKroneckerProductAddedKroneckerDiagLazyTensor(TestKroneckerProductAdded
         kp_lazy_tensor = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b), NonLazyTensor(c))
         diag_lazy_tensor = KroneckerProductDiagLazyTensor(
             DiagLazyTensor(d), ConstantDiagLazyTensor(e, diag_shape=2), ConstantDiagLazyTensor(f, diag_shape=4)
-        )       
+        )
         return KroneckerProductAddedDiagLazyTensor(kp_lazy_tensor, diag_lazy_tensor)
 
 
@@ -102,34 +103,6 @@ class TestKroneckerProductAddedConstDiagLazyTensor(TestKroneckerProductAddedDiag
                 self.assertAllClose(res, actual, rtol=0.05, atol=0.02)
                 chol_mock.assert_not_called()
 
-# class TestKroneckerProductAddedDiagAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestCase):
-#     # this lazy tensor has an explicit inverse so we don't need to run these
-#     skip_slq_tests = True
-
-#     def create_lazy_tensor(self):
-#         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
-#         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
-#         d = torch.tensor([2, 1, 3], dtype=torch.float)
-#         e = torch.tensor([5], dtype=torch.float)
-#         f = torch.tensor([0.25], dtype=torch.float)
-#         a.requires_grad_(True)
-#         b.requires_grad_(True)
-#         d.requires_grad_(True)
-#         e.requires_grad_(True)
-#         f.requires_grad_(True)
-
-#         kp_lazy_tensor = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b))
-#         diag_lazy_tensor = KroneckerProductDiagLazyTensor(
-#             DiagLazyTensor(d), ConstantDiagLazyTensor(e, diag_shape=2)
-#         )
-#         second_diag_lazy_tensor = ConstantDiagLazyTensor(f, diag_shape=6)
-#         kpadlt1 = KroneckerProductAddedDiagLazyTensor(kp_lazy_tensor, second_diag_lazy_tensor)
-#         return KroneckerProductAddedDiagLazyTensor(kpadlt1, diag_lazy_tensor)
-
-#     def evaluate_lazy_tensor(self, lazy_tensor):
-#         lt1_eval = lazy_tensor.lazy_tensor.evaluate()
-#         lt2_eval = lazy_tensor.diag_tensor._diag.diag()
-#         return lt1_eval + lt2_eval
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
@@ -20,7 +20,7 @@ class TestKroneckerProductAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestC
     # this lazy tensor has an explicit inverse so we don't need to run these
     skip_slq_tests = True
 
-    def create_lazy_tensor(self, constant_diag=False):
+    def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
         c = torch.tensor([[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float)
@@ -28,12 +28,7 @@ class TestKroneckerProductAddedDiagLazyTensor(unittest.TestCase, LazyTensorTestC
         b.requires_grad_(True)
         c.requires_grad_(True)
         kp_lazy_tensor = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b), NonLazyTensor(c))
-        if constant_diag:
-            diag_lazy_tensor = ConstantDiagLazyTensor(
-                torch.tensor([0.25], dtype=torch.float), kp_lazy_tensor.shape[-1],
-            )
-        else:
-            diag_lazy_tensor = DiagLazyTensor(0.5 * torch.rand(kp_lazy_tensor.shape[-1], dtype=torch.float))
+        diag_lazy_tensor = DiagLazyTensor(0.5 * torch.rand(kp_lazy_tensor.shape[-1], dtype=torch.float))
         return KroneckerProductAddedDiagLazyTensor(kp_lazy_tensor, diag_lazy_tensor)
 
     def evaluate_lazy_tensor(self, lazy_tensor):
@@ -46,7 +41,17 @@ class TestKroneckerProductAddedConstDiagLazyTensor(TestKroneckerProductAddedDiag
     should_call_cg = False
 
     def create_lazy_tensor(self):
-        return super().create_lazy_tensor(constant_diag=True)
+        a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
+        b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
+        c = torch.tensor([[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float)
+        a.requires_grad_(True)
+        b.requires_grad_(True)
+        c.requires_grad_(True)
+        kp_lazy_tensor = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b), NonLazyTensor(c))
+        diag_lazy_tensor = ConstantDiagLazyTensor(
+            torch.tensor([0.25], dtype=torch.float), kp_lazy_tensor.shape[-1],
+        )
+        return KroneckerProductAddedDiagLazyTensor(kp_lazy_tensor, diag_lazy_tensor)
 
     def test_if_cholesky_used(self):
         lazy_tensor = self.create_lazy_tensor()

--- a/test/lazy/test_kronecker_product_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_lazy_tensor.py
@@ -48,9 +48,9 @@ class TestKroneckerProductLazyTensor(LazyTensorTestCase, unittest.TestCase):
 
 class TestKroneckerProductDiagLazyTensor(TestDiagLazyTensor):
     def create_lazy_tensor(self):
-        a = torch.tensor([40, 10., 2.], dtype=torch.float)
-        b = torch.tensor([80., 1], dtype=torch.float)
-        c = torch.tensor([4.75, 10.95, 1.05, 0.25], dtype=torch.float)
+        a = torch.tensor([4., 1., 2.], dtype=torch.float)
+        b = torch.tensor([3., 1.3], dtype=torch.float)
+        c = torch.tensor([1.75, 1.95, 1.05, 0.25], dtype=torch.float)
         a.requires_grad_(True)
         b.requires_grad_(True)
         c.requires_grad_(True)

--- a/test/lazy/test_kronecker_product_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_lazy_tensor.py
@@ -4,9 +4,9 @@ import unittest
 
 import torch
 
-from gpytorch.lazy import KroneckerProductLazyTensor, NonLazyTensor
+from gpytorch.lazy import KroneckerProductLazyTensor, KroneckerProductDiagLazyTensor, NonLazyTensor, DiagLazyTensor
 from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase, RectangularLazyTensorTestCase
-
+from .test_diag_lazy_tensor import TestDiagLazyTensor
 
 def kron(a, b):
     res = []
@@ -17,6 +17,14 @@ def kron(a, b):
         res.append(torch.cat(row_res, -1))
     return torch.cat(res, -2)
 
+def kron_diag(*lts):
+    """Compute diagonal of a KroneckerProductLazyTensor from the diagonals of the constituiting tensors"""
+    lead_diag = lts[0].diag()
+    if len(lts) == 1:  # base case:
+        return lead_diag
+    trail_diag = kron_diag(*lts[1:])
+    diag = lead_diag.unsqueeze(-2) * trail_diag.unsqueeze(-1)
+    return diag.transpose(-1, -2).reshape(*diag.shape[:-2], -1)
 
 class TestKroneckerProductLazyTensor(LazyTensorTestCase, unittest.TestCase):
     seed = 0
@@ -37,6 +45,21 @@ class TestKroneckerProductLazyTensor(LazyTensorTestCase, unittest.TestCase):
         res = kron(res, lazy_tensor.lazy_tensors[2].tensor)
         return res
 
+
+class TestKroneckerProductDiagLazyTensor(TestDiagLazyTensor):
+    def create_lazy_tensor(self):
+        a = torch.tensor([40, 10., 2.], dtype=torch.float)
+        b = torch.tensor([80., 1], dtype=torch.float)
+        c = torch.tensor([4.75, 10.95, 1.05, 0.25], dtype=torch.float)
+        a.requires_grad_(True)
+        b.requires_grad_(True)
+        c.requires_grad_(True)
+        kp_lazy_tensor = KroneckerProductDiagLazyTensor(DiagLazyTensor(a), DiagLazyTensor(b), DiagLazyTensor(c))
+        return kp_lazy_tensor
+
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        res_diag = kron_diag(*lazy_tensor.lazy_tensors)
+        return torch.diag_embed(res_diag)
 
 class TestKroneckerProductLazyTensorBatch(TestKroneckerProductLazyTensor):
     seed = 0

--- a/test/lazy/test_kronecker_sum_lazy_tensor.py
+++ b/test/lazy/test_kronecker_sum_lazy_tensor.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+
+from gpytorch.lazy import KroneckerSumLazyTensor, KroneckerProductLazyTensor, NonLazyTensor
+from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase
+
+def kron(a, b):
+    res = []
+    for i in range(a.size(-2)):
+        row_res = []
+        for j in range(a.size(-1)):
+            row_res.append(b * a[..., i, j].unsqueeze(-1).unsqueeze(-2))
+        res.append(torch.cat(row_res, -1))
+    return torch.cat(res, -2)
+
+
+class TestKroneckerSumLazyTensor(LazyTensorTestCase, unittest.TestCase):
+    seed = 0
+    should_call_lanczos = True
+    should_call_cg = False
+    skip_slq_tests = True
+
+    def create_lazy_tensor(self):
+        a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
+        b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
+        c = torch.tensor([[4, 0.5, 1], [0.5, 4, -1], [1, -1, 3]], dtype=torch.float)
+        d = torch.tensor([[1.2, 0.75], [0.75, 1.2]], dtype=torch.float)
+
+        a.requires_grad_(True)
+        b.requires_grad_(True)
+        c.requires_grad_(True)
+        d.requires_grad_(True)
+        kp_lt_1 = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b))
+        kp_lt_2 = KroneckerProductLazyTensor(NonLazyTensor(c), NonLazyTensor(d))
+
+        return KroneckerSumLazyTensor(kp_lt_1, kp_lt_2)
+
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        res1 = kron(
+            lazy_tensor.lazy_tensors[0].lazy_tensors[0].tensor,
+            lazy_tensor.lazy_tensors[0].lazy_tensors[1].tensor
+        )
+        res2 = kron(
+            lazy_tensor.lazy_tensors[1].lazy_tensors[0].tensor,
+            lazy_tensor.lazy_tensors[1].lazy_tensors[1].tensor
+        )
+        return res1 + res2


### PR DESCRIPTION
This is a sub pull request into #1430 separating out the unit tests for the separate cases when `D` is a Kronecker product of constant diagonals and when `D` is a Kronecker product of non-constant diagonal cases. 

edit: This will not pass the failing unit test wrt the quad_form_derivative in the constant diagonal case.