### PR TITLE
More explicit prior shape broadcasting

### DIFF
--- a/gpytorch/kernels/arc_kernel.py
+++ b/gpytorch/kernels/arc_kernel.py
@@ -121,24 +121,24 @@ class ArcKernel(Kernel):
         self.register_parameter(
             name="raw_angle", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, self.last_dim)),
         )
+        self.register_constraint("raw_angle", angle_constraint)
+
         if angle_prior is not None:
             self.register_prior(
                 "angle_prior", angle_prior, lambda: self.angle, lambda v: self._set_angle(v),
             )
 
-        self.register_constraint("raw_angle", angle_constraint)
-
         self.register_parameter(
             name="raw_radius", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, self.last_dim)),
         )
+        radius_constraint = Positive()
+        self.register_constraint("raw_radius", radius_constraint)
 
         if radius_prior is not None:
             self.register_prior(
                 "radius_prior", radius_prior, lambda: self.radius, lambda v: self._set_radius(v),
             )
 
-        radius_constraint = Positive()
-        self.register_constraint("raw_radius", radius_constraint)
 
         self.base_kernel = base_kernel
         if self.base_kernel.has_lengthscale:

--- a/gpytorch/kernels/cosine_kernel.py
+++ b/gpytorch/kernels/cosine_kernel.py
@@ -65,6 +65,7 @@ class CosineKernel(Kernel):
 
         if period_length_constraint is None:
             period_length_constraint = Positive()
+        self.register_constraint("raw_period_length", period_length_constraint)
 
         if period_length_prior is not None:
             self.register_prior(
@@ -74,7 +75,6 @@ class CosineKernel(Kernel):
                 lambda v: self._set_period_length(v),
             )
 
-        self.register_constraint("raw_period_length", period_length_constraint)
 
     @property
     def period_length(self):

--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -53,10 +53,11 @@ class IndexKernel(Kernel):
             name="covar_factor", parameter=torch.nn.Parameter(torch.randn(*self.batch_shape, num_tasks, rank))
         )
         self.register_parameter(name="raw_var", parameter=torch.nn.Parameter(torch.randn(*self.batch_shape, num_tasks)))
+        self.register_constraint("raw_var", var_constraint)
+
         if prior is not None:
             self.register_prior("IndexKernelPrior", prior, self._eval_covar_matrix)
 
-        self.register_constraint("raw_var", var_constraint)
 
     @property
     def var(self):

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -166,12 +166,13 @@ class Kernel(Module):
                 name="raw_lengthscale",
                 parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, lengthscale_num_dims)),
             )
+            self.register_constraint("raw_lengthscale", lengthscale_constraint)
+
             if lengthscale_prior is not None:
                 self.register_prior(
                     "lengthscale_prior", lengthscale_prior, lambda: self.lengthscale, lambda v: self._set_lengthscale(v)
                 )
 
-            self.register_constraint("raw_lengthscale", lengthscale_constraint)
 
         self.distance_module = None
         # TODO: Remove this on next official PyTorch release.

--- a/gpytorch/kernels/linear_kernel.py
+++ b/gpytorch/kernels/linear_kernel.py
@@ -57,12 +57,12 @@ class LinearKernel(Kernel):
             # Remove after 1.0
             warnings.warn("The `offset_prior` argument is deprecated and no longer used.", DeprecationWarning)
         self.register_parameter(name="raw_variance", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, 1)))
+        self.register_constraint("raw_variance", variance_constraint)
         if variance_prior is not None:
             self.register_prior(
                 "variance_prior", variance_prior, lambda: self.variance, lambda v: self._set_variance(v)
             )
 
-        self.register_constraint("raw_variance", variance_constraint)
 
     @property
     def variance(self):

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -82,6 +82,7 @@ class PeriodicKernel(Kernel):
         self.register_parameter(
             name="raw_period_length", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, 1))
         )
+        self.register_constraint("raw_period_length", period_length_constraint)
 
         if period_length_prior is not None:
             self.register_prior(
@@ -91,7 +92,6 @@ class PeriodicKernel(Kernel):
                 lambda v: self._set_period_length(v),
             )
 
-        self.register_constraint("raw_period_length", period_length_constraint)
 
     @property
     def period_length(self):

--- a/gpytorch/kernels/polynomial_kernel.py
+++ b/gpytorch/kernels/polynomial_kernel.py
@@ -51,11 +51,11 @@ class PolynomialKernel(Kernel):
                 power = power.item()
 
         self.power = power
+        self.register_constraint("raw_offset", offset_constraint)
 
         if offset_prior is not None:
             self.register_prior("offset_prior", offset_prior, lambda: self.offset, lambda v: self._set_offset(v))
 
-        self.register_constraint("raw_offset", offset_constraint)
 
     @property
     def offset(self) -> torch.Tensor:

--- a/gpytorch/kernels/scale_kernel.py
+++ b/gpytorch/kernels/scale_kernel.py
@@ -68,12 +68,13 @@ class ScaleKernel(Kernel):
         self.base_kernel = base_kernel
         outputscale = torch.zeros(*self.batch_shape) if len(self.batch_shape) else torch.tensor(0.0)
         self.register_parameter(name="raw_outputscale", parameter=torch.nn.Parameter(outputscale))
+        self.register_constraint("raw_outputscale", outputscale_constraint)
+
         if outputscale_prior is not None:
             self.register_prior(
                 "outputscale_prior", outputscale_prior, lambda: self.outputscale, lambda v: self._set_outputscale(v)
             )
 
-        self.register_constraint("raw_outputscale", outputscale_constraint)
 
     @property
     def outputscale(self):

--- a/gpytorch/likelihoods/beta_likelihood.py
+++ b/gpytorch/likelihoods/beta_likelihood.py
@@ -33,10 +33,10 @@ class BetaLikelihood(_OneDimensionalLikelihood):
             scale_constraint = Positive()
 
         self.raw_scale = torch.nn.Parameter(torch.ones(*batch_shape, 1))
+        self.register_constraint("raw_scale", scale_constraint)
         if scale_prior is not None:
             self.register_prior("scale_prior", scale_prior, lambda: self.scale, lambda v: self._set_scale(v))
 
-        self.register_constraint("raw_scale", scale_constraint)
 
     @property
     def scale(self):

--- a/gpytorch/likelihoods/laplace_likelihood.py
+++ b/gpytorch/likelihoods/laplace_likelihood.py
@@ -22,11 +22,11 @@ class LaplaceLikelihood(_OneDimensionalLikelihood):
             noise_constraint = Positive()
 
         self.raw_noise = torch.nn.Parameter(torch.zeros(*batch_shape, 1))
+        self.register_constraint("raw_noise", noise_constraint)
 
         if noise_prior is not None:
             self.register_prior("noise_prior", noise_prior, lambda: self.noise, lambda v: self._set_noise(v))
 
-        self.register_constraint("raw_noise", noise_constraint)
 
     @property
     def noise(self):

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -208,6 +208,7 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
         if noise_constraint is None:
             noise_constraint = GreaterThan(1e-4)
         self.register_parameter(name="raw_noise", parameter=torch.nn.Parameter(torch.zeros(*batch_shape, 1)))
+        self.register_constraint("raw_noise", noise_constraint)
         if rank == 0:
             self.register_parameter(
                 name="raw_task_noises", parameter=torch.nn.Parameter(torch.zeros(*batch_shape, num_tasks))
@@ -223,7 +224,6 @@ class MultitaskGaussianLikelihoodKronecker(_MultitaskGaussianLikelihoodBase):
         self.num_tasks = num_tasks
         self.rank = rank
 
-        self.register_constraint("raw_noise", noise_constraint)
 
     @property
     def noise(self):

--- a/gpytorch/likelihoods/noise_models.py
+++ b/gpytorch/likelihoods/noise_models.py
@@ -25,10 +25,10 @@ class _HomoskedasticNoiseBase(Noise):
             noise_constraint = GreaterThan(1e-4)
 
         self.register_parameter(name="raw_noise", parameter=Parameter(torch.zeros(*batch_shape, num_tasks)))
+        self.register_constraint("raw_noise", noise_constraint)
         if noise_prior is not None:
             self.register_prior("noise_prior", noise_prior, lambda: self.noise, lambda v: self._set_noise(v))
 
-        self.register_constraint("raw_noise", noise_constraint)
 
     @property
     def noise(self):

--- a/gpytorch/likelihoods/student_t_likelihood.py
+++ b/gpytorch/likelihoods/student_t_likelihood.py
@@ -35,18 +35,18 @@ class StudentTLikelihood(_OneDimensionalLikelihood):
 
         self.raw_deg_free = torch.nn.Parameter(torch.zeros(*batch_shape, 1))
         self.raw_noise = torch.nn.Parameter(torch.zeros(*batch_shape, 1))
+        self.register_constraint("raw_noise", noise_constraint)
 
         if noise_prior is not None:
             self.register_prior("noise_prior", noise_prior, lambda: self.noise, lambda v: self._set_noise(v))
 
-        self.register_constraint("raw_noise", noise_constraint)
+        self.register_constraint("raw_deg_free", deg_free_constraint)
 
         if deg_free_prior is not None:
             self.register_prior(
                 "deg_free_prior", deg_free_prior, lambda: self.deg_free, lambda v: self._set_deg_free(v)
             )
 
-        self.register_constraint("raw_deg_free", deg_free_constraint)
 
         # Rough initialization
         self.initialize(deg_free=7)

--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -235,6 +235,20 @@ class Module(nn.Module):
 
         else:
             closure = param_or_closure
+        
+        hyperparameter_shape = closure().shape
+        prior_shape = prior.shape()
+
+        if prior_shape != hyperparameter_shape:
+            try:
+                prior = prior.expand(hyperparameter_shape)
+            except RuntimeError: 
+                raise RuntimeError(
+                    "Attempting to broadcast a prior that is not broadcastable! "
+                    + f"Got parameter shape {hyperparameter_shape} "
+                    + f"but prior shape {prior_shape}!"
+                )
+
         self.add_module(name, prior)
         self._priors[name] = (prior, closure, setting_closure)
 


### PR DESCRIPTION
This is an attempt to address #1317 and #1318 -- incomplete but hopefully helps concretize discussion. I think these bugs basically have to do with unexpected implicit broadcasting behavior of priors (where you think your prior should broadcast over events but it silently broadcasts over batches, or vice versa). So this PR makes prior broadcasting universal and explicit, and throws if it can't expand shapes. Without something like `to_event` (which I think we'd need pyro for) or a restriction to not to broadcast priors over event dimensions, we (still) have a mismatch between gpytorch batch/event shapes and the underlying torch distributions shapes, but I think that the errors are correct (i.e. they are thrown if "event" and "batch" dimensions don't match even if they're not encoded as such attributes). 

I'm not sure it's the correct thing. For example, you need to `prior.sample()` without args to get a full gpytorch-batch of priors, and if you `prior.sample(torch.Size([3])` you get 3 batches of batched priors. 

Below are some examples of what happens with these changes, based on @gpleiss' taxonomy of parameters that take priors. If they make sense, they can become tests in this PR. 

``` 
# setup
import torch
from gpytorch.priors import NormalPrior, GammaPrior
from gpytorch.kernels import RBFKernel, ScaleKernel
from gpytorch.likelihoods.noise_models import HomoskedasticNoise
from gpytorch.likelihoods import GaussianLikelihood
from gpytorch.means import ConstantMean
```

# Case 1:  Noise prior
`[*batch_shape, 1]`

```
# no broadcast
noise = HomoskedasticNoise(noise_prior=GammaPrior(concentration=2., rate=2.))
new_noise = noise.noise_prior.sample()
assert noise.noise.shape == new_noise.shape

# batched broadcast
noise = HomoskedasticNoise(noise_prior=GammaPrior(concentration=2., rate=2.), batch_shape=torch.Size([3,5]))
new_noise = noise.noise_prior.sample()
assert noise.noise.shape == new_noise.shape

# fails (can't broadcast)
noise = HomoskedasticNoise(noise_prior=GammaPrior(concentration=2., rate=torch.ones(2)))

# also fails, because mixing event and batch dims
noise = HomoskedasticNoise(noise_prior=GammaPrior(concentration=2., rate=torch.ones(2)), batch_shape=torch.Size([2]))

# succeeds with batched priors
noise = HomoskedasticNoise(noise_prior=GammaPrior(concentration=2., rate=torch.ones(2, 1)), batch_shape=torch.Size([2]))
```
And here's @dme65's example: 
```
# throws, noise is [*batch_shape, 1] and we give a [*batch_shape] prior which cannot broadcast
likelihood = GaussianLikelihood(
    noise_prior=gpytorch.priors.NormalPrior(loc=torch.zeros(2), scale=torch.ones(2)),
    batch_shape=torch.Size([2]),
)

# after this PR, the correct way of doing this would be:
likelihood = GaussianLikelihood(
    noise_prior=gpytorch.priors.NormalPrior(loc=torch.zeros(2, 1), scale=torch.ones(2, 1)),
    batch_shape=torch.Size([2]),
)
```

# Case 2: means
`[*batch_shape, 1]`, this is basically the same as noise. 
```
# unbatched, works
mean = ConstantMean(prior=NormalPrior(loc=10, scale=3))
new_mean = mean.mean_prior.sample()
assert mean.constant.shape == new_mean.shape

# fails (can't broadcast)
mean = ConstantMean(prior=NormalPrior(loc=10, scale=torch.ones(2)))

# also fails, batch shape isn't event shape
mean = ConstantMean(prior=NormalPrior(loc=10, scale=torch.ones(2)), batch_shape = torch.Size([2]))

# succeeds 
mean = ConstantMean(prior=NormalPrior(loc=10, scale=torch.ones(2, 1)), batch_shape = torch.Size([2]))
```

# Case 3: outputscales
`[*batch_shape]`
```
# unbatched, no broadcast
kernel = ScaleKernel(RBFKernel(), outputscale_prior=NormalPrior(loc=10, scale=1.3))
new_outputscale = kernel.outputscale_prior.sample()
assert kernel.outputscale.shape == new_outputscale.shape

# batched
kernel = ScaleKernel(RBFKernel(), outputscale_prior=NormalPrior(loc=10, scale=1.3), batch_shape=torch.Size([3,4]))
new_outputscale = kernel.outputscale_prior.sample()
assert kernel.outputscale.shape == new_outputscale.shape

# ScaleKernel has no ARD, error
kernel = ScaleKernel(RBFKernel(), outputscale_prior=NormalPrior(loc=10, scale=torch.ones(2)))

# this works. I'm not sure if it should work -- since there's no event dim, the last prior dim is actually batch dim here
kernel = ScaleKernel(RBFKernel(), outputscale_prior=NormalPrior(loc=10, scale=torch.ones(2)), batch_shape=torch.Size([2]))
``` 

# Lengthscales
[*batch_shape, 1, d]

```
# no broadcasting
kernel = RBFKernel(ard_num_dims=2,lengthscale_prior=GammaPrior(3.0, torch.ones(2)))
new_lengthscale = kernel.lengthscale_prior.sample()
assert kernel.lengthscale.shape == new_lengthscale.shape

# broadcast event
kernel = RBFKernel(ard_num_dims=2, lengthscale_prior=NormalPrior(loc=10, scale=1))
new_lengthscale = kernel.lengthscale_prior.sample()
assert kernel.lengthscale.shape == new_lengthscale.shape

# broadcast batch
kernel = RBFKernel(ard_num_dims=1, lengthscale_prior=NormalPrior(loc=10, scale=1.3), batch_shape=torch.Size([3,5]))
new_lengthscale = kernel.lengthscale_prior.sample()
assert kernel.lengthscale.shape == new_lengthscale.shape

# broadcast batch + event -- this is possibly the most semantically strange one
kernel = RBFKernel(ard_num_dims=2, lengthscale_prior=NormalPrior(loc=10, scale=1.3), batch_shape=torch.Size([3,5]))
new_lengthscale = kernel.lengthscale_prior.sample()
assert kernel.lengthscale.shape == new_lengthscale.shape

# ARD, no way to broadcast, error
kernel = RBFKernel(ard_num_dims=1, lengthscale_prior=NormalPrior(loc=10, scale=torch.ones(2)))

# batch is not event, errors
kernel = RBFKernel(ard_num_dims=1,lengthscale_prior=NormalPrior(loc=10, scale=torch.ones(2)), batch_shape=torch.Size([2]),)
kernel = RBFKernel(ard_num_dims=1,lengthscale_prior=NormalPrior(loc=10, scale=torch.ones(2, 1)), batch_shape=torch.Size([2]),)

# succeeds, batched prior
kernel = RBFKernel(ard_num_dims=2,lengthscale_prior=NormalPrior(loc=10, scale=torch.ones(2, 1, 1)), batch_shape=torch.Size([2]))
new_lengthscale = kernel.lengthscale_prior.sample()
assert kernel.lengthscale.shape == new_lengthscale.shape
```