### PR TITLE
Fix handling of batched tensors in cat_rows

### DIFF
--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1594,7 +1594,8 @@ class LazyTensor(ABC):
         from .chol_lazy_tensor import CholLazyTensor
         from .root_lazy_tensor import RootLazyTensor
 
-        # # no need to do extra work if we already have a cached cholesky decomposition
+        # no need to do extra work if we already have a cached cholesky decomposition
+        # TODO: Resolve issues related to triangular tensor instantiation
         # if _is_in_cache_ignore_args(self, "cholesky"):
         #     res = self.cholesky()
         #     return CholLazyTensor(res)
@@ -1667,7 +1668,8 @@ class LazyTensor(ABC):
         if self.shape[-2:].numel() == 1:
             return RootLazyTensor(1 / self.evaluate().sqrt())
 
-        # # no need to do extra work if we already have a cached cholesky decomposition
+        # no need to do extra work if we already have a cached cholesky decomposition
+        # TODO: Resolve issues related to triangular tensor instantiation \
         # if _is_in_cache_ignore_args(self, "cholesky"):
         #     res = self.cholesky()
         #     return CholLazyTensor(res).inverse()

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -840,7 +840,8 @@ class LazyTensor(ABC):
             else:
                 # solve with least squares
                 if R.ndim > 2:
-                    # temporary hack around PyTorch limitation, this is no good...
+                    # TODO: Replace with `torch.linalg.lstsq` (introduced in #49093) once we have a Pytorch >=1.9 req.
+                    # temporary hack around this limitation for now
                     new_inv_root = (torch.pinverse(R) @ Q.transpose(-1, -2)).transpose(-1, -2)
                 else:
                     new_inv_root = torch.lstsq(Q.transpose(-2, -1), R).solution.transpose(-2, -1)

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -32,8 +32,8 @@ from ..utils.memoize import (
     get_from_cache,
     pop_from_cache,
 )
+from ..utils.pinverse import stable_pinverse
 from ..utils.pivoted_cholesky import pivoted_cholesky
-from ..utils.qr import stable_qr
 from ..utils.warnings import NumericalWarning
 from .lazy_tensor_representation_tree import LazyTensorRepresentationTree
 
@@ -744,20 +744,20 @@ class LazyTensor(ABC):
     def cat_rows(self, cross_mat, new_mat, generate_roots=True, **root_decomp_kwargs):
         """
         Concatenates new rows and columns to the matrix that this LazyTensor represents, e.g.
-        C = ((A; B); B^T, D). where A is the existing lazy tensor, and B (cross_mat) and D (new_mat)
+        C = [A B^T; B D]. where A is the existing lazy tensor, and B (cross_mat) and D (new_mat)
         are new components. This is most commonly used when fantasizing with kernel matrices.
 
-        We have access to K \\approx LL^T and K^{-1} \\approx RR^T, where L and R are low rank matrices
+        We have access to A \\approx LL^T and A^{-1} \\approx RR^T, where L and R are low rank matrices
         resulting from root and root inverse decompositions (see the LOVE paper).
 
         To update R, we first update L:
-            [K U; U^T S] = [L 0; A B][L^T A^T; 0 BT]
+            [A B^T; B D] = [E 0; F G][E^T F^T; 0 G^T]
         Solving this matrix equation, we get:
-            K = LL^T ==>       L = L
-            U = LA^T ==>       A = UR^{-1}
-            S = AA^T + BB^T ==> B = cholesky(S - AA^T)
+            A = EE^T = LL^T  ==>   E = L
+            B = EF^T         ==>   F = BR
+            D = FF^T + GG^T  ==>   G = (D - FF^T)^{1/2}
 
-        Once we've computed Z = [L 0; A B], we have that the new kernel matrix [K U; U^T S] \approx ZZ^T. Therefore,
+        Once we've computed Z = [E 0; F G], we have that the new kernel matrix [K U; U^T S] \approx ZZ^T. Therefore,
         we can form a pseudo-inverse of Z directly to approximate [K U; U^T S]^{-1/2}.
 
         This strategy is also described in "Efficient Nonmyopic Bayesian Optimization via One-Shot Multistep Trees,"
@@ -779,75 +779,54 @@ class LazyTensor(ABC):
         from .root_lazy_tensor import RootLazyTensor
         from .triangular_lazy_tensor import TriangularLazyTensor
 
-        cross_mat = lazify(cross_mat)
-        batch_shape = cross_mat.shape[:-2]
-        new_mat = lazify(new_mat)
+        B_, B = cross_mat, lazify(cross_mat)
+        D = lazify(new_mat)
+        batch_shape = B.shape[:-2]
         if self.ndimension() < cross_mat.ndimension():
-            expand_shape = _mul_broadcast_shape(self.shape[:-2], cross_mat.shape[:-2]) + self.shape[-2:]
-            old_tsr = self.expand(expand_shape)
+            expand_shape = _mul_broadcast_shape(self.shape[:-2], B.shape[:-2]) + self.shape[-2:]
+            A = self.expand(expand_shape)
         else:
-            old_tsr = self
+            A = self
 
-        new_lazy_tensor_1 = CatLazyTensor(old_tsr, cross_mat, dim=-2)
-        new_lazy_tensor_2 = CatLazyTensor(cross_mat.transpose(-1, -2), new_mat, dim=-2)
-        new_lazy_tensor = CatLazyTensor(new_lazy_tensor_1, new_lazy_tensor_2, dim=-1)
+        # form matrix C = [A B; B^T D]
+        upper_row = CatLazyTensor(A, B, dim=-2)
+        lower_row = CatLazyTensor(B.transpose(-1, -2), D, dim=-2)
+        new_lazy_tensor = CatLazyTensor(upper_row, lower_row, dim=-1)
 
         # if the old lazy tensor does not have either a root decomposition or a root inverse decomposition
         # don't create one
-        does_not_have_roots = _is_in_cache_ignore_args(self, "root_decomposition") or _is_in_cache_ignore_args(
-            self, "root_inv_decomposition"
+        does_not_have_roots = any(
+            _is_in_cache_ignore_args(self, key) for key in ("root_inv_decomposition", "root_inv_decomposition")
         )
         if not generate_roots and not does_not_have_roots:
             return new_lazy_tensor
 
-        L = self.root_decomposition(**root_decomp_kwargs).root
-        l_is_triang = isinstance(L, TriangularLazyTensor)
-        L = L.evaluate()
-        L_inverse = self.root_inv_decomposition().root.evaluate()
+        E = self.root_decomposition(**root_decomp_kwargs).root
+        m, n = E.shape[-2:]
+        R = self.root_inv_decomposition().root.evaluate()  # this is fast if L is triangular
+        F = B_ @ R
+        G = lazify(D - F.matmul(F.transpose(-2, -1))).root_decomposition().root.evaluate()
 
-        m, n = L.shape[-2:]
+        # Form new root Z = [E 0; F G]
+        num_fant = G.size(-2)
+        new_root = torch.zeros(*batch_shape, m + num_fant, n + num_fant, device=E.device, dtype=E.dtype)
+        new_root[..., :m, :n] = E.evaluate()
+        new_root[..., m:, : F.shape[-1]] = F
+        new_root[..., m:, n : (n + G.shape[-1])] = G
 
-        if l_is_triang:
-            # The whole thing is triangular, we can just do two triangular solves
-            if isinstance(cross_mat, LazyTensor):
-                cross_mat = cross_mat.evaluate()
-            lower_left = torch.triangular_solve(cross_mat.transpose(-1, -2), L, upper=False).solution.transpose(-2, -1)
+        if isinstance(E, TriangularLazyTensor) and isinstance(G, TriangularLazyTensor):
+            # make sure these are actually upper triangular
+            if getattr(E, "upper", False) or getattr(G, "upper", False):
+                raise NotImplementedError
+            # in this case we know new_root is triangular as well
+            new_root = TriangularLazyTensor(new_root)
+            new_inv_root = new_root.inverse().transpose(-1, -2)
         else:
-            lower_left = cross_mat.matmul(L_inverse)
+            # otherwise we use the pseudo-inverse of Z as new inv root
+            new_inv_root = stable_pinverse(new_root).transpose(-2, -1)
 
-        schur = new_mat - lower_left.matmul(lower_left.transpose(-2, -1))
-        schur_root = lazify(schur).root_decomposition().root.evaluate()
-
-        # Form new root Z = [L 0; lower_left schur_root]
-        num_fant = schur_root.size(-2)
-        new_root = torch.zeros(*batch_shape, m + num_fant, n + num_fant, device=L.device, dtype=L.dtype)
-        new_root[..., :m, :n] = L
-        new_root[..., m:, : lower_left.shape[-1]] = lower_left
-        new_root[..., m:, n : (n + schur_root.shape[-1])] = schur_root
-
-        # Use pseudo-inverse of Z as new inv root
-        if l_is_triang:
-            # we know L is triangular, so inverting is a triangular solve agaist the identity
-            # we don't need the batch shape here, thanks to broadcasting
-            Eye = torch.eye(new_root.shape[-2], device=new_root.device, dtype=new_root.dtype)
-            new_inv_root = torch.triangular_solve(Eye, new_root, upper=False)[0]
-            new_inv_root = new_inv_root.transpose(-1, -2)
-        else:
-            Q, R = stable_qr(new_root)
-
-            if R.shape[-2] == R.shape[-1]:
-                new_inv_root = torch.triangular_solve(Q.transpose(-2, -1), R, upper=True).solution.transpose(-2, -1)
-            else:
-                # solve with least squares
-                if R.ndim > 2:
-                    # TODO: Replace with `torch.linalg.lstsq` (introduced in #49093) once we have a Pytorch >=1.9 req.
-                    # temporary hack around this limitation for now
-                    new_inv_root = (torch.pinverse(R) @ Q.transpose(-1, -2)).transpose(-1, -2)
-                else:
-                    new_inv_root = torch.lstsq(Q.transpose(-2, -1), R).solution.transpose(-2, -1)
-
-        add_to_cache(new_lazy_tensor, "root_decomposition", RootLazyTensor(TriangularLazyTensor(new_root)))
-        add_to_cache(new_lazy_tensor, "root_inv_decomposition", RootLazyTensor(TriangularLazyTensor(new_inv_root)))
+        add_to_cache(new_lazy_tensor, "root_decomposition", RootLazyTensor(lazify(new_root)))
+        add_to_cache(new_lazy_tensor, "root_inv_decomposition", RootLazyTensor(lazify(new_inv_root)))
 
         return new_lazy_tensor
 
@@ -898,8 +877,8 @@ class LazyTensor(ABC):
 
         # if the old lazy tensor does not have either a root decomposition or a root inverse decomposition
         # don't create one
-        does_not_have_roots = _is_in_cache_ignore_args(self, "root_decomposition") or _is_in_cache_ignore_args(
-            self, "root_inv_decomposition"
+        does_not_have_roots = any(
+            _is_in_cache_ignore_args(self, key) for key in ("root_decomposition", "root_inv_decomposition")
         )
         if not generate_roots and not does_not_have_roots:
             return new_lazy_tensor
@@ -981,7 +960,7 @@ class LazyTensor(ABC):
             upper (bool) - upper triangular or lower triangular factor (default: False)
 
         Returns:
-            (LazyTensor) Cholesky factor (lower triangular)
+            (LazyTensor) Cholesky factor (triangular, upper/lower depending on "upper" arg)
         """
         chol = self._cholesky(upper=False)
         if upper:
@@ -1615,6 +1594,11 @@ class LazyTensor(ABC):
         from .chol_lazy_tensor import CholLazyTensor
         from .root_lazy_tensor import RootLazyTensor
 
+        # # no need to do extra work if we already have a cached cholesky decomposition
+        # if _is_in_cache_ignore_args(self, "cholesky"):
+        #     res = self.cholesky()
+        #     return CholLazyTensor(res)
+
         if not self.is_square:
             raise RuntimeError(
                 "root_decomposition only operates on (batches of) square (symmetric) LazyTensors. "
@@ -1683,6 +1667,11 @@ class LazyTensor(ABC):
         if self.shape[-2:].numel() == 1:
             return RootLazyTensor(1 / self.evaluate().sqrt())
 
+        # # no need to do extra work if we already have a cached cholesky decomposition
+        # if _is_in_cache_ignore_args(self, "cholesky"):
+        #     res = self.cholesky()
+        #     return CholLazyTensor(res).inverse()
+
         if method is None:
             if (
                 self.size(-1) <= settings.max_cholesky_size.value()
@@ -1701,6 +1690,8 @@ class LazyTensor(ABC):
                 Linv = torch.triangular_solve(Eye, L, upper=False)[0]
                 res = lazify(Linv.transpose(-1, -2))
                 return RootLazyTensor(res)
+                # L = self.cholesky()
+                # return CholLazyTensor(L).inverse()
             except RuntimeError as e:
                 warnings.warn(
                     "Runtime Error when computing Cholesky decomposition: {}. Using RootDecomposition.".format(e),

--- a/gpytorch/utils/__init__.py
+++ b/gpytorch/utils/__init__.py
@@ -5,6 +5,8 @@ from .contour_integral_quad import contour_integral_quad
 from .linear_cg import linear_cg
 from .memoize import cached
 from .minres import minres
+from .pinverse import stable_pinverse
+from .qr import stable_qr
 from .stochastic_lq import StochasticLQ
 
 
@@ -31,9 +33,12 @@ __all__ = [
     "interpolation",
     "lanczos",
     "minres",
+    "pinverse",
     "pivoted_cholesky",
     "prod",
     "quadrature",
     "sparse",
+    "stable_pinverse",
+    "stable_qr",
     "warnings",
 ]

--- a/gpytorch/utils/pinverse.py
+++ b/gpytorch/utils/pinverse.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import torch
+from torch import Tensor
+
+from .qr import stable_qr
+
+
+def stable_pinverse(A: Tensor) -> Tensor:
+    """Compute a pseudoinverse of a matrix. Employs a stabilized QR decomposition.
+    """
+    if A.shape[-2] >= A.shape[-1]:
+        # skinny (or square) matrix
+        Q, R = stable_qr(A)
+        return torch.triangular_solve(Q.transpose(-1, -2), R).solution
+    else:
+        # fat matrix
+        Q, R = stable_qr(A.transpose(-1, -2))
+        return torch.triangular_solve(Q.transpose(-1, -2), R).solution.transpose(-1, -2)

--- a/gpytorch/utils/qr.py
+++ b/gpytorch/utils/qr.py
@@ -7,8 +7,9 @@ def stable_qr(mat):
     """
     performs a QR decomposition on the batched matrix mat.
     We need to use these functions because of
-        a) slow batched QR in pytorch (pytorch/pytorch#22573)
-        b) possible singularity in R
+
+    1. slow batched QR in pytorch (pytorch/pytorch#22573)
+    2. possible singularity in R
     """
     if mat.shape[-1] <= 2048:
         # Dispatch to CPU so long as pytorch/pytorch#22573 is not fixed

--- a/test/lazy/test_root_lazy_tensor.py
+++ b/test/lazy/test_root_lazy_tensor.py
@@ -28,20 +28,19 @@ class TestRootLazyTensorBatch(TestRootLazyTensor):
     seed = 1
 
     def create_lazy_tensor(self):
-        root = torch.randn(3, 5, 5)
-        root.add_(torch.eye(5).unsqueeze(0))
+        root = torch.randn(3, 5, 5) + torch.eye(5)
         root.requires_grad_(True)
         return RootLazyTensor(root)
 
 
 class TestRootLazyTensorMultiBatch(TestRootLazyTensor):
-    seed = 1
+    seed = 2
     # Because these LTs are large, we'll skil the big tests
     should_test_sample = False
     skip_slq_tests = True
 
     def create_lazy_tensor(self):
-        root = torch.randn(4, 3, 5, 5)
+        root = torch.randn(2, 3, 5, 5) + torch.eye(5)
         root.requires_grad_(True)
         return RootLazyTensor(root)
 


### PR DESCRIPTION
This fixes the issue discussed in https://github.com/cornellius-gp/gpytorch/pull/1499#discussion_r594720889: Prior to this PR things break if a batched set of additional rows/cols are added to a LazyTensors via `cat_rows`. This is required for batched fantasizing. This PR also adds unit tests to cover this setting.

The unit test for the batched version with a low-rank root currently fails due to what looks like numerical issues. 