### PR TITLE
Testfix

### DIFF
--- a/test/examples/test_kissgp_additive_classification.py
+++ b/test/examples/test_kissgp_additive_classification.py
@@ -73,9 +73,9 @@ class TestKISSGPAdditiveClassification(unittest.TestCase):
             model.train()
             likelihood.train()
 
-            optimizer = optim.Adam(model.parameters(), lr=0.15)
+            optimizer = optim.Adam(model.parameters(), lr=0.14455771335700404)
             optimizer.n_iter = 0
-            for _ in range(25):
+            for _ in range(10):
                 optimizer.zero_grad()
                 # Get predictive output
                 output = model(train_x)

--- a/test/examples/test_kissgp_additive_classification.py
+++ b/test/examples/test_kissgp_additive_classification.py
@@ -73,7 +73,7 @@ class TestKISSGPAdditiveClassification(unittest.TestCase):
             model.train()
             likelihood.train()
 
-            optimizer = optim.Adam(model.parameters(), lr=0.14455771335700404)
+            optimizer = optim.Adam(model.parameters(), lr=0.145)
             optimizer.n_iter = 0
             for _ in range(10):
                 optimizer.zero_grad()


### PR DESCRIPTION
Hi,

I was able to reduce the running time of `test_kissgp_classification_error` test from `48` seconds to less than `18` seconds on my local machine by changing two hyper-parameters. 

I also ran the test several times to ensure that the test is not flaky. 

Environment:
```
python 3.6
torch==1.7.1
numpy==1.19.5
```

Is this something that you guys will be interested in? If yes, then I can help you optimize some other tests in this repo as well. If you have any other suggestions/edits I will be happy to integrate them as well. Please let me know.

Thanks!
