### PR TITLE
Fix IndexKernel for non-square cases and mixed discrete-continuous inputs

### DIFF
--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -85,7 +85,7 @@ class IndexKernel(Kernel):
 
         i1, i2 = i1.long(), i2.long()
         covar_matrix = self._eval_covar_matrix()
-        batch_shape = _mul_broadcast_shape(i1.shape[:-2], self.batch_shape)
+        batch_shape = _mul_broadcast_shape(i1.shape[:-2], i2.shape[:-2], self.batch_shape)
 
         res = InterpolatedLazyTensor(
             base_lazy_tensor=covar_matrix,

--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -83,7 +83,7 @@ class IndexKernel(Kernel):
 
     def forward(self, i1, i2, **params):
 
-        i1, i2 = torch.LongTensor(i1.long()), torch.LongTensor(i2.long())
+        i1, i2 = i1.long(), i2.long()
         covar_matrix = self._eval_covar_matrix()
         batch_shape = _mul_broadcast_shape(i1.shape[:-2], self.batch_shape)
         index1_shape = batch_shape + i1.shape[-2:]

--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -86,12 +86,10 @@ class IndexKernel(Kernel):
         i1, i2 = i1.long(), i2.long()
         covar_matrix = self._eval_covar_matrix()
         batch_shape = _mul_broadcast_shape(i1.shape[:-2], self.batch_shape)
-        index1_shape = batch_shape + i1.shape[-2:]
-        index2_shape = batch_shape + i2.shape[-2:]
 
         res = InterpolatedLazyTensor(
             base_lazy_tensor=covar_matrix,
-            left_interp_indices=i1.expand(index1_shape),
-            right_interp_indices=i2.expand(index2_shape),
+            left_interp_indices=i1.expand(batch_shape + i1.shape[-2:]),
+            right_interp_indices=i2.expand(batch_shape + i2.shape[-2:]),
         )
         return res

--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -82,13 +82,16 @@ class IndexKernel(Kernel):
         return res
 
     def forward(self, i1, i2, **params):
+
+        i1, i2 = torch.LongTensor(i1.long()), torch.LongTensor(i2.long())
         covar_matrix = self._eval_covar_matrix()
         batch_shape = _mul_broadcast_shape(i1.shape[:-2], self.batch_shape)
-        index_shape = batch_shape + i1.shape[-2:]
+        index1_shape = batch_shape + i1.shape[-2:]
+        index2_shape = batch_shape + i2.shape[-2:]
 
         res = InterpolatedLazyTensor(
             base_lazy_tensor=covar_matrix,
-            left_interp_indices=i1.expand(index_shape),
-            right_interp_indices=i2.expand(index_shape),
+            left_interp_indices=i1.expand(index1_shape),
+            right_interp_indices=i2.expand(index2_shape),
         )
         return res


### PR DESCRIPTION
1. Currently IndexKernel doesn't work if the two inputs (`i1` and `i2`) have mismatching index shapes, and this looks like a broadcasting bug to me, hopefully a minor fix. 
2. Currently IndexKernel is incompatible with using `ard_num_dims` and `active_dims` to split a single input into continuous and discrete kernels (via additive or multiplicative kernel, or some other wrapper). Not sure if this is intended functionality, but it'd be nice to have. The explicit cast fixes that. 