### PR TITLE
Fixes for MultitaskGaussianLikelihood setters

### DIFF
--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -15,6 +15,7 @@ from ..lazy import (
     RootLazyTensor,
 )
 from ..likelihoods import Likelihood, _GaussianLikelihoodBase
+from ..utils.pivoted_cholesky import pivoted_cholesky
 
 
 class _MultitaskGaussianLikelihoodBase(_GaussianLikelihoodBase):
@@ -185,7 +186,8 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
                     name="raw_task_noises", parameter=torch.nn.Parameter(torch.zeros(*batch_shape, num_tasks))
                 )
                 self.register_constraint("raw_task_noises", noise_constraint)
-                self.register_prior("raw_task_noises_prior", noise_prior, lambda m: m.task_noises)
+                if noise_prior is not None:
+                    self.register_prior("raw_task_noises_prior", noise_prior, lambda m: m.task_noises)
                 if task_prior is not None:
                     raise RuntimeError("Cannot set a `task_prior` if rank=0")
             else:
@@ -201,7 +203,8 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
         if has_global_noise:
             self.register_parameter(name="raw_noise", parameter=torch.nn.Parameter(torch.zeros(*batch_shape, 1)))
             self.register_constraint("raw_noise", noise_constraint)
-            self.register_prior("raw_noise_prior", noise_prior, lambda m: m.noise)
+            if noise_prior is not None:
+                self.register_prior("raw_noise_prior", noise_prior, lambda m: m.noise)
 
         self.has_global_noise = has_global_noise
         self.has_task_noise = has_task_noise
@@ -216,10 +219,37 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
 
     @property
     def task_noises(self):
-        return self.raw_task_noises_constraint.transform(self.raw_task_noises)
+        if self.rank == 0:
+            return self.raw_task_noises_constraint.transform(self.raw_task_noises)
+        else:
+            raise AttributeError("Cannot set diagonal task noises when covariance has ", self.rank, ">0")
+
+    @task_noises.setter
+    def task_noises(self, value):
+        if self.rank == 0:
+            self._set_task_noises(value)
+        else:
+            raise AttributeError("Cannot set diagonal task noises when covariance has ", self.rank, ">0")
 
     def _set_noise(self, value):
         self.initialize(raw_noise=self.raw_noise_constraint.inverse_transform(value))
+
+    def _set_task_noises(self, value):
+        self.initialize(raw_task_noises=self.raw_task_noises_constraint.inverse_transform(value))
+
+    @property
+    def task_noise_covar(self):
+        if self.rank > 0:
+            return self.task_noise_covar_factor.matmul(self.task_noise_covar_factor.transpose(-1, -2))
+        else:
+            raise AttributeError("Cannot retrieve task noises when covariance is diagonal.")
+
+    @task_noise_covar.setter
+    def task_noise_covar(self, value):
+        if self.rank > 0:
+            self.task_noise_covar_factor.data = pivoted_cholesky(value, max_iter=self.rank)
+        else:
+            raise AttributeError("Cannot set non-diagonal task noises when covariance is diagonal.")
 
     def _eval_covar_matrix(self):
         covar_factor = self.task_noise_covar_factor

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -246,6 +246,8 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
 
     @task_noise_covar.setter
     def task_noise_covar(self, value):
+        # internally uses a pivoted cholesky decomposition to construct a low rank
+        # approximation of the covariance
         if self.rank > 0:
             self.task_noise_covar_factor.data = pivoted_cholesky(value, max_iter=self.rank)
         else:

--- a/test/likelihoods/test_multitask_gaussian_likelihood.py
+++ b/test/likelihoods/test_multitask_gaussian_likelihood.py
@@ -33,7 +33,7 @@ class TestMultitaskGaussianLikelihood(BaseLikelihoodTestCase, unittest.TestCase)
 
         # test rank 0 setters
         likelihood.noise = 0.5
-        self.assertEqual(0.5, likelihood.noise.item())
+        self.assertAlmostEqual(0.5, likelihood.noise.item())
 
         likelihood.task_noises = torch.tensor([0.04, 0.04, 0.04])
         for i in range(3):
@@ -42,7 +42,7 @@ class TestMultitaskGaussianLikelihood(BaseLikelihoodTestCase, unittest.TestCase)
         # test low rank setters
         likelihood = MultitaskGaussianLikelihood(num_tasks=3, rank=2)
         likelihood.noise = 0.5
-        self.assertEqual(0.5, likelihood.noise.item())
+        self.assertAlmostEqual(0.5, likelihood.noise.item())
 
         a = torch.randn(3, 2)
         mat = a.matmul(a.transpose(-1, -2))

--- a/test/likelihoods/test_multitask_gaussian_likelihood.py
+++ b/test/likelihoods/test_multitask_gaussian_likelihood.py
@@ -28,6 +28,27 @@ class TestMultitaskGaussianLikelihood(BaseLikelihoodTestCase, unittest.TestCase)
     def create_likelihood(self):
         return MultitaskGaussianLikelihood(num_tasks=4, rank=2)
 
+    def test_setters(self):
+        likelihood = MultitaskGaussianLikelihood(num_tasks=3, rank=0)
+
+        # test rank 0 setters
+        likelihood.noise = 0.5
+        self.assertEqual(0.5, likelihood.noise.item())
+
+        likelihood.task_noises = torch.tensor([0.04, 0.04, 0.04])
+        for i in range(3):
+            self.assertAlmostEqual(0.04, likelihood.task_noises[i].item())
+
+        # test low rank setters
+        likelihood = MultitaskGaussianLikelihood(num_tasks=3, rank=2)
+        likelihood.noise = 0.5
+        self.assertEqual(0.5, likelihood.noise.item())
+
+        a = torch.randn(3, 2)
+        mat = a.matmul(a.transpose(-1, -2))
+        likelihood.task_noise_covar = mat
+        self.assertAllClose(mat, likelihood.task_noise_covar)
+
 
 class TestMultitaskGaussianLikelihoodBatch(TestMultitaskGaussianLikelihood):
     seed = 0

--- a/test/likelihoods/test_multitask_gaussian_likelihood.py
+++ b/test/likelihoods/test_multitask_gaussian_likelihood.py
@@ -31,6 +31,9 @@ class TestMultitaskGaussianLikelihood(BaseLikelihoodTestCase, unittest.TestCase)
     def test_setters(self):
         likelihood = MultitaskGaussianLikelihood(num_tasks=3, rank=0)
 
+        a = torch.randn(3, 2)
+        mat = a.matmul(a.transpose(-1, -2))
+
         # test rank 0 setters
         likelihood.noise = 0.5
         self.assertAlmostEqual(0.5, likelihood.noise.item())
@@ -39,15 +42,21 @@ class TestMultitaskGaussianLikelihood(BaseLikelihoodTestCase, unittest.TestCase)
         for i in range(3):
             self.assertAlmostEqual(0.04, likelihood.task_noises[i].item())
 
+        with self.assertRaises(AttributeError) as context:
+            likelihood.task_noise_covar = mat
+        self.assertTrue("task noises" in str(context.exception))
+
         # test low rank setters
         likelihood = MultitaskGaussianLikelihood(num_tasks=3, rank=2)
         likelihood.noise = 0.5
         self.assertAlmostEqual(0.5, likelihood.noise.item())
 
-        a = torch.randn(3, 2)
-        mat = a.matmul(a.transpose(-1, -2))
         likelihood.task_noise_covar = mat
         self.assertAllClose(mat, likelihood.task_noise_covar)
+
+        with self.assertRaises(AttributeError) as context:
+            likelihood.task_noises = torch.tensor([0.04, 0.04, 0.04])
+        self.assertTrue("task noises" in str(context.exception))
 
 
 class TestMultitaskGaussianLikelihoodBatch(TestMultitaskGaussianLikelihood):


### PR DESCRIPTION
Resolution for #1516. I should have written better unit tests for these in the first place, but you can now do the following:
```python
from gpytorch.likelihoods import MultitaskGaussianLikelihood

likelihood = MultitaskGaussianLikelihood(rank=0, num_tasks=3)
likelihood.noise = 0.5
likelihood.task_noises = torch.tensor([0.04, 0.04, 0.04])

likelihood = MultitaskGaussianLikelihood(rank=2, num_tasks=5)
likelihood.noise = 0.5

a = torch.randn(5, 3)
m = a.matmul(a.transpose(-1, -2))
likelihood.task_noise_covar = m # does a pivoted cholesky of num_rank steps
```

