### PR TITLE
Bug fixes to LowRank lazy tensors

### DIFF
--- a/gpytorch/kernels/rff_kernel.py
+++ b/gpytorch/kernels/rff_kernel.py
@@ -6,7 +6,7 @@ from typing import Optional
 import torch
 from torch import Tensor
 
-from ..lazy import MatmulLazyTensor, RootLazyTensor
+from ..lazy import LowRankRootLazyTensor, MatmulLazyTensor
 from ..models.exact_prediction_strategies import RFFPredictionStrategy
 from .kernel import Kernel
 
@@ -128,7 +128,7 @@ class RFFKernel(Kernel):
         if diag:
             return (z1 * z2).sum(-1) / D
         if x1_eq_x2:
-            return RootLazyTensor(z1 / math.sqrt(D))
+            return LowRankRootLazyTensor(z1 / math.sqrt(D))
         else:
             return MatmulLazyTensor(z1 / D, z2.transpose(-1, -2))
 

--- a/gpytorch/lazy/low_rank_root_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_lazy_tensor.py
@@ -49,4 +49,4 @@ class LowRankRootLazyTensor(RootLazyTensor):
         if isinstance(other, DiagLazyTensor):
             return LowRankRootAddedDiagLazyTensor(self, other)
         else:
-            return super().__add__(self, other)
+            return super().__add__(other)

--- a/gpytorch/lazy/root_lazy_tensor.py
+++ b/gpytorch/lazy/root_lazy_tensor.py
@@ -55,6 +55,13 @@ class RootLazyTensor(LazyTensor):
     def _matmul(self, rhs):
         return self.root._matmul(self.root._t_matmul(rhs))
 
+    def _mul_constant(self, constant):
+        if constant > 0:
+            res = self.__class__(self.root._mul_constant(constant.sqrt()))
+        else:
+            res = super()._mul_constant(constant)
+        return res
+
     def _t_matmul(self, rhs):
         # Matrix is symmetric
         return self._matmul(rhs)

--- a/gpytorch/test/lazy_tensor_test_case.py
+++ b/gpytorch/test/lazy_tensor_test_case.py
@@ -97,7 +97,12 @@ class RectangularLazyTensorTestCase(BaseTestCase):
     def test_constant_mul(self):
         lazy_tensor = self.create_lazy_tensor()
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)
-        self.assertAllClose((lazy_tensor * 5).evaluate(), evaluated * 5)
+        self.assertAllClose((lazy_tensor * 5.0).evaluate(), evaluated * 5.0)
+
+    def test_neg_constant_mul(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+        self.assertAllClose((lazy_tensor * -5.0).evaluate(), evaluated * -5.0)
 
     def test_evaluate(self):
         lazy_tensor = self.create_lazy_tensor()

--- a/test/examples/test_sgpr_regression.py
+++ b/test/examples/test_sgpr_regression.py
@@ -84,6 +84,10 @@ class TestSGPRRegression(unittest.TestCase):
             loss.backward()
             optimizer.step()
 
+            # Check that we have the right LazyTensor type
+            kernel = likelihood(gp_model(train_x)).lazy_covariance_matrix.evaluate_kernel()
+            self.assertIsInstance(kernel, gpytorch.lazy.LowRankRootAddedDiagLazyTensor)
+
         for param in gp_model.parameters():
             self.assertTrue(param.grad is not None)
             self.assertGreater(param.grad.norm().item(), 0)

--- a/test/lazy/test_low_rank_root_added_diag_lazy_tensor.py
+++ b/test/lazy/test_low_rank_root_added_diag_lazy_tensor.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+
+import math
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+import gpytorch
+from gpytorch.lazy import LowRankRootAddedDiagLazyTensor, LowRankRootLazyTensor
+from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase, _ensure_symmetric_grad
+
+
+class TestLowRankRootAddedDiagLazyTensor(LazyTensorTestCase, unittest.TestCase):
+    seed = 0
+    should_test_sample = True
+
+    def create_lazy_tensor(self):
+        tensor = torch.randn(5, 2)
+        diag = torch.tensor([1.0, 2.0, 4.0, 2.0, 3.0])
+        lt = LowRankRootLazyTensor(tensor).add_diag(diag)
+        assert isinstance(lt, LowRankRootAddedDiagLazyTensor)
+        return lt
+
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        diag = lazy_tensor._diag_tensor._diag
+        root = lazy_tensor._lazy_tensor.root.tensor
+        return root @ root.transpose(-1, -2) + diag.diag_embed(dim1=-2, dim2=-1)
+
+    def _test_inv_matmul(self, rhs, lhs=None, cholesky=False):
+        lazy_tensor = self.create_lazy_tensor().requires_grad_(True)
+        lazy_tensor_copy = lazy_tensor.clone().detach_().requires_grad_(True)
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor_copy)
+        evaluated.register_hook(_ensure_symmetric_grad)
+
+        # Create a test right hand side and left hand side
+        rhs.requires_grad_(True)
+        rhs_copy = rhs.clone().detach().requires_grad_(True)
+        if lhs is not None:
+            lhs.requires_grad_(True)
+            lhs_copy = lhs.clone().detach().requires_grad_(True)
+
+        _wrapped_cg = MagicMock(wraps=gpytorch.utils.linear_cg)
+        with patch("gpytorch.utils.linear_cg", new=_wrapped_cg) as linear_cg_mock:
+            with gpytorch.settings.max_cholesky_size(math.inf if cholesky else 0), gpytorch.settings.cg_tolerance(1e-4):
+                # Perform the inv_matmul
+                if lhs is not None:
+                    res = lazy_tensor.inv_matmul(rhs, lhs)
+                    actual = lhs_copy @ evaluated.inverse() @ rhs_copy
+                else:
+                    res = lazy_tensor.inv_matmul(rhs)
+                    actual = evaluated.inverse().matmul(rhs_copy)
+                self.assertAllClose(res, actual, rtol=0.02, atol=1e-5)
+
+                # Perform backward pass
+                grad = torch.randn_like(res)
+                res.backward(gradient=grad)
+                actual.backward(gradient=grad)
+                for arg, arg_copy in zip(lazy_tensor.representation(), lazy_tensor_copy.representation()):
+                    if arg_copy.requires_grad and arg_copy.is_leaf and arg_copy.grad is not None:
+                        self.assertAllClose(arg.grad, arg_copy.grad, rtol=0.03, atol=1e-5)
+                self.assertAllClose(rhs.grad, rhs_copy.grad, rtol=0.03, atol=1e-5)
+                if lhs is not None:
+                    self.assertAllClose(lhs.grad, lhs_copy.grad, rtol=0.03, atol=1e-5)
+
+            self.assertFalse(linear_cg_mock.called)
+
+    def _test_inv_quad_logdet(self, reduce_inv_quad=True, cholesky=False):
+        if not self.__class__.skip_slq_tests:
+            # Forward
+            lazy_tensor = self.create_lazy_tensor()
+            evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+            flattened_evaluated = evaluated.view(-1, *lazy_tensor.matrix_shape)
+
+            vecs = torch.randn(*lazy_tensor.batch_shape, lazy_tensor.size(-1), 3, requires_grad=True)
+            vecs_copy = vecs.clone().detach_().requires_grad_(True)
+
+            _wrapped_cg = MagicMock(wraps=gpytorch.utils.linear_cg)
+            with patch("gpytorch.utils.linear_cg", new=_wrapped_cg) as linear_cg_mock:
+                with gpytorch.settings.num_trace_samples(256), gpytorch.settings.max_cholesky_size(
+                    math.inf if cholesky else 0
+                ), gpytorch.settings.cg_tolerance(1e-5):
+
+                    res_inv_quad, res_logdet = lazy_tensor.inv_quad_logdet(
+                        inv_quad_rhs=vecs, logdet=True, reduce_inv_quad=reduce_inv_quad
+                    )
+
+            actual_inv_quad = evaluated.inverse().matmul(vecs_copy).mul(vecs_copy).sum(-2)
+            if reduce_inv_quad:
+                actual_inv_quad = actual_inv_quad.sum(-1)
+            actual_logdet = torch.cat(
+                [torch.logdet(flattened_evaluated[i]).unsqueeze(0) for i in range(lazy_tensor.batch_shape.numel())]
+            ).view(lazy_tensor.batch_shape)
+
+            self.assertAllClose(res_inv_quad, actual_inv_quad, rtol=0.01, atol=0.01)
+            self.assertAllClose(res_logdet, actual_logdet, rtol=0.2, atol=0.03)
+
+            self.assertFalse(linear_cg_mock.called)
+
+
+class TestLowRankRootAddedDiagLazyTensorBatch(TestLowRankRootAddedDiagLazyTensor):
+    seed = 4
+    should_test_sample = True
+
+    def create_lazy_tensor(self):
+        tensor = torch.randn(3, 5, 2)
+        diag = torch.tensor([[1.0, 2.0, 4.0, 2.0, 3.0], [2.0, 1.0, 2.0, 1.0, 4.0], [1.0, 2.0, 2.0, 3.0, 4.0]])
+        lt = LowRankRootLazyTensor(tensor).add_diag(diag)
+        assert isinstance(lt, LowRankRootAddedDiagLazyTensor)
+        return lt
+
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        diag = lazy_tensor._diag_tensor._diag
+        root = lazy_tensor._lazy_tensor.root.tensor
+        return root @ root.transpose(-1, -2) + diag.diag_embed(dim1=-2, dim2=-1)
+
+
+class TestLowRankRootAddedDiagLazyTensorMultiBatch(TestLowRankRootAddedDiagLazyTensor):
+    seed = 4
+    # Because these LTs are large, we'll skil the big tests
+    should_test_sample = False
+    skip_slq_tests = True
+
+    def create_lazy_tensor(self):
+        tensor = torch.randn(4, 3, 5, 2)
+        diag = torch.tensor([[1.0, 2.0, 4.0, 2.0, 3.0], [2.0, 1.0, 2.0, 1.0, 4.0], [1.0, 2.0, 2.0, 3.0, 4.0]]).repeat(
+            4, 1, 1
+        )
+        lt = LowRankRootLazyTensor(tensor).add_diag(diag)
+        assert isinstance(lt, LowRankRootAddedDiagLazyTensor)
+        return lt
+
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        diag = lazy_tensor._diag_tensor._diag
+        root = lazy_tensor._lazy_tensor.root.tensor
+        return root @ root.transpose(-1, -2) + diag.diag_embed(dim1=-2, dim2=-1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/lazy/test_low_rank_root_lazy_tensor.py
+++ b/test/lazy/test_low_rank_root_lazy_tensor.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+
+from gpytorch.lazy import LowRankRootLazyTensor
+from gpytorch.test.lazy_tensor_test_case import RectangularLazyTensorTestCase
+
+
+class TestLowRankRootLazyTensor(RectangularLazyTensorTestCase, unittest.TestCase):
+    def create_lazy_tensor(self):
+        root = torch.randn(3, 1, requires_grad=True)
+        return LowRankRootLazyTensor(root)
+
+    def evaluate_lazy_tensor(self, lazy_tensor):
+        root = lazy_tensor.root.tensor
+        res = root.matmul(root.transpose(-1, -2))
+        return res
+
+
+class TestLowRankRootLazyTensorBatch(TestLowRankRootLazyTensor):
+    seed = 1
+
+    def create_lazy_tensor(self):
+        root = torch.randn(3, 5, 2)
+        return LowRankRootLazyTensor(root)
+
+
+class TestLowRankRootLazyTensorMultiBatch(TestLowRankRootLazyTensor):
+    seed = 1
+    # Because these LTs are large, we'll skil the big tests
+    should_test_sample = False
+    skip_slq_tests = True
+
+    def create_lazy_tensor(self):
+        root = torch.randn(4, 3, 5, 2)
+        return LowRankRootLazyTensor(root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
There were no unit tests for LowRankRootLazyTensor (or its added diag variant), and there were a number of issues. Most notably, `inv_quad_logdet` was not returning the right `inv_quad` term, which caused errors when using this LazyTensor on a batched GP model.

This PR fixes these issues, and also uses `LowRankRootLazyTensor` for RFF kernels.