### PR TITLE
Verbose mode logs expensive linalg routines

### DIFF
--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -456,6 +456,11 @@ class LazyTensor(ABC):
                 projected_mat = self._matmul(random_basis)
                 proj_q = torch.qr(projected_mat)
                 orthog_projected_mat = self._matmul(proj_q).transpose(-2, -1)
+                # Maybe log
+                if settings.verbose_linalg.on():
+                    settings.verbose_linalg.logger.debug(
+                        f"Running svd on a matrix of size {orthog_projected_mat.shape}."
+                    )
                 U, S, V = torch.svd(orthog_projected_mat)
                 U = proj_q.matmul(U)
 
@@ -1876,6 +1881,9 @@ class LazyTensor(ABC):
     def _symeig(self, eigenvectors: bool = False) -> Tuple[Tensor, Optional["LazyTensor"]]:
         """Method that allows implementing special-cased symeig computation. Should not be called directly"""
         from gpytorch.lazy.non_lazy_tensor import NonLazyTensor
+
+        if settings.verbose_linalg.on():
+            settings.verbose_linalg.logger.debug(f"Running symeig on a matrix of size {self.shape}.")
 
         dtype = self.dtype  # perform decomposition in double precision for numerical stability
         # TODO: Use fp64 registry once #1213 is addressed

--- a/gpytorch/priors/lkj_prior.py
+++ b/gpytorch/priors/lkj_prior.py
@@ -7,6 +7,7 @@ import torch
 from torch.distributions import constraints
 from torch.nn import Module as TModule
 
+from .. import settings
 from ..utils.cholesky import psd_safe_cholesky
 from .prior import Prior
 
@@ -153,6 +154,9 @@ def _is_valid_correlation_matrix(Sigma, tol=1e-6):
             mode, all matrices in the batch need to be valid correlation matrices)
 
     """
+    if settings.verbose_linalg.on():
+        settings.verbose_linalg.logger.debug(f"Running symeig on a matrix of size {Sigma.shape}.")
+
     evals, _ = torch.symeig(Sigma, eigenvectors=False)
     if not torch.all(evals >= -tol):
         return False

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import logging
 import warnings
 
 import torch
@@ -661,3 +662,16 @@ class use_toeplitz(_feature_flag):
     """
 
     _default = True
+
+
+class verbose(_feature_flag):
+    """
+    Print out information whenever running an expesnive linear algebra routine (e.g. Cholesky, CG, Lanczos, CIQ, etc.)
+    """
+
+    _default = False
+
+    def __init__(self, state=True):
+        super().__init__(state=state)
+        if state:
+            logging.basicConfig(level=logging.DEBUG)

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -664,14 +664,20 @@ class use_toeplitz(_feature_flag):
     _default = True
 
 
-class verbose(_feature_flag):
+class verbose_linalg(_feature_flag):
     """
     Print out information whenever running an expesnive linear algebra routine (e.g. Cholesky, CG, Lanczos, CIQ, etc.)
     """
 
     _default = False
 
-    def __init__(self, state=True):
-        super().__init__(state=state)
-        if state:
-            logging.basicConfig(level=logging.DEBUG)
+    # Create a global logger
+    logger = logging.getLogger("LinAlg (Verbose)")
+    logger.setLevel(logging.DEBUG)
+
+    # Output logging results to the stdout stream
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)

--- a/gpytorch/utils/cholesky.py
+++ b/gpytorch/utils/cholesky.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
 import warnings
 
 import torch
@@ -26,8 +25,8 @@ def psd_safe_cholesky(A, upper=False, out=None, jitter=None, max_tries=3):
             Number of attempts (with successively increasing jitter) to make before raising an error.
     """
     # Maybe log
-    if settings.verbose.on():
-        logging.debug(f"Running Cholesky on a matrix of size {A.shape}.")
+    if settings.verbose_linalg.on():
+        settings.verbose_linalg.logger.debug(f"Running Cholesky on a matrix of size {A.shape}.")
 
     try:
         L = torch.cholesky(A, upper=upper, out=out)

--- a/gpytorch/utils/cholesky.py
+++ b/gpytorch/utils/cholesky.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import logging
 import warnings
 
 import torch
@@ -24,6 +25,10 @@ def psd_safe_cholesky(A, upper=False, out=None, jitter=None, max_tries=3):
         :attr:`max_tries` (int, optional):
             Number of attempts (with successively increasing jitter) to make before raising an error.
     """
+    # Maybe log
+    if settings.verbose.on():
+        logging.debug(f"Running Cholesky on a matrix of size {A.shape}.")
+
     try:
         L = torch.cholesky(A, upper=upper, out=out)
         return L

--- a/gpytorch/utils/contour_integral_quad.py
+++ b/gpytorch/utils/contour_integral_quad.py
@@ -80,6 +80,9 @@ def contour_integral_quad(
         # Compute an approximate condition number
         # We'll do this with Lanczos
         try:
+            if settings.verbose_linalg.on():
+                settings.verbose_linalg.logger.debug(f"Running symeig on a matrix of size {lanczos_mat.shape}.")
+
             approx_eigs = lanczos_mat.symeig()[0]
             if approx_eigs.min() <= 0:
                 raise RuntimeError

--- a/gpytorch/utils/lanczos.py
+++ b/gpytorch/utils/lanczos.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import logging
+
 import torch
 
 from .. import settings
@@ -56,6 +58,11 @@ def lanczos_tridiag(
     # Define some constants
     num_iter = min(max_iter, matrix_shape[-1])
     dim_dimension = -2
+
+    if settings.verbose.on():
+        logging.debug(
+            f"Running Lanczos on a {matrix_shape} matrix with a {init_vecs.shape} RHS for {num_iter} iterations."
+        )
 
     # Create storage for q_mat, alpha,and beta
     # q_mat - batch version of Q - orthogonal matrix of decomp

--- a/gpytorch/utils/lanczos.py
+++ b/gpytorch/utils/lanczos.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
-
 import torch
 
 from .. import settings
@@ -59,8 +57,8 @@ def lanczos_tridiag(
     num_iter = min(max_iter, matrix_shape[-1])
     dim_dimension = -2
 
-    if settings.verbose.on():
-        logging.debug(
+    if settings.verbose_linalg.on():
+        settings.verbose_linalg.logger.debug(
             f"Running Lanczos on a {matrix_shape} matrix with a {init_vecs.shape} RHS for {num_iter} iterations."
         )
 

--- a/gpytorch/utils/lanczos.py
+++ b/gpytorch/utils/lanczos.py
@@ -166,6 +166,9 @@ def lanczos_tridiag_to_diag(t_mat):
     TODO: make the eigenvalue computations done in batch mode.
     """
     orig_device = t_mat.device
+    if settings.verbose_linalg.on():
+        settings.verbose_linalg.logger.debug(f"Running symeig on a matrix of size {t_mat.shape}.")
+
     if t_mat.size(-1) < 32:
         retr = torch.symeig(t_mat.cpu(), eigenvectors=True)
     else:

--- a/gpytorch/utils/linear_cg.py
+++ b/gpytorch/utils/linear_cg.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
 import warnings
 
 import torch
@@ -179,8 +178,8 @@ def linear_cg(
     result = initial_guess.expand_as(residual).contiguous()
 
     # Maybe log
-    if settings.verbose.on():
-        logging.debug(
+    if settings.verbose_linalg.on():
+        settings.verbose_linalg.logger.debug(
             f"Running CG on a {rhs.shape} RHS for {n_iter} iterations (tol={tolerance}). Output: {result.shape}."
         )
 

--- a/gpytorch/utils/linear_cg.py
+++ b/gpytorch/utils/linear_cg.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import logging
 import warnings
 
 import torch
@@ -176,6 +177,12 @@ def linear_cg(
 
     # result <- x_{0}
     result = initial_guess.expand_as(residual).contiguous()
+
+    # Maybe log
+    if settings.verbose.on():
+        logging.debug(
+            f"Running CG on a {rhs.shape} RHS for {n_iter} iterations (tol={tolerance}). Output: {result.shape}."
+        )
 
     # Check for NaNs
     if not torch.equal(residual, residual):

--- a/gpytorch/utils/minres.py
+++ b/gpytorch/utils/minres.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import logging
+
 import torch
 
 from .. import settings
@@ -105,6 +107,13 @@ def minres(matmul_closure, rhs, eps=1e-25, shifts=None, value=None, max_iter=Non
     # Terms for checking for convergence
     solution_norm = torch.zeros(*solution.shape[:-2], solution.size(-1), dtype=solution.dtype, device=solution.device)
     search_update_norm = torch.zeros_like(solution_norm)
+
+    # Maybe log
+    if settings.verbose.on():
+        logging.debug(
+            f"Running MINRES on a {rhs.shape} RHS for {max_iter} iterations (tol={settings.minres_tolerance.value()}). "
+            f"Output: {solution.shape}."
+        )
 
     # Perform iterations
     for i in range(max_iter + 2):

--- a/gpytorch/utils/minres.py
+++ b/gpytorch/utils/minres.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
-
 import torch
 
 from .. import settings
@@ -109,8 +107,8 @@ def minres(matmul_closure, rhs, eps=1e-25, shifts=None, value=None, max_iter=Non
     search_update_norm = torch.zeros_like(solution_norm)
 
     # Maybe log
-    if settings.verbose.on():
-        logging.debug(
+    if settings.verbose_linalg.on():
+        settings.verbose_linalg.logger.debug(
             f"Running MINRES on a {rhs.shape} RHS for {max_iter} iterations (tol={settings.minres_tolerance.value()}). "
             f"Output: {solution.shape}."
         )

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
-
 import torch
 
 from .. import settings
@@ -43,8 +41,10 @@ def pivoted_cholesky(matrix, max_iter, error_tol=None):
     ]
 
     # Maybe log
-    if settings.verbose.on():
-        logging.debug(f"Running Pivoted Cholesky on a {matrix.shape} RHS for {max_iter} iterations.")
+    if settings.verbose_linalg.on():
+        settings.verbose_linalg.logger.debug(
+            f"Running Pivoted Cholesky on a {matrix.shape} RHS for {max_iter} iterations."
+        )
 
     m = 0
     while (m == 0) or (m < max_iter and torch.max(errors) > error_tol):

--- a/gpytorch/utils/pivoted_cholesky.py
+++ b/gpytorch/utils/pivoted_cholesky.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import logging
+
 import torch
 
 from .. import settings
@@ -39,6 +41,10 @@ def pivoted_cholesky(matrix, max_iter, error_tol=None):
         .view(-1)
         for i, size in enumerate(batch_shape)
     ]
+
+    # Maybe log
+    if settings.verbose.on():
+        logging.debug(f"Running Pivoted Cholesky on a {matrix.shape} RHS for {max_iter} iterations.")
 
     m = 0
     while (m == 0) or (m < max_iter and torch.max(errors) > error_tol):


### PR DESCRIPTION
Whenever I debug, I'm always adding print statements to log CG/Cholesky/etc. calls. Seems like a useful tool to actually add to the library :)

```python
with gpytorch.settings.verbose(True):
    # Training and eval code
```

Produces the following output:

```sh
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
Iter 1/10 - Loss: 4.051 in 0.06775569915771484
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
Iter 2/10 - Loss: 3.862 in 0.06846332550048828
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
Iter 3/10 - Loss: 3.637 in 0.063079833984375
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
Iter 4/10 - Loss: 3.421 in 0.06230592727661133
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
Iter 5/10 - Loss: 3.213 in 0.06436872482299805
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
Iter 6/10 - Loss: 3.004 in 0.0612645149230957
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
Iter 7/10 - Loss: 2.796 in 0.06605362892150879
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
Iter 8/10 - Loss: 2.587 in 0.06762933731079102
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
Iter 9/10 - Loss: 2.377 in 0.060160160064697266
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
Iter 10/10 - Loss: 2.167 in 0.05991625785827637
GPyTorch training time 0.8552227020263672
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Pivoted Cholesky on a torch.Size([5, 4979, 4979]) RHS for 10 iterations.
DEBUG:root:Running Cholesky on a matrix of size torch.Size([5, 500, 500]).
DEBUG:root:Running Lanczos on a torch.Size([4979, 4979]) matrix with a torch.Size([5, 4979, 1]) RHS for 30 iterations.
predict torch.Size([5, 11620, 18]) in 0.16702032089233398
predict 2nd time torch.Size([5, 11620, 18]) in 0.0020859241485595703
Test MAE: 0.08435824513435364
predict single point torch.Size([5, 18]) in 0.0018382072448730469
```
