### PR TITLE
Faster SGPR predictions, PredictionStrategy bug fixes

### DIFF
--- a/examples/02_Scalable_Exact_GPs/SGPR_Regression_CUDA.ipynb
+++ b/examples/02_Scalable_Exact_GPs/SGPR_Regression_CUDA.ipynb
@@ -264,8 +264,7 @@
     "model.eval()\n",
     "likelihood.eval()\n",
     "with gpytorch.settings.max_preconditioner_size(10), torch.no_grad():\n",
-    "    with gpytorch.settings.max_root_decomposition_size(30), gpytorch.settings.fast_pred_var():\n",
-    "        preds = model(test_x)"
+    "    preds = model(test_x)"
    ]
   },
   {

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -10,7 +10,7 @@ from torch.nn import ModuleList
 from .. import settings
 from ..constraints import Positive
 from ..lazy import LazyEvaluatedKernelTensor, ZeroLazyTensor, delazify, lazify
-from ..models.exact_prediction_strategies import DefaultPredictionStrategy, SumPredictionStrategy
+from ..models import exact_prediction_strategies
 from ..module import Module
 from ..utils.broadcasting import _mul_broadcast_shape
 
@@ -345,7 +345,9 @@ class Kernel(Module):
         return 1
 
     def prediction_strategy(self, train_inputs, train_prior_dist, train_labels, likelihood):
-        return DefaultPredictionStrategy(train_inputs, train_prior_dist, train_labels, likelihood)
+        return exact_prediction_strategies.DefaultPredictionStrategy(
+            train_inputs, train_prior_dist, train_labels, likelihood
+        )
 
     def sub_kernels(self):
         for _, kernel in self.named_sub_kernels():
@@ -469,7 +471,9 @@ class AdditiveKernel(Kernel):
         return res
 
     def prediction_strategy(self, train_inputs, train_prior_dist, train_labels, likelihood):
-        return SumPredictionStrategy(train_inputs, train_prior_dist, train_labels, likelihood)
+        return exact_prediction_strategies.SumPredictionStrategy(
+            train_inputs, train_prior_dist, train_labels, likelihood
+        )
 
     def num_outputs_per_input(self, x1, x2):
         return self.kernels[0].num_outputs_per_input(x1, x2)

--- a/gpytorch/kernels/scale_kernel.py
+++ b/gpytorch/kernels/scale_kernel.py
@@ -102,3 +102,6 @@ class ScaleKernel(Kernel):
 
     def num_outputs_per_input(self, x1, x2):
         return self.base_kernel.num_outputs_per_input(x1, x2)
+
+    def prediction_strategy(self, train_inputs, train_prior_dist, train_labels, likelihood):
+        return self.base_kernel.prediction_strategy(train_inputs, train_prior_dist, train_labels, likelihood)

--- a/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
@@ -36,6 +36,9 @@ class LowRankRootAddedDiagLazyTensor(AddedDiagLazyTensor):
 
         return chol_cap_mat
 
+    def _inv_matmul_preconditioner(self):
+        return None
+
     def _mul_constant(self, constant):
         # We have to over-ride this here for the case where the constant is negative
         if constant > 0:

--- a/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
@@ -36,6 +36,19 @@ class LowRankRootAddedDiagLazyTensor(AddedDiagLazyTensor):
 
         return chol_cap_mat
 
+    def _mul_constant(self, constant):
+        # We have to over-ride this here for the case where the constant is negative
+        if constant > 0:
+            res = super()._mul_constant(constant)
+        else:
+            res = AddedDiagLazyTensor(
+                self._lazy_tensor._mul_constant(constant), self._diag_tensor._mul_constant(constant)
+            )
+        return res
+
+    def _preconditioner(self):
+        return None, None, None
+
     def _solve(self, rhs, preconditioner=None, num_tridiag=0):
         A_inv = self._diag_tensor.inverse()  # This is fine since it's a DiagLazyTensor
         U = self._lazy_tensor.root

--- a/gpytorch/lazy/mul_lazy_tensor.py
+++ b/gpytorch/lazy/mul_lazy_tensor.py
@@ -63,8 +63,14 @@ class MulLazyTensor(LazyTensor):
         res = res.squeeze(-1) if is_vector else res
         return res
 
-    def _mul_constant(self, other):
-        return self.__class__(self.left_lazy_tensor._mul_constant(other), self.right_lazy_tensor)
+    def _mul_constant(self, constant):
+        if constant > 0:
+            res = self.__class__(self.left_lazy_tensor._mul_constant(constant), self.right_lazy_tensor)
+        else:
+            # Negative constants can screw up the root_decomposition
+            # So we'll do a standard _mul_constant
+            res = super()._mul_constant(constant)
+        return res
 
     def _quad_form_derivative(self, left_vecs, right_vecs):
         if left_vecs.ndimension() == 1:

--- a/gpytorch/lazy/sum_lazy_tensor.py
+++ b/gpytorch/lazy/sum_lazy_tensor.py
@@ -39,6 +39,10 @@ class SumLazyTensor(LazyTensor):
     def _matmul(self, rhs):
         return sum(lazy_tensor._matmul(rhs) for lazy_tensor in self.lazy_tensors)
 
+    def _mul_constant(self, other):
+        # We're using a custom method here - the constant mul is applied to the base_lazy_tensors
+        return self.__class__(*[lt._mul_constant(other) for lt in self.lazy_tensors])
+
     def _quad_form_derivative(self, left_vecs, right_vecs):
         return tuple(
             var for lazy_tensor in self.lazy_tensors for var in lazy_tensor._quad_form_derivative(left_vecs, right_vecs)

--- a/gpytorch/models/__init__.py
+++ b/gpytorch/models/__init__.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-from . import deep_gps, pyro
+from . import deep_gps, exact_prediction_strategies, pyro
 from .approximate_gp import ApproximateGP
 from .exact_gp import ExactGP
 from .gp import GP
@@ -38,5 +38,6 @@ __all__ = [
     "PyroGP",
     "VariationalGP",
     "deep_gps",
+    "exact_prediction_strategies",
     "pyro",
 ]

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -35,9 +35,14 @@ def prediction_strategy(train_inputs, train_prior_dist, train_labels, likelihood
 
 class DefaultPredictionStrategy(object):
     def __init__(self, train_inputs, train_prior_dist, train_labels, likelihood, root=None, inv_root=None):
+        # Get training shape
+        self._train_shape = train_prior_dist.event_shape
+        # Ensure that the event_shape actually matches the number of inputs
+        if self._train_shape[0] != train_inputs[0].size(-2):
+            self._train_shape = torch.Size([train_inputs[0].size(-2), *self._train_shape[1:]])
+
         # Flatten the training labels
-        train_shape = train_prior_dist.event_shape
-        train_labels = train_labels.reshape(*train_labels.shape[: -len(train_shape)], train_shape.numel())
+        train_labels = train_labels.reshape(*train_labels.shape[: -len(self.train_shape)], self.num_train)
 
         self.train_inputs = train_inputs
         self.train_prior_dist = train_prior_dist
@@ -295,11 +300,11 @@ class DefaultPredictionStrategy(object):
 
     @property
     def num_train(self):
-        return self.train_prior_dist.event_shape.numel()
+        return self._train_shape.numel()
 
     @property
     def train_shape(self):
-        return self.train_prior_dist.event_shape
+        return self._train_shape
 
     def exact_prediction(self, joint_mean, joint_covar):
         # Find the components of the distribution that contain test data

--- a/test/examples/test_rff_gp_regression.py
+++ b/test/examples/test_rff_gp_regression.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import os
+import random
+import unittest
+import warnings
+from math import pi
+
+import gpytorch
+import torch
+from gpytorch.distributions import MultivariateNormal
+from gpytorch.kernels import RFFKernel, ScaleKernel
+from gpytorch.likelihoods import GaussianLikelihood
+from gpytorch.means import ConstantMean
+from gpytorch.priors import SmoothedBoxPrior
+from gpytorch.utils.warnings import NumericalWarning
+from torch import optim
+
+
+# Simple training data: let's try to learn a sine function,
+# let's use 100 training examples.
+def make_data(cuda=False):
+    train_x = torch.linspace(0, 1, 100)
+    train_y = torch.sin(train_x * (2 * pi))
+    train_y.add_(torch.randn_like(train_y), alpha=1e-2)
+    test_x = torch.rand(51)
+    test_y = torch.sin(test_x * (2 * pi))
+    if cuda:
+        train_x = train_x.cuda()
+        train_y = train_y.cuda()
+        test_x = test_x.cuda()
+        test_y = test_y.cuda()
+    return train_x, train_y, test_x, test_y
+
+
+class GPRegressionModel(gpytorch.models.ExactGP):
+    def __init__(self, train_x, train_y, likelihood):
+        super(GPRegressionModel, self).__init__(train_x, train_y, likelihood)
+        self.mean_module = ConstantMean(prior=SmoothedBoxPrior(-1e-5, 1e-5))
+        self.covar_module = ScaleKernel(RFFKernel(num_samples=10))
+
+    def forward(self, x):
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
+        return MultivariateNormal(mean_x, covar_x)
+
+
+class TestRFFRegression(unittest.TestCase):
+    def setUp(self):
+        if os.getenv("UNLOCK_SEED") is None or os.getenv("UNLOCK_SEED").lower() == "false":
+            self.rng_state = torch.get_rng_state()
+            torch.manual_seed(0)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(0)
+            random.seed(0)
+
+    def tearDown(self):
+        if hasattr(self, "rng_state"):
+            torch.set_rng_state(self.rng_state)
+
+    def test_rff_mean_abs_error(self):
+        # Suppress numerical warnings
+        warnings.simplefilter("ignore", NumericalWarning)
+
+        train_x, train_y, test_x, test_y = make_data()
+        likelihood = GaussianLikelihood()
+        gp_model = GPRegressionModel(train_x, train_y, likelihood)
+        mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, gp_model)
+
+        # Optimize the model
+        gp_model.train()
+        likelihood.train()
+
+        optimizer = optim.Adam(gp_model.parameters(), lr=0.1)
+        for _ in range(30):
+            optimizer.zero_grad()
+            output = gp_model(train_x)
+            loss = -mll(output, train_y)
+            loss.backward()
+            optimizer.step()
+
+            # Check that we have the right LazyTensor type
+            kernel = likelihood(gp_model(train_x)).lazy_covariance_matrix.evaluate_kernel()
+            self.assertIsInstance(kernel, gpytorch.lazy.LowRankRootAddedDiagLazyTensor)
+
+        for param in gp_model.parameters():
+            self.assertTrue(param.grad is not None)
+            self.assertGreater(param.grad.norm().item(), 0)
+
+        # Test the model
+        gp_model.eval()
+        likelihood.eval()
+
+        test_preds = likelihood(gp_model(test_x)).mean
+        mean_abs_error = torch.mean(torch.abs(test_y - test_preds))
+
+        self.assertLess(mean_abs_error.squeeze().item(), 0.05)

--- a/test/kernels/test_inducing_point_kernel.py
+++ b/test/kernels/test_inducing_point_kernel.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+import gpytorch
+from gpytorch.kernels import InducingPointKernel, RBFKernel, ScaleKernel
+
+
+class TestModel(gpytorch.models.ExactGP):
+    def __init__(self, train_x, train_y):
+        likelihood = gpytorch.likelihoods.GaussianLikelihood()
+        super().__init__(train_x, train_y, likelihood)
+        self.mean_module = gpytorch.means.ZeroMean()
+        self.covar_module = InducingPointKernel(
+            ScaleKernel(RBFKernel(ard_num_dims=3)), inducing_points=torch.randn(512, 3), likelihood=likelihood,
+        )
+
+    def forward(self, input):
+        mean = self.mean_module(input)
+        covar = self.covar_module(input)
+        return gpytorch.distributions.MultivariateNormal(mean, covar)
+
+
+class TestInducingPointKernel(unittest.TestCase):
+    def test_kernel_output(self):
+        train_x = torch.randn(1000, 3)
+        train_y = torch.randn(1000)
+        test_x = torch.randn(500, 3)
+        model = TestModel(train_x, train_y)
+
+        # Make sure that the prior kernel is the correct type
+        model.train()
+        output = model(train_x).lazy_covariance_matrix.evaluate_kernel()
+        self.assertIsInstance(output, gpytorch.lazy.LowRankRootLazyTensor)
+
+        # Make sure that the prior predictive kernel is the correct type
+        model.train()
+        output = model.likelihood(model(train_x)).lazy_covariance_matrix.evaluate_kernel()
+        self.assertIsInstance(output, gpytorch.lazy.LowRankRootAddedDiagLazyTensor)
+
+        # Make sure we're calling the correct prediction strategy
+        _wrapped_ps = MagicMock(wraps=gpytorch.models.exact_prediction_strategies.SGPRPredictionStrategy)
+        with patch("gpytorch.models.exact_prediction_strategies.SGPRPredictionStrategy", new=_wrapped_ps) as ps_mock:
+            model.eval()
+            output = model.likelihood(model(test_x))
+            _ = output.mean + output.variance  # Compute something to break through any lazy evaluations
+            self.assertTrue(ps_mock.called)

--- a/test/kernels/test_rff_kernel.py
+++ b/test/kernels/test_rff_kernel.py
@@ -15,7 +15,7 @@ class TestModel(gpytorch.models.ExactGP):
         likelihood = gpytorch.likelihoods.GaussianLikelihood()
         super().__init__(train_x, train_y, likelihood)
         self.mean_module = gpytorch.means.ZeroMean()
-        self.covar_module = gpytorch.kernels.ScaleKernel(RFFKernel(num_samples=100))
+        self.covar_module = gpytorch.kernels.ScaleKernel(RFFKernel(num_samples=50))
 
     def forward(self, input):
         mean = self.mean_module(input)
@@ -24,6 +24,8 @@ class TestModel(gpytorch.models.ExactGP):
 
 
 class TestRFFKernel(unittest.TestCase, BaseKernelTestCase):
+    seed = 0
+
     def create_kernel_no_ard(self, **kwargs):
         return RFFKernel(num_samples=5, **kwargs)
 

--- a/test/kernels/test_rff_kernel.py
+++ b/test/kernels/test_rff_kernel.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -14,7 +15,7 @@ class TestModel(gpytorch.models.ExactGP):
         likelihood = gpytorch.likelihoods.GaussianLikelihood()
         super().__init__(train_x, train_y, likelihood)
         self.mean_module = gpytorch.means.ZeroMean()
-        self.covar_module = gpytorch.kernels.ScaleKernel(RFFKernel(num_samples=5))
+        self.covar_module = gpytorch.kernels.ScaleKernel(RFFKernel(num_samples=100))
 
     def forward(self, input):
         mean = self.mean_module(input)
@@ -79,10 +80,52 @@ class TestRFFKernel(unittest.TestCase, BaseKernelTestCase):
 
         self.assertLess(torch.norm(res1 - res2) / res1.norm(), 1e-4)
 
-    def test_kernel_output(self):
+    def test_kernel_output_fewer_features_than_data(self):
         train_x = torch.randn(1000, 3)
         train_y = torch.randn(1000)
+        test_x = torch.randn(500, 3)
         model = TestModel(train_x, train_y)
+
+        # Make sure that the prior kernel is the correct type
+        model.train()
+        output = model(train_x).lazy_covariance_matrix.evaluate_kernel()
+        self.assertIsInstance(output, gpytorch.lazy.LowRankRootLazyTensor)
+
+        # Make sure that the prior predictive kernel is the correct type
         model.train()
         output = model.likelihood(model(train_x)).lazy_covariance_matrix.evaluate_kernel()
         self.assertIsInstance(output, gpytorch.lazy.LowRankRootAddedDiagLazyTensor)
+
+        # Make sure we're calling the correct prediction strategy
+        _wrapped_ps = MagicMock(wraps=gpytorch.models.exact_prediction_strategies.RFFPredictionStrategy)
+        with patch("gpytorch.models.exact_prediction_strategies.RFFPredictionStrategy", new=_wrapped_ps) as ps_mock:
+            model.eval()
+            output = model.likelihood(model(test_x))
+            _ = output.mean + output.variance  # Compute something to break through any lazy evaluations
+            self.assertTrue(ps_mock.called)
+
+    def test_kernel_output_more_features_than_data(self):
+        train_x = torch.randn(50, 3)
+        train_y = torch.randn(50)
+        test_x = torch.randn(500, 3)
+        model = TestModel(train_x, train_y)
+
+        # Make sure that the prior kernel is the correct type
+        model.train()
+        output = model(train_x).lazy_covariance_matrix.evaluate_kernel()
+        self.assertIsInstance(output, gpytorch.lazy.RootLazyTensor)
+        self.assertNotIsInstance(output, gpytorch.lazy.LowRankRootLazyTensor)
+
+        # Make sure that the prior predictive kernel is the correct type
+        model.train()
+        output = model.likelihood(model(train_x)).lazy_covariance_matrix.evaluate_kernel()
+        self.assertIsInstance(output, gpytorch.lazy.AddedDiagLazyTensor)
+        self.assertNotIsInstance(output, gpytorch.lazy.LowRankRootAddedDiagLazyTensor)
+
+        # Make sure we're calling the correct prediction strategy
+        _wrapped_ps = MagicMock(wraps=gpytorch.models.exact_prediction_strategies.RFFPredictionStrategy)
+        with patch("gpytorch.models.exact_prediction_strategies.RFFPredictionStrategy", new=_wrapped_ps) as ps_mock:
+            model.eval()
+            output = model.likelihood(model(test_x))
+            _ = output.mean + output.variance  # Compute something to break through any lazy evaluations
+            self.assertTrue(ps_mock.called)


### PR DESCRIPTION
- Add a SGPRPredictionStrategy to improve SGPR prediction speed [Fixes #1459]
- Ensure that we're not making any unnecessary preconditioner calls for LowRankRootAddedDiagLazyTensor
- Make sure RFFPredictionStrategy is used in conjunction with ScaleKernel (it was being ignored - now there's unit tests to make sure it's used)
- Improve SumPredictionStrategy, and ensure it is used in conjunction with ScaleKernel