### PR TITLE
Add a Check for TriangularLazyTensors in inv_quad_logdet

### DIFF
--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -23,7 +23,7 @@ from ..utils.cholesky import psd_safe_cholesky
 from ..utils.deprecation import _deprecate_renamed_methods
 from ..utils.errors import CachingError
 from ..utils.getitem import _compute_getitem_size, _convert_indices_to_tensors, _is_noop_index, _noop_index
-from ..utils.memoize import add_to_cache, cached, get_from_cache, pop_from_cache
+from ..utils.memoize import _is_in_cache_ignore_all_args, add_to_cache, cached, get_from_cache, pop_from_cache
 from ..utils.pivoted_cholesky import pivoted_cholesky
 from ..utils.warnings import NumericalWarning
 from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
@@ -1031,8 +1031,7 @@ class LazyTensor(ABC):
             # if the root decomposition has already been computed and is triangular we can use it instead
             # of computing the cholesky.
             will_need_cholesky = True
-            # TODO: shouldn't this be _is_in_cache_ignore_args
-            if hasattr(self, "_memoize_cache") and "root_decomposition" in [x[0] for x in self._memoize_cache.keys()]:
+            if _is_in_cache_ignore_all_args(self, "root_decomposition"):
                 root = self.root_decomposition().root
                 if isinstance(root, TriangularLazyTensor):
                     cholesky = CholLazyTensor(root)

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -23,7 +23,7 @@ from ..utils.cholesky import psd_safe_cholesky
 from ..utils.deprecation import _deprecate_renamed_methods
 from ..utils.errors import CachingError
 from ..utils.getitem import _compute_getitem_size, _convert_indices_to_tensors, _is_noop_index, _noop_index
-from ..utils.memoize import _is_in_cache_ignore_args, add_to_cache, cached, get_from_cache, pop_from_cache
+from ..utils.memoize import add_to_cache, cached, get_from_cache, pop_from_cache
 from ..utils.pivoted_cholesky import pivoted_cholesky
 from ..utils.warnings import NumericalWarning
 from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
@@ -1031,7 +1031,8 @@ class LazyTensor(ABC):
             # if the root decomposition has already been computed and is triangular we can use it instead
             # of computing the cholesky.
             will_need_cholesky = True
-            if _is_in_cache_ignore_args(self, "root_decomposition"):
+            # TODO: shouldn't this be _is_in_cache_ignore_args
+            if hasattr(self, "_memoize_cache") and "root_decomposition" in [x[0] for x in self._memoize_cache.keys()]:
                 root = self.root_decomposition().root
                 if isinstance(root, TriangularLazyTensor):
                     cholesky = CholLazyTensor(root)

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1030,11 +1030,13 @@ class LazyTensor(ABC):
 
             # if the root decomposition has already been computed and is triangular we can use it instead
             # of computing the cholesky.
+            will_need_cholesky = True
             if _is_in_cache_ignore_args(self, "root_decomposition"):
                 root = self.root_decomposition().root
                 if isinstance(root, TriangularLazyTensor):
-                    cholesky = root
-            else:
+                    cholesky = CholLazyTensor(root)
+                    will_need_cholesky = False
+            if will_need_cholesky:
                 cholesky = CholLazyTensor(TriangularLazyTensor(self.cholesky()))
             return cholesky.inv_quad_logdet(inv_quad_rhs=inv_quad_rhs, logdet=logdet, reduce_inv_quad=reduce_inv_quad)
 

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -23,7 +23,7 @@ from ..utils.cholesky import psd_safe_cholesky
 from ..utils.deprecation import _deprecate_renamed_methods
 from ..utils.errors import CachingError
 from ..utils.getitem import _compute_getitem_size, _convert_indices_to_tensors, _is_noop_index, _noop_index
-from ..utils.memoize import add_to_cache, cached, get_from_cache, pop_from_cache
+from ..utils.memoize import _is_in_cache_ignore_args, add_to_cache, cached, get_from_cache, pop_from_cache
 from ..utils.pivoted_cholesky import pivoted_cholesky
 from ..utils.warnings import NumericalWarning
 from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
@@ -1028,7 +1028,14 @@ class LazyTensor(ABC):
             from .chol_lazy_tensor import CholLazyTensor
             from .triangular_lazy_tensor import TriangularLazyTensor
 
-            cholesky = CholLazyTensor(TriangularLazyTensor(self.cholesky()))
+            # if the root decomposition has already been computed and is triangular we can use it instead
+            # of computing the cholesky.
+            if _is_in_cache_ignore_args(self, "root_decomposition"):
+                root = self.root_decomposition().root
+                if isinstance(root, TriangularLazyTensor):
+                    cholesky = root
+            else:
+                cholesky = CholLazyTensor(TriangularLazyTensor(self.cholesky()))
             return cholesky.inv_quad_logdet(inv_quad_rhs=inv_quad_rhs, logdet=logdet, reduce_inv_quad=reduce_inv_quad)
 
         # Default: use modified batch conjugate gradients to compute these terms

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -117,3 +117,8 @@ def _get_from_cache_ignore_args(obj, name):
 
 def _is_in_cache_ignore_args(obj, name):
     return hasattr(obj, "_memoize_cache") and name in obj._memoize_cache
+
+
+def _is_in_cache_ignore_all_args(obj, name):
+    """ checks if item is in cache by name. """
+    return hasattr(obj, "_memoize_cache") and name in [x[0] for x in obj._memoize_cache.keys()]

--- a/test/lazy/test_low_rank_root_added_diag_lazy_tensor.py
+++ b/test/lazy/test_low_rank_root_added_diag_lazy_tensor.py
@@ -97,6 +97,9 @@ class TestLowRankRootAddedDiagLazyTensor(LazyTensorTestCase, unittest.TestCase):
 
             self.assertFalse(linear_cg_mock.called)
 
+    def test_root_decomposition_cholesky(self):
+        self.test_root_decomposition(cholesky=True)
+
 
 class TestLowRankRootAddedDiagLazyTensorBatch(TestLowRankRootAddedDiagLazyTensor):
     seed = 4


### PR DESCRIPTION
Adds a check to see if the root decomposition has already been computed and if that returned a `TriangularLazyTensor` for `inv_quad_logdet`. 

Enables the internals to use the new root decompositions after rows/columns have been updated like in #1499, which correspondingly makes some BO acquisition functions easier to implement (like botorch #724). 