### PR TITLE
Add a base sample shape property to MultivariateNormal

### DIFF
--- a/gpytorch/distributions/multitask_multivariate_normal.py
+++ b/gpytorch/distributions/multitask_multivariate_normal.py
@@ -63,6 +63,15 @@ class MultitaskMultivariateNormal(MultivariateNormal):
         super().__init__(mean=mean_mvn, covariance_matrix=covariance_matrix, validate_args=validate_args)
 
     @property
+    def base_sample_shape(self):
+        """
+        Returns the shape of a base sample (without batching) that is used to
+        generate a single sample.
+        """
+        base_sample_shape = self.event_shape
+        return base_sample_shape
+
+    @property
     def event_shape(self):
         return self._output_shape[-2:]
 

--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -128,8 +128,7 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
         """
         base_sample_shape = self.event_shape
         if isinstance(self.lazy_covariance_matrix, RootLazyTensor):
-            if self.lazy_covariance_matrix.root.shape[-1] > self.lazy_covariance_matrix.root.shape[-2]:
-                base_sample_shape = self.lazy_covariance_matrix.root.shape[-1:]
+            base_sample_shape = self.lazy_covariance_matrix.root.shape[-1:]
 
         return base_sample_shape
 

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -38,12 +38,9 @@ class DefaultPredictionStrategy(object):
     def __init__(self, train_inputs, train_prior_dist, train_labels, likelihood, root=None, inv_root=None):
         # Get training shape
         self._train_shape = train_prior_dist.event_shape
-        # Ensure that the event_shape actually matches the number of inputs
-        if self._train_shape[0] != train_inputs[0].size(-2):
-            self._train_shape = torch.Size([train_inputs[0].size(-2), *self._train_shape[1:]])
 
         # Flatten the training labels
-        train_labels = train_labels.reshape(*train_labels.shape[: -len(self.train_shape)], self.num_train)
+        train_labels = train_labels.reshape(*train_labels.shape[: -len(self.train_shape)], self._train_shape.numel())
 
         self.train_inputs = train_inputs
         self.train_prior_dist = train_prior_dist

--- a/test/distributions/test_multivariate_normal.py
+++ b/test/distributions/test_multivariate_normal.py
@@ -7,7 +7,7 @@ import torch
 from torch.distributions import MultivariateNormal as TMultivariateNormal
 
 from gpytorch.distributions import MultivariateNormal
-from gpytorch.lazy import DiagLazyTensor, LazyTensor, NonLazyTensor
+from gpytorch.lazy import DiagLazyTensor, LazyTensor, NonLazyTensor, RootLazyTensor, lazify
 from gpytorch.test.base_test_case import BaseTestCase
 from gpytorch.test.utils import least_used_cuda_device
 
@@ -295,6 +295,18 @@ class TestMultivariateNormal(BaseTestCase, unittest.TestCase):
         d = dist[1, 2, 2, ...]
         assert torch.equal(d.mean, dist.mean[1, 2, 2, :])
         self.assertAllClose(d.covariance_matrix, dist_cov[1, 2, 2, :, :])
+
+    def test_base_sample_shape(self):
+        a = torch.randn(5, 10)
+        lazy_square_a = RootLazyTensor(lazify(a))
+        dist = MultivariateNormal(torch.zeros(5), lazy_square_a)
+
+        # check that providing the base samples is okay
+        samples = dist.rsample(torch.Size((16,)), base_samples=torch.randn(16, 10))
+        self.assertEqual(samples.shape, torch.Size((16, 5)))
+
+        # check that an event shape of base samples fails
+        self.assertRaises(RuntimeError, dist.rsample, torch.Size((16,)), base_samples=torch.randn(16, 5))
 
 
 if __name__ == "__main__":

--- a/test/distributions/test_multivariate_normal.py
+++ b/test/distributions/test_multivariate_normal.py
@@ -308,6 +308,14 @@ class TestMultivariateNormal(BaseTestCase, unittest.TestCase):
         # check that an event shape of base samples fails
         self.assertRaises(RuntimeError, dist.rsample, torch.Size((16,)), base_samples=torch.randn(16, 5))
 
+        # check that the proper event shape of base samples is okay for
+        # a non root lt
+        nonlazy_square_a = lazify(lazy_square_a.evaluate())
+        dist = MultivariateNormal(torch.zeros(5), nonlazy_square_a)
+
+        samples = dist.rsample(torch.Size((16,)), base_samples=torch.randn(16, 5))
+        self.assertEqual(samples.shape, torch.Size((16, 5)))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds a base sample shape property to MultivariateNormal. I should have just added this in #1355 instead of the fix I did. I checked and it resolves the failing unit test in botorch (botorch/models/test_higher_order_gp.py), but botorch will need another PR to properly use the base_sample_shape property in its samplers.