### PR TITLE
Working keops bypass for RBF

### DIFF
--- a/gpytorch/kernels/keops/rbf_kernel.py
+++ b/gpytorch/kernels/keops/rbf_kernel.py
@@ -26,17 +26,17 @@ try:
             )
 
         def covar_func(self, x1, x2, diag=False):
-           # We only should use KeOps on big kernel matrices
-           # If we would otherwise be performing Cholesky inference, (or when just computing a kernel matrix diag)
-           # then don't apply KeOps
-           if (
-               diag
-               or x1.size(-2) < settings.max_cholesky_size.value()
-               or x2.size(-2) < settings.max_cholesky_size.value()
-           ):
-               return self._nonkeops_covar_func(x1, x2, diag=diag)
+            # We only should use KeOps on big kernel matrices
+            # If we would otherwise be performing Cholesky inference, (or when just computing a kernel matrix diag)
+            # then don't apply KeOps
+            if (
+                diag
+                or x1.size(-2) < settings.max_cholesky_size.value()
+                or x2.size(-2) < settings.max_cholesky_size.value()
+            ):
+                return self._nonkeops_covar_func(x1, x2, diag=diag)
 
-           with torch.autograd.enable_grad():
+            with torch.autograd.enable_grad():
                 x1_ = KEOLazyTensor(x1[..., :, None, :])
                 x2_ = KEOLazyTensor(x2[..., None, :, :])
 
@@ -47,7 +47,7 @@ try:
         def forward(self, x1, x2, diag=False, **params):
             x1_ = x1.div(self.lengthscale)
             x2_ = x2.div(self.lengthscale)
-            
+
             covar_func = lambda x1, x2, diag=diag: self.covar_func(x1, x2, diag)
 
             if diag:

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -262,7 +262,7 @@ class LazyEvaluatedKernelTensor(LazyTensor):
             if res.shape != expected_shape:
                 raise RuntimeError(
                     "The kernel {} is not equipped to handle and diag. Expected size {}. "
-                    "Got size {}".format(self.__class__.__name__, expected_shape, res.shape)
+                    "Got size {}".format(self.kernel.__class__.__name__, expected_shape, res.shape)
                 )
 
         if isinstance(res, LazyTensor):


### PR DESCRIPTION
The KeOps bypass logic in the KeOps RBF kernel doesn't work if `diag=True` since the lambda function is explicitly created with `diag=False`. In fixing it I also moved the logic into `forward` since there's not much value in creating a KeOpsLazyTensor out of the result if we're not going to use KeOps as far as I can tell.

The Matern kernel is fine.