### PR TITLE
inv_quad_logdet method for sumKronecker

### DIFF
--- a/gpytorch/lazy/sum_kronecker_lazy_tensor.py
+++ b/gpytorch/lazy/sum_kronecker_lazy_tensor.py
@@ -75,7 +75,7 @@ class SumKroneckerLazyTensor(SumLazyTensor):
         logdet_term = None
 
         if inv_quad_rhs is not None:
-            solve = self._solve(inv_quad_rhs)
+            solve = self.inv_matmul(inv_quad_rhs)
             inv_quad_term = (inv_quad_rhs * solve).sum(-2)
 
             if inv_quad_term.numel() and reduce_inv_quad:

--- a/test/lazy/test_sum_kronecker_lazy_tensor.py
+++ b/test/lazy/test_sum_kronecker_lazy_tensor.py
@@ -22,7 +22,7 @@ class TestSumKroneckerLazyTensor(LazyTensorTestCase, unittest.TestCase):
     seed = 0
     should_call_lanczos = True
     should_call_cg = False
-    skip_slq_tests = True
+    skip_slq_tests = False
 
     def create_lazy_tensor(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
@@ -47,3 +47,19 @@ class TestSumKroneckerLazyTensor(LazyTensorTestCase, unittest.TestCase):
             lazy_tensor.lazy_tensors[1].lazy_tensors[0].tensor, lazy_tensor.lazy_tensors[1].lazy_tensors[1].tensor
         )
         return res1 + res2
+
+    def test_inv_quad_logdet(self):
+        # mock call cg here
+        self.__class__.should_call_cg = True
+        super().test_inv_quad_logdet()
+        self.__class__.should_call_cg = False
+
+    def test_inv_quad_logdet_no_reduce(self):
+        self.__class__.should_call_cg = True
+        super().test_inv_quad_logdet_no_reduce()
+        self.__class__.should_call_cg = False
+
+    def test_root_decomposition_cholesky(self):
+        self.__class__.should_call_cg = True
+        super().test_root_decomposition_cholesky()
+        self.__class__.should_call_cg = False


### PR DESCRIPTION
Fix for #1673. Had to do some weird things with the unit test because I think it's proper to allow `linear_cg` to be called in this situation (solve itself doesn't use cg, but the sub-solve does).

Edit: Also realized that previously rank > 1 multi-task gaussian likelihoods were not returning the specialized `SumKroneckerLazyTensor`, which is a pretty big performance hit (CG vs structured e-decomp solves / logdets).