### PR TITLE
Removed unnecessary line in FirstSincKernel forward

### DIFF
--- a/examples/00_Basic_Usage/Implementing_a_custom_Kernel.ipynb
+++ b/examples/00_Basic_Usage/Implementing_a_custom_Kernel.ipynb
@@ -114,7 +114,7 @@
     "        # calculate the distance between inputs\n",
     "        diff = self.covar_dist(x1, x2, **params)\n",
     "        # prevent divide by 0 errors\n",
-    "        diff.where(diff == 0, torch.as_tensor(1e-20))\n",
+    "        # diff.where(diff == 0, torch.as_tensor(1e-20))\n",
     "        # return sinc(diff) = sin(diff) / diff\n",
     "        return torch.sin(diff).div(diff)"
    ]
@@ -422,7 +422,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I believe Line 117 in examples/00_Basic_Usage/Implementing_a_custom_Kernel.ipynb is not functional, since it is not assigning the result of diff.where(diff == 0, torch.as_tensor(1e-20) to diff.

In addition, I think this line is not necessary since method _dist in class Distance uses clamp_min_(1e-30).