### PR TITLE
Fix MLL Calculation for Sampling

### DIFF
--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -69,6 +69,6 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
     def pyro_factor(self, output, target, *params):
         import pyro
 
-        mll = self(output, target, *params)
+        mll = target.size(-1) * self(output, target, *params)
         pyro.factor("gp_mll", mll)
         return mll


### PR DESCRIPTION
When sampling, it's a bug to scale the MLL by n, because our acceptance probabilities change:

`exp(a - b) != exp(a/n - b/n)`.