### PR TITLE
Fix skip connection in DGP example

### DIFF
--- a/examples/05_Deep_Gaussian_Processes/Deep_Gaussian_Processes.ipynb
+++ b/examples/05_Deep_Gaussian_Processes/Deep_Gaussian_Processes.ipynb
@@ -192,7 +192,7 @@
     "                x = x.rsample()\n",
     "\n",
     "            processed_inputs = [\n",
-    "                inp.unsqueeze(0).expand(self.num_samples, *inp.shape)\n",
+    "                inp.unsqueeze(0).expand(gpytorch.settings.num_likelihood_samples.value(), *inp.shape)\n",
     "                for inp in other_inputs\n",
     "            ]\n",
     "\n",


### PR DESCRIPTION
Fix `self.num_samples` to `gpytorch.settings.num_likelihood_samples.value()`, as `DeepGPLayer` does not currently have attribute `num_samples`. 