### PR TITLE
Use Gauss Hermite Locs value in init body

### DIFF
--- a/gpytorch/utils/quadrature.py
+++ b/gpytorch/utils/quadrature.py
@@ -20,8 +20,10 @@ class GaussHermiteQuadrature1D(Module):
     should initialize one time, but that should obey parent calls to .cuda(), .double() etc.
     """
 
-    def __init__(self, num_locs=settings.num_gauss_hermite_locs.value()):
+    def __init__(self, num_locs=None):
         super().__init__()
+        if num_locs is None:
+            num_locs = settings.num_gauss_hermite_locs.value()
         self.num_locs = num_locs
 
         locations, weights = self._locs_and_weights(num_locs)


### PR DESCRIPTION
Easy resolution to #1509, must have been something with the global state in the initialization.

```python
from gpytorch.utils.quadrature import GaussHermiteQuadrature1D
from gpytorch.settings import num_gauss_hermite_locs

with num_gauss_hermite_locs(25):
    quadrature = GaussHermiteQuadrature1D()
    print(num_gauss_hermite_locs._global_value) # 25
    print(num_gauss_hermite_locs.value()) # 25
    print(quadrature.num_locs) # 25
```

It's still sort of weird behavior to have to call the setting on the likelihood init but at least you can change it now.
```python
with num_gauss_hermite_locs(25):
    likelihood = Likelihood()
```