### PR TITLE
Set the default method as symeig for KroneckerProductLazyTensor to compute diag

### DIFF
--- a/gpytorch/lazy/kronecker_product_lazy_tensor.py
+++ b/gpytorch/lazy/kronecker_product_lazy_tensor.py
@@ -138,6 +138,11 @@ class KroneckerProductLazyTensor(LazyTensor):
                 raise RuntimeError("Diag works on square matrices (or batches)")
         return _kron_diag(*self.lazy_tensors)
 
+    def diagonalization(self, method: Optional[str] = None):
+        if method is None:
+            method = "symeig"
+        return super().diagonalization(method=method)
+
     @cached
     def inverse(self):
         # here we use that (A \kron B)^-1 = A^-1 \kron B^-1

--- a/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_added_diag_lazy_tensor.py
@@ -50,6 +50,7 @@ class TestKroneckerProductAddedKroneckerDiagLazyTensor(TestKroneckerProductAdded
     # this lazy tensor has an explicit inverse so we don't need to run these
     skip_slq_tests = True
     should_call_cg = False
+    should_call_lanczos = False
 
     def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
@@ -72,6 +73,8 @@ class TestKroneckerProductAddedKroneckerDiagLazyTensor(TestKroneckerProductAdded
 
 
 class TestKroneckerProductAddedKroneckerConstDiagLazyTensor(TestKroneckerProductAddedKroneckerDiagLazyTensor):
+    should_call_lanczos = True
+
     def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
@@ -96,6 +99,7 @@ class TestKroneckerProductAddedKroneckerConstDiagLazyTensor(TestKroneckerProduct
 
 class TestKroneckerProductAddedConstDiagLazyTensor(TestKroneckerProductAddedDiagLazyTensor):
     should_call_cg = False
+    should_call_lanczos = False
 
     def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)

--- a/test/lazy/test_kronecker_product_lazy_tensor.py
+++ b/test/lazy/test_kronecker_product_lazy_tensor.py
@@ -33,6 +33,7 @@ def kron_diag(*lts):
 class TestKroneckerProductLazyTensor(LazyTensorTestCase, unittest.TestCase):
     seed = 0
     should_call_lanczos = True
+    should_call_lanczos_diagonalization = False
 
     def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
@@ -51,6 +52,8 @@ class TestKroneckerProductLazyTensor(LazyTensorTestCase, unittest.TestCase):
 
 
 class TestKroneckerProductDiagLazyTensor(TestDiagLazyTensor):
+    should_call_lanczos_diagonalization = False
+
     def create_lazy_tensor(self):
         a = torch.tensor([4.0, 1.0, 2.0], dtype=torch.float)
         b = torch.tensor([3.0, 1.3], dtype=torch.float)
@@ -69,6 +72,7 @@ class TestKroneckerProductDiagLazyTensor(TestDiagLazyTensor):
 class TestKroneckerProductLazyTensorBatch(TestKroneckerProductLazyTensor):
     seed = 0
     should_call_lanczos = True
+    should_call_lanczos_diagonalization = False
 
     def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float).repeat(3, 1, 1)


### PR DESCRIPTION
Latest GPyTorch master changed the default method from `symeig` to `lanczos` to compute diagonalization when data exceeds max_cholesky_size. However lanczos causes sizing mismatch for KroneckerProductLazyTensor, thus Higher-Order GP fitting fails.  Here I change the default method back to `symeig` for KroneckerProductLazyTensor. 