### PR TITLE
Use torch.linalg.cholesky_ex instead of torch.cholesky

### DIFF
--- a/gpytorch/test/lazy_tensor_test_case.py
+++ b/gpytorch/test/lazy_tensor_test_case.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import torch
 
 import gpytorch
+from gpytorch.utils.cholesky import CHOLESKY_METHOD
 
 from .base_test_case import BaseTestCase
 
@@ -614,8 +615,10 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
                     lazy_tensor, "root_decomposition", gpytorch.lazy.RootLazyTensor(chol)
                 )
 
-                _wrapped_cholesky = MagicMock(wraps=torch.cholesky)
-                with patch("torch.cholesky", new=_wrapped_cholesky) as cholesky_mock:
+                _wrapped_cholesky = MagicMock(
+                    wraps=torch.cholesky if CHOLESKY_METHOD == "torch.cholesky" else torch.linalg.cholesky_ex
+                )
+                with patch(CHOLESKY_METHOD, new=_wrapped_cholesky) as cholesky_mock:
                     self._test_inv_quad_logdet(reduce_inv_quad=True, cholesky=True, lazy_tensor=lazy_tensor)
                 self.assertFalse(cholesky_mock.called)
 

--- a/gpytorch/test/variational_test_case.py
+++ b/gpytorch/test/variational_test_case.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import torch
 
 import gpytorch
+from gpytorch.utils.cholesky import CHOLESKY_METHOD
 
 from .base_test_case import BaseTestCase
 
@@ -131,10 +132,12 @@ class VariationalTestCase(BaseTestCase):
         eval_data_batch_shape = eval_data_batch_shape if eval_data_batch_shape is not None else self.batch_shape
 
         # Mocks
-        _wrapped_cholesky = MagicMock(wraps=torch.cholesky)
+        _wrapped_cholesky = MagicMock(
+            wraps=torch.cholesky if CHOLESKY_METHOD == "torch.cholesky" else torch.linalg.cholesky_ex
+        )
         _wrapped_cg = MagicMock(wraps=gpytorch.utils.linear_cg)
         _wrapped_ciq = MagicMock(wraps=gpytorch.utils.contour_integral_quad)
-        _cholesky_mock = patch("torch.cholesky", new=_wrapped_cholesky)
+        _cholesky_mock = patch(CHOLESKY_METHOD, new=_wrapped_cholesky)
         _cg_mock = patch("gpytorch.utils.linear_cg", new=_wrapped_cg)
         _ciq_mock = patch("gpytorch.utils.contour_integral_quad", new=_wrapped_ciq)
 
@@ -191,10 +194,12 @@ class VariationalTestCase(BaseTestCase):
         expected_batch_shape = expected_batch_shape if expected_batch_shape is not None else self.batch_shape
 
         # Mocks
-        _wrapped_cholesky = MagicMock(wraps=torch.cholesky)
+        _wrapped_cholesky = MagicMock(
+            wraps=torch.cholesky if CHOLESKY_METHOD == "torch.cholesky" else torch.linalg.cholesky_ex
+        )
         _wrapped_cg = MagicMock(wraps=gpytorch.utils.linear_cg)
         _wrapped_ciq = MagicMock(wraps=gpytorch.utils.contour_integral_quad)
-        _cholesky_mock = patch("torch.cholesky", new=_wrapped_cholesky)
+        _cholesky_mock = patch(CHOLESKY_METHOD, new=_wrapped_cholesky)
         _cg_mock = patch("gpytorch.utils.linear_cg", new=_wrapped_cg)
         _ciq_mock = patch("gpytorch.utils.contour_integral_quad", new=_wrapped_ciq)
 

--- a/gpytorch/utils/cholesky.py
+++ b/gpytorch/utils/cholesky.py
@@ -45,13 +45,13 @@ except ImportError:
     # Fall back to torch.cholesky - this can be more than 3 orders of magnitude slower!
     # TODO: Remove once PyTorch req. is >= 1.9
 
-    def _psd_safe_cholesky(A, upper=False, out=None, jitter=None, max_tries=3):
+    def _psd_safe_cholesky(A, out=None, jitter=None, max_tries=3):
         # Maybe log
         if settings.verbose_linalg.on():
             settings.verbose_linalg.logger.debug(f"Running Cholesky on a matrix of size {A.shape}.")
 
         try:
-            L = torch.cholesky(A, upper=upper, out=out)
+            L = torch.cholesky(A, out=out)
             return L
         except RuntimeError as e:
             isnan = torch.isnan(A)
@@ -69,7 +69,7 @@ except ImportError:
                 Aprime.diagonal(dim1=-2, dim2=-1).add_(jitter_new - jitter_prev)
                 jitter_prev = jitter_new
                 try:
-                    L = torch.cholesky(Aprime, upper=upper, out=out)
+                    L = torch.cholesky(Aprime, out=out)
                     warnings.warn(f"A not p.d., added jitter of {jitter_new:.1e} to the diagonal", NumericalWarning)
                     return L
                 except RuntimeError:

--- a/gpytorch/utils/cholesky.py
+++ b/gpytorch/utils/cholesky.py
@@ -8,35 +8,20 @@ from .. import settings
 from .errors import NanError, NotPSDError
 from .warnings import NumericalWarning
 
+try:
+    from torch.linalg import cholesky_ex as cholesky_ex
 
-def psd_safe_cholesky(A, upper=False, out=None, jitter=None, max_tries=3):
-    """Compute the Cholesky decomposition of A. If A is only p.s.d, add a small jitter to the diagonal.
-    Args:
-        :attr:`A` (Tensor):
-            The tensor to compute the Cholesky decomposition of
-        :attr:`upper` (bool, optional):
-            See torch.cholesky
-        :attr:`out` (Tensor, optional):
-            See torch.cholesky
-        :attr:`jitter` (float, optional):
-            The jitter to add to the diagonal of A in case A is only p.s.d. If omitted,
-            uses settings.cholesky_jitter.value()
-        :attr:`max_tries` (int, optional):
-            Number of attempts (with successively increasing jitter) to make before raising an error.
-    """
-    # Maybe log
-    if settings.verbose_linalg.on():
-        settings.verbose_linalg.logger.debug(f"Running Cholesky on a matrix of size {A.shape}.")
+    def _psd_safe_cholesky(A, out=None, jitter=None, max_tries=3):
+        # Maybe log
+        if settings.verbose_linalg.on():
+            settings.verbose_linalg.logger.debug(f"Running Cholesky on a matrix of size {A.shape}.")
 
-    try:
-        L = torch.cholesky(A, upper=upper, out=out)
-        return L
-    except RuntimeError as e:
-        isnan = torch.isnan(A)
-        if isnan.any():
-            raise NanError(
-                f"cholesky_cpu: {isnan.sum().item()} of {A.numel()} elements of the {A.shape} tensor are NaN."
-            )
+        if out is not None:
+            out = (out, torch.empty(*A.shape[:-2], dtype=torch.int32))
+
+        L, info = cholesky_ex(A, out=out)
+        if not torch.any(info):
+            return L
 
         if jitter is None:
             jitter = settings.cholesky_jitter.value(A.dtype)
@@ -44,15 +29,73 @@ def psd_safe_cholesky(A, upper=False, out=None, jitter=None, max_tries=3):
         jitter_prev = 0
         for i in range(max_tries):
             jitter_new = jitter * (10 ** i)
-            Aprime.diagonal(dim1=-2, dim2=-1).add_(jitter_new - jitter_prev)
+            # add jitter only where needed
+            diag_add = ((info > 0) * (jitter_new - jitter_prev)).unsqueeze(-1).expand(*Aprime.shape[:-1])
+            Aprime.diagonal(dim1=-1, dim2=-2).add_(diag_add)
             jitter_prev = jitter_new
-            try:
-                L = torch.cholesky(Aprime, upper=upper, out=out)
-                warnings.warn(f"A not p.d., added jitter of {jitter_new:.1e} to the diagonal", NumericalWarning)
+            warnings.warn(f"A not p.d., added jitter of {jitter_new:.1e} to the diagonal", NumericalWarning)
+            L, info = cholesky_ex(Aprime, out=out)
+            if not torch.any(info):
                 return L
-            except RuntimeError:
-                continue
-        raise NotPSDError(
-            f"Matrix not positive definite after repeatedly adding jitter up to {jitter_new:.1e}. "
-            f"Original error on first attempt: {e}"
-        )
+        raise NotPSDError(f"Matrix not positive definite after repeatedly adding jitter up to {jitter_new:.1e}.")
+
+
+except ImportError:
+
+    # Fall back to torch.cholesky - this can be more than 3 orders of magnitude slower!
+    # TODO: Remove once PyTorch req. is >= 1.9
+
+    def _psd_safe_cholesky(A, upper=False, out=None, jitter=None, max_tries=3):
+        # Maybe log
+        if settings.verbose_linalg.on():
+            settings.verbose_linalg.logger.debug(f"Running Cholesky on a matrix of size {A.shape}.")
+
+        try:
+            L = torch.cholesky(A, upper=upper, out=out)
+            return L
+        except RuntimeError as e:
+            isnan = torch.isnan(A)
+            if isnan.any():
+                raise NanError(
+                    f"cholesky_cpu: {isnan.sum().item()} of {A.numel()} elements of the {A.shape} tensor are NaN."
+                )
+
+            if jitter is None:
+                jitter = settings.cholesky_jitter.value(A.dtype)
+            Aprime = A.clone()
+            jitter_prev = 0
+            for i in range(max_tries):
+                jitter_new = jitter * (10 ** i)
+                Aprime.diagonal(dim1=-2, dim2=-1).add_(jitter_new - jitter_prev)
+                jitter_prev = jitter_new
+                try:
+                    L = torch.cholesky(Aprime, upper=upper, out=out)
+                    warnings.warn(f"A not p.d., added jitter of {jitter_new:.1e} to the diagonal", NumericalWarning)
+                    return L
+                except RuntimeError:
+                    continue
+            raise NotPSDError(
+                f"Matrix not positive definite after repeatedly adding jitter up to {jitter_new:.1e}. "
+                f"Original error on first attempt: {e}"
+            )
+
+
+def psd_safe_cholesky(A, upper=False, out=None, jitter=None, max_tries=3):
+    """Compute the Cholesky decomposition of A. If A is only p.s.d, add a small jitter to the diagonal.
+        Args:
+            :attr:`A` (Tensor):
+                The tensor to compute the Cholesky decomposition of
+            :attr:`upper` (bool, optional):
+                See torch.cholesky
+            :attr:`out` (Tensor, optional):
+                See torch.cholesky
+            :attr:`jitter` (float, optional):
+                The jitter to add to the diagonal of A in case A is only p.s.d. If omitted,
+                uses settings.cholesky_jitter.value()
+            :attr:`max_tries` (int, optional):
+                Number of attempts (with successively increasing jitter) to make before raising an error.
+        """
+    L = _psd_safe_cholesky(A, out=out, jitter=jitter, max_tries=max_tries)
+    if upper:
+        L = L.transpose(-1, -2)
+    return L

--- a/gpytorch/utils/cholesky.py
+++ b/gpytorch/utils/cholesky.py
@@ -97,5 +97,8 @@ def psd_safe_cholesky(A, upper=False, out=None, jitter=None, max_tries=3):
         """
     L = _psd_safe_cholesky(A, out=out, jitter=jitter, max_tries=max_tries)
     if upper:
-        L = L.transpose(-1, -2)
+        if out is not None:
+            out = out.transpose_(-1, -2)
+        else:
+            L = L.transpose(-1, -2)
     return L

--- a/gpytorch/utils/cholesky.py
+++ b/gpytorch/utils/cholesky.py
@@ -9,7 +9,9 @@ from .errors import NanError, NotPSDError
 from .warnings import NumericalWarning
 
 try:
-    from torch.linalg import cholesky_ex as cholesky_ex
+    from torch.linalg import cholesky_ex  # noqa: F401
+
+    CHOLESKY_METHOD = "torch.linalg.cholesky_ex"  # used for counting mock calls
 
     def _psd_safe_cholesky(A, out=None, jitter=None, max_tries=3):
         # Maybe log
@@ -17,11 +19,17 @@ try:
             settings.verbose_linalg.logger.debug(f"Running Cholesky on a matrix of size {A.shape}.")
 
         if out is not None:
-            out = (out, torch.empty(*A.shape[:-2], dtype=torch.int32))
+            out = (out, torch.empty(A.shape[:-2], dtype=torch.int32))
 
-        L, info = cholesky_ex(A, out=out)
+        L, info = torch.linalg.cholesky_ex(A, out=out)
         if not torch.any(info):
             return L
+
+        isnan = torch.isnan(A)
+        if isnan.any():
+            raise NanError(
+                f"cholesky_cpu: {isnan.sum().item()} of {A.numel()} elements of the {A.shape} tensor are NaN."
+            )
 
         if jitter is None:
             jitter = settings.cholesky_jitter.value(A.dtype)
@@ -34,7 +42,7 @@ try:
             Aprime.diagonal(dim1=-1, dim2=-2).add_(diag_add)
             jitter_prev = jitter_new
             warnings.warn(f"A not p.d., added jitter of {jitter_new:.1e} to the diagonal", NumericalWarning)
-            L, info = cholesky_ex(Aprime, out=out)
+            L, info = torch.linalg.cholesky_ex(Aprime, out=out)
             if not torch.any(info):
                 return L
         raise NotPSDError(f"Matrix not positive definite after repeatedly adding jitter up to {jitter_new:.1e}.")
@@ -44,6 +52,8 @@ except ImportError:
 
     # Fall back to torch.cholesky - this can be more than 3 orders of magnitude slower!
     # TODO: Remove once PyTorch req. is >= 1.9
+
+    CHOLESKY_METHOD = "torch.cholesky"  # used for counting mock calls
 
     def _psd_safe_cholesky(A, out=None, jitter=None, max_tries=3):
         # Maybe log


### PR DESCRIPTION
This can *significantly* speed up `psd_safe_cholesky` due to cutting out the pytorch error-handling middle man, achieving ~2,000 X reduction in wall time: https://github.com/pytorch/pytorch/pull/56724#issuecomment-825397299.

This also allows us to add jitter to the specific batch elements for which the decomp failed (rather than indiscriminately to all).

This requires https://github.com/pytorch/pytorch/pull/56724 that hasn't landed yet but will be part of 1.9. Either way, I implemented this in a backward-compatible fashion so this will work with older pytorch versions as well.