### PR TITLE
Raise error if "initialize" method is called in eval mode.

### DIFF
--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -90,6 +90,12 @@ class Module(nn.Module):
                 module.initialize(**{name: val})
             elif not hasattr(self, name):
                 raise AttributeError("Unknown parameter {p} for {c}".format(p=name, c=self.__class__.__name__))
+            elif not self.training:
+                raise RuntimeError(
+                    f"Attempting to set parameter {name} while in eval mode. "
+                    "This is discouraged because certain cached tensors may not be appropriately updated. "
+                    "Please call self.train() and try again."
+                )
             elif name not in self._parameters and name not in self._buffers:
                 setattr(self, name, val)
             elif torch.is_tensor(val):


### PR DESCRIPTION
This PR is in response to #1556, wherein updating kernel hyperparameters while in eval mode leads to incorrect predictions because the cached values in `model.prediction_strategy` are not updated. As suggested by @jacobrgardner a simple way to avoid this is to throw an error if the parameters are updated in eval mode. I've implemented this by adding a small check in `Module.initialize`.

Pros of this implementation:
- Affects all setter methods in one place (since they all seem to call `self.initialize`)
- Simpler than writing separate code for each setter method

Cons of this implementation:
- The check performed isn't exactly right: technically it only checks whether the *kernel* is in eval mode, when the actual problem is when the *GP model* is in eval mode since the GP model holds the problematic cached values. Although uncommon, it is possible for the `.training` attribute to be different between submodules (for example if the user manually sets them). It is unclear if this can be avoided since the kernel modules don't seem to contain a reference to the GP model that contains them.
- Users can still bypass this if they set the `raw_*` tensors directly (although maybe this isn't a bad thing)