### PR TITLE
Rename KroneckerSumLT to be SumKroneckerLT

### DIFF
--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -18,7 +18,6 @@ from .kronecker_product_lazy_tensor import (
     KroneckerProductLazyTensor,
     KroneckerProductTriangularLazyTensor,
 )
-from .kronecker_sum_lazy_tensor import KroneckerSumLazyTensor
 from .lazy_evaluated_kernel_tensor import LazyEvaluatedKernelTensor
 from .lazy_tensor import LazyTensor, delazify
 from .low_rank_root_added_diag_lazy_tensor import LowRankRootAddedDiagLazyTensor
@@ -29,6 +28,7 @@ from .non_lazy_tensor import NonLazyTensor, lazify
 from .psd_sum_lazy_tensor import PsdSumLazyTensor
 from .root_lazy_tensor import RootLazyTensor
 from .sum_batch_lazy_tensor import SumBatchLazyTensor
+from .sum_kronecker_lazy_tensor import SumKroneckerLazyTensor
 from .sum_lazy_tensor import SumLazyTensor
 from .toeplitz_lazy_tensor import ToeplitzLazyTensor
 from .triangular_lazy_tensor import TriangularLazyTensor
@@ -57,7 +57,7 @@ __all__ = [
     "KroneckerProductAddedDiagLazyTensor",
     "KroneckerProductDiagLazyTensor",
     "KroneckerProductTriangularLazyTensor",
-    "KroneckerSumLazyTensor",
+    "SumKroneckerLazyTensor",
     "LowRankRootAddedDiagLazyTensor",
     "LowRankRootLazyTensor",
     "MatmulLazyTensor",

--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -87,9 +87,9 @@ class KroneckerProductLazyTensor(LazyTensor):
 
             return KroneckerProductAddedDiagLazyTensor(self, other)
         if isinstance(other, KroneckerProductLazyTensor):
-            from .kronecker_sum_lazy_tensor import KroneckerSumLazyTensor
+            from .sum_kronecker_lazy_tensor import SumKroneckerLazyTensor
 
-            return KroneckerSumLazyTensor(self, other)
+            return SumKroneckerLazyTensor(self, other)
         if isinstance(other, DiagLazyTensor):
             return self.add_diag(other.diag())
         return super().__add__(other)

--- a/gpytorch/lazy/sum_kronecker_lazy_tensor.py
+++ b/gpytorch/lazy/sum_kronecker_lazy_tensor.py
@@ -5,7 +5,7 @@ from .kronecker_product_lazy_tensor import KroneckerProductLazyTensor
 from .sum_lazy_tensor import SumLazyTensor
 
 
-class KroneckerSumLazyTensor(SumLazyTensor):
+class SumKroneckerLazyTensor(SumLazyTensor):
     r"""
     Returns the sum of two Kronecker product lazy tensors. Solves and log-determinants
     are computed using the eigen-decomposition of the right lazy tensor; that is,
@@ -18,7 +18,7 @@ class KroneckerSumLazyTensor(SumLazyTensor):
     The original reference is [https://papers.nips.cc/paper/2013/file/59c33016884a62116be975a9bb8257e3-Paper.pdf].
 
     Args:
-        :`lazy_tensors`: List of lazy tensors
+        :`lazy_tensors`: List of two Kronecker lazy tensors
     """
 
     @property

--- a/gpytorch/likelihoods/__init__.py
+++ b/gpytorch/likelihoods/__init__.py
@@ -6,11 +6,7 @@ from .gaussian_likelihood import FixedNoiseGaussianLikelihood, GaussianLikelihoo
 from .laplace_likelihood import LaplaceLikelihood
 from .likelihood import Likelihood, _OneDimensionalLikelihood
 from .likelihood_list import LikelihoodList
-from .multitask_gaussian_likelihood import (
-    MultitaskGaussianLikelihood,
-    MultitaskGaussianLikelihoodKronecker,
-    _MultitaskGaussianLikelihoodBase,
-)
+from .multitask_gaussian_likelihood import MultitaskGaussianLikelihood, _MultitaskGaussianLikelihoodBase
 from .noise_models import HeteroskedasticNoise
 from .softmax_likelihood import SoftmaxLikelihood
 from .student_t_likelihood import StudentTLikelihood
@@ -28,7 +24,6 @@ __all__ = [
     "Likelihood",
     "LikelihoodList",
     "MultitaskGaussianLikelihood",
-    "MultitaskGaussianLikelihoodKronecker",
     "SoftmaxLikelihood",
     "StudentTLikelihood",
 ]

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -228,6 +228,4 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
         return covar_factor.matmul(covar_factor.transpose(-1, -2)) + D
 
 
-# TODO: remove in a later commit
 # MultitaskGaussianLikelihood has replaced MultitaskGaussianLikelihoodKronecker
-MultitaskGaussianLikelihoodKronecker = MultitaskGaussianLikelihood

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -161,7 +161,7 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
             task_prior (:obj:`gpytorch.priors.Prior`): Prior to use over the task noise covariance matrix if
             `rank` > 0, or a prior over the log of just the diagonal elements, if `rank` == 0.
 
-            has_global_noise (bool): whether to include a \sigma^2 I_{nt} term in the noise model.
+            has_global_noise (bool): whether to include a \\sigma^2 I_{nt} term in the noise model.
 
             has_task_noise (bool): whether to include task-specific noise terms, which add I_n \kron D_T
             into the noise model.

--- a/test/examples/test_batch_multitask_gp_regression.py
+++ b/test/examples/test_batch_multitask_gp_regression.py
@@ -10,7 +10,7 @@ import gpytorch
 from torch import optim
 from gpytorch.kernels import RBFKernel, MultitaskKernel
 from gpytorch.means import ConstantMean, MultitaskMean
-from gpytorch.likelihoods import MultitaskGaussianLikelihoodKronecker
+from gpytorch.likelihoods import MultitaskGaussianLikelihood
 from gpytorch.distributions import MultitaskMultivariateNormal
 
 
@@ -68,7 +68,7 @@ class TestBatchMultitaskGPRegression(unittest.TestCase):
 
     def test_train_on_single_set_test_on_batch(self):
         # We're manually going to set the hyperparameters to something they shouldn't be
-        likelihood = MultitaskGaussianLikelihoodKronecker(
+        likelihood = MultitaskGaussianLikelihood(
             noise_prior=gpytorch.priors.NormalPrior(loc=torch.zeros(1), scale=torch.ones(1)), num_tasks=2
         )
         gp_model = ExactGPModel(train_x1, train_y1, likelihood)
@@ -108,7 +108,7 @@ class TestBatchMultitaskGPRegression(unittest.TestCase):
 
     def test_train_on_batch_test_on_batch(self):
         # We're manually going to set the hyperparameters to something they shouldn't be
-        likelihood = MultitaskGaussianLikelihoodKronecker(
+        likelihood = MultitaskGaussianLikelihood(
             noise_prior=gpytorch.priors.NormalPrior(loc=torch.zeros(2), scale=torch.ones(2)),
             batch_shape=torch.Size([2]),
             num_tasks=2,
@@ -146,7 +146,7 @@ class TestBatchMultitaskGPRegression(unittest.TestCase):
 
     def test_train_on_batch_test_on_batch_shared_hypers_over_batch(self):
         # We're manually going to set the hyperparameters to something they shouldn't be
-        likelihood = MultitaskGaussianLikelihoodKronecker(
+        likelihood = MultitaskGaussianLikelihood(
             noise_prior=gpytorch.priors.NormalPrior(loc=torch.zeros(2), scale=torch.ones(2)),
             batch_shape=torch.Size(),
             num_tasks=2,

--- a/test/lazy/test_sum_kronecker_lazy_tensor.py
+++ b/test/lazy/test_sum_kronecker_lazy_tensor.py
@@ -4,7 +4,7 @@ import unittest
 
 import torch
 
-from gpytorch.lazy import KroneckerProductLazyTensor, KroneckerSumLazyTensor, NonLazyTensor
+from gpytorch.lazy import KroneckerProductLazyTensor, NonLazyTensor, SumKroneckerLazyTensor
 from gpytorch.test.lazy_tensor_test_case import LazyTensorTestCase
 
 
@@ -18,7 +18,7 @@ def kron(a, b):
     return torch.cat(res, -2)
 
 
-class TestKroneckerSumLazyTensor(LazyTensorTestCase, unittest.TestCase):
+class TestSumKroneckerLazyTensor(LazyTensorTestCase, unittest.TestCase):
     seed = 0
     should_call_lanczos = True
     should_call_cg = False
@@ -37,7 +37,7 @@ class TestKroneckerSumLazyTensor(LazyTensorTestCase, unittest.TestCase):
         kp_lt_1 = KroneckerProductLazyTensor(NonLazyTensor(a), NonLazyTensor(b))
         kp_lt_2 = KroneckerProductLazyTensor(NonLazyTensor(c), NonLazyTensor(d))
 
-        return KroneckerSumLazyTensor(kp_lt_1, kp_lt_2)
+        return SumKroneckerLazyTensor(kp_lt_1, kp_lt_2)
 
     def evaluate_lazy_tensor(self, lazy_tensor):
         res1 = kron(

--- a/test/likelihoods/test_general_multitask_gaussian_likelihood.py
+++ b/test/likelihoods/test_general_multitask_gaussian_likelihood.py
@@ -10,7 +10,7 @@ import torch
 import gpytorch
 from gpytorch.distributions import MultitaskMultivariateNormal
 from gpytorch.kernels import MultitaskKernel, RBFKernel
-from gpytorch.likelihoods import MultitaskGaussianLikelihoodKronecker
+from gpytorch.likelihoods import MultitaskGaussianLikelihood
 from gpytorch.means import ConstantMean, MultitaskMean
 
 # Simple training data: let's try to learn a sine function
@@ -53,7 +53,7 @@ class TestMultiTaskGPRegression(unittest.TestCase):
             torch.set_rng_state(self.rng_state)
 
     def test_multitask_low_rank_noise_covar(self):
-        likelihood = MultitaskGaussianLikelihoodKronecker(num_tasks=2, rank=1)
+        likelihood = MultitaskGaussianLikelihood(num_tasks=2, rank=1)
         model = MultitaskGPModel(train_x, train_y, likelihood)
         # Find optimal model hyperparameters
         model.train()


### PR DESCRIPTION
Renames and fixes the comment in the documentation. Also removes MultitaskGaussianLikelihoodKronecker.
