### PR TITLE
Update default value latent_dim in LMC

### DIFF
--- a/gpytorch/variational/lmc_variational_strategy.py
+++ b/gpytorch/variational/lmc_variational_strategy.py
@@ -78,7 +78,7 @@ class LMCVariationalStrategy(_VariationalStrategy):
     """
 
     def __init__(
-        self, base_variational_strategy, num_tasks, num_latents=1, latent_dim=0,
+        self, base_variational_strategy, num_tasks, num_latents=1, latent_dim=-1,
     ):
         Module.__init__(self)
         self.base_variational_strategy = base_variational_strategy


### PR DESCRIPTION
Currently the default value for `latent_dim` always crashes. This updates it to be in line with what the documentation promises.