### PR TITLE
DOC fix typo in formula of PeriodicKernel

### DIFF
--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -16,7 +16,7 @@ class PeriodicKernel(Kernel):
 
        \begin{equation*}
           k_{\text{Periodic}}(\mathbf{x_1}, \mathbf{x_2}) = \exp \left(
-            \frac{2 \sin^2 \left( \pi \Vert \mathbf{x_1} - \mathbf{x_2} \Vert_1 / p \right) }
+            \frac{-2 \sin^2 \left( \pi \Vert \mathbf{x_1} - \mathbf{x_2} \Vert_1 / p \right) }
             { \ell^2 } \right)
        \end{equation*}
 


### PR DESCRIPTION
There are currently a typo in the equation of the `PeriodicKernel` that does not reflect the implementation.