### PR TITLE
Better additive/product kernel composition

### DIFF
--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -402,10 +402,16 @@ class Kernel(Module):
         return self.__dict__
 
     def __add__(self, other):
-        return AdditiveKernel(self, other)
+        kernels = []
+        kernels += self.kernels if isinstance(self, AdditiveKernel) else [self]
+        kernels += other.kernels if isinstance(other, AdditiveKernel) else [other]
+        return AdditiveKernel(*kernels)
 
     def __mul__(self, other):
-        return ProductKernel(self, other)
+        kernels = []
+        kernels += self.kernels if isinstance(self, ProductKernel) else [self]
+        kernels += other.kernels if isinstance(other, ProductKernel) else [other]
+        return ProductKernel(*kernels)
 
     def __setstate__(self, d):
         self.__dict__ = d

--- a/test/kernels/test_additive_and_product_kernels.py
+++ b/test/kernels/test_additive_and_product_kernels.py
@@ -5,10 +5,10 @@ import unittest
 
 import torch
 
-from gpytorch.kernels import AdditiveKernel, LinearKernel, ProductKernel, RBFKernel
+from gpytorch.kernels import LinearKernel, RBFKernel
 
 
-class TestAdditiveKernel(unittest.TestCase):
+class TestAdditiveAndProductKernel(unittest.TestCase):
     def test_computes_product_of_radial_basis_function(self):
         a = torch.tensor([4, 2, 8], dtype=torch.float).view(3, 1)
         b = torch.tensor([0, 2], dtype=torch.float).view(2, 1)
@@ -118,10 +118,68 @@ class TestAdditiveKernel(unittest.TestCase):
         kernel_1 = RBFKernel().initialize(lengthscale=lengthscale)
         kernel_2 = RBFKernel().initialize(lengthscale=lengthscale)
         kernel_3 = RBFKernel().initialize(lengthscale=lengthscale)
-        kernel = ProductKernel(kernel_1, kernel_2, kernel_3)
+        kernel = (kernel_1 * kernel_2) * kernel_3
+        self.assertEqual(len(kernel.kernels), 3)
+        for sub_kernel in kernel.kernels:
+            self.assertIsInstance(sub_kernel, RBFKernel)
 
         actual = torch.tensor([[16, 4], [4, 0], [64, 36]], dtype=torch.float)
         actual = actual.mul_(-0.5).div_(lengthscale ** 2).exp() ** 3
+
+        kernel.eval()
+        res = kernel(a, b).evaluate()
+        self.assertLess(torch.norm(res - actual), 2e-5)
+
+        kernel_1 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel_2 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel_3 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel = (kernel_1 * kernel_2) * kernel_3
+        self.assertEqual(len(kernel.kernels), 3)
+        for sub_kernel in kernel.kernels:
+            self.assertIsInstance(sub_kernel, RBFKernel)
+
+        kernel.eval()
+        res = kernel(a, b).evaluate()
+        self.assertLess(torch.norm(res - actual), 2e-5)
+
+    def test_computes_product_of_four_radial_basis_function(self):
+        a = torch.tensor([4, 2, 8], dtype=torch.float).view(3, 1)
+        b = torch.tensor([0, 2], dtype=torch.float).view(2, 1)
+        lengthscale = 2
+
+        kernel_1 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel_2 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel_3 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel_4 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel = kernel_1 * kernel_2 * kernel_3 * kernel_4
+        self.assertEqual(len(kernel.kernels), 4)
+        for sub_kernel in kernel.kernels:
+            self.assertIsInstance(sub_kernel, RBFKernel)
+
+        actual = torch.tensor([[16, 4], [4, 0], [64, 36]], dtype=torch.float)
+        actual = actual.mul_(-0.5).div_(lengthscale ** 2).exp() ** 4
+
+        kernel.eval()
+        res = kernel(a, b).evaluate()
+        self.assertLess(torch.norm(res - actual), 2e-5)
+
+    def test_computes_sum_of_four_radial_basis_function(self):
+        a = torch.tensor([4, 2, 8], dtype=torch.float).view(3, 1)
+        b = torch.tensor([0, 2], dtype=torch.float).view(2, 1)
+        lengthscale = 2
+
+        kernel_1 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel_2 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel_3 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel_4 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel = (kernel_1 + kernel_2) + (kernel_3 + kernel_4)
+        self.assertEqual(len(kernel.kernels), 4)
+        for sub_kernel in kernel.kernels:
+            self.assertIsInstance(sub_kernel, RBFKernel)
+
+        actual = (
+            torch.tensor([[16, 4], [4, 0], [64, 36]], dtype=torch.float).mul_(-0.5).div_(lengthscale ** 2).exp() * 4
+        )
 
         kernel.eval()
         res = kernel(a, b).evaluate()
@@ -135,11 +193,26 @@ class TestAdditiveKernel(unittest.TestCase):
         kernel_1 = RBFKernel().initialize(lengthscale=lengthscale)
         kernel_2 = RBFKernel().initialize(lengthscale=lengthscale)
         kernel_3 = RBFKernel().initialize(lengthscale=lengthscale)
-        kernel = AdditiveKernel(kernel_1, kernel_2, kernel_3)
+        kernel = (kernel_1 + kernel_2) + kernel_3
+        self.assertEqual(len(kernel.kernels), 3)
+        for sub_kernel in kernel.kernels:
+            self.assertIsInstance(sub_kernel, RBFKernel)
 
         actual = (
             torch.tensor([[16, 4], [4, 0], [64, 36]], dtype=torch.float).mul_(-0.5).div_(lengthscale ** 2).exp() * 3
         )
+
+        kernel.eval()
+        res = kernel(a, b).evaluate()
+        self.assertLess(torch.norm(res - actual), 2e-5)
+
+        kernel_1 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel_2 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel_3 = RBFKernel().initialize(lengthscale=lengthscale)
+        kernel = kernel_1 + (kernel_2 + kernel_3)
+        self.assertEqual(len(kernel.kernels), 3)
+        for sub_kernel in kernel.kernels:
+            self.assertIsInstance(sub_kernel, RBFKernel)
 
         kernel.eval()
         res = kernel(a, b).evaluate()
@@ -184,7 +257,7 @@ class TestAdditiveKernel(unittest.TestCase):
         kernel_1 = RBFKernel().initialize(lengthscale=lengthscale)
         kernel_2 = RBFKernel().initialize(lengthscale=lengthscale)
         kernel_3 = RBFKernel().initialize(lengthscale=lengthscale)
-        kernel = AdditiveKernel(kernel_1, kernel_2, kernel_3)
+        kernel = kernel_1 + kernel_2 + kernel_3
         kernel.eval()
 
         output = kernel(a, b).evaluate()


### PR DESCRIPTION
Current behavior:

```python
kernel_1 + kernel_2 + kernel_3
# Results in nested kernel structure
# AdditiveKernel(AdditiveKernel(kernel_1, kernel_2), kernel_3)
```

This PR flattens chained kernel addition and multiplication:

```python
kernel_1 + kernel_2 + kernel_3
# AdditiveKernel(kernel_1, kernel_2, kernel_3)
kernel_1 * kernel_2 * kernel_3
# ProductKernel(kernel_1, kernel_2, kernel_3)
```

[Fixes #1478]