### PR TITLE
Fix SGPR prediction speed with no fast_computations

### DIFF
--- a/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
@@ -124,3 +124,24 @@ class LowRankRootAddedDiagLazyTensor(AddedDiagLazyTensor):
             logdet_term = self._logdet()
 
         return inv_quad_term, logdet_term
+
+    def inv_matmul(self, right_tensor, left_tensor=None):
+            if not self.is_square:
+                raise RuntimeError(
+                    "inv_matmul only operates on (batches of) square (positive semi-definite) LazyTensors. "
+                    "Got a {} of size {}.".format(self.__class__.__name__, self.size())
+                )
+
+            if self.dim() == 2 and right_tensor.dim() == 1:
+                if self.shape[-1] != right_tensor.numel():
+                    raise RuntimeError(
+                        "LazyTensor (size={}) cannot be multiplied with right-hand-side Tensor (size={}).".format(
+                            self.shape, right_tensor.shape
+                        )
+                    )
+
+            solve = self._solve(right_tensor)
+            if left_tensor is not None:
+                return left_tensor @ solve
+            else:
+                return solve

--- a/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
@@ -126,22 +126,22 @@ class LowRankRootAddedDiagLazyTensor(AddedDiagLazyTensor):
         return inv_quad_term, logdet_term
 
     def inv_matmul(self, right_tensor, left_tensor=None):
-            if not self.is_square:
+        if not self.is_square:
+            raise RuntimeError(
+                "inv_matmul only operates on (batches of) square (positive semi-definite) LazyTensors. "
+                "Got a {} of size {}.".format(self.__class__.__name__, self.size())
+            )
+
+        if self.dim() == 2 and right_tensor.dim() == 1:
+            if self.shape[-1] != right_tensor.numel():
                 raise RuntimeError(
-                    "inv_matmul only operates on (batches of) square (positive semi-definite) LazyTensors. "
-                    "Got a {} of size {}.".format(self.__class__.__name__, self.size())
+                    "LazyTensor (size={}) cannot be multiplied with right-hand-side Tensor (size={}).".format(
+                        self.shape, right_tensor.shape
+                    )
                 )
 
-            if self.dim() == 2 and right_tensor.dim() == 1:
-                if self.shape[-1] != right_tensor.numel():
-                    raise RuntimeError(
-                        "LazyTensor (size={}) cannot be multiplied with right-hand-side Tensor (size={}).".format(
-                            self.shape, right_tensor.shape
-                        )
-                    )
-
-            solve = self._solve(right_tensor)
-            if left_tensor is not None:
-                return left_tensor @ solve
-            else:
-                return solve
+        solve = self._solve(right_tensor)
+        if left_tensor is not None:
+            return left_tensor @ solve
+        else:
+            return solve

--- a/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
+++ b/gpytorch/lazy/low_rank_root_added_diag_lazy_tensor.py
@@ -140,7 +140,15 @@ class LowRankRootAddedDiagLazyTensor(AddedDiagLazyTensor):
                     )
                 )
 
+        squeeze_solve = False
+        if right_tensor.ndimension() == 1:
+            right_tensor = right_tensor.unsqueeze(-1)
+            squeeze_solve = True
+
         solve = self._solve(right_tensor)
+        if squeeze_solve:
+            solve = solve.squeeze(-1)
+
         if left_tensor is not None:
             return left_tensor @ solve
         else:


### PR DESCRIPTION
With `fast_computations` off, our `InvMatmul` doesn't call `_solve` it calls `cholesky` regardless of the lazy tensor, so `LowRankRootAddedDiagLazyTensor` needs to override `inv_matmul` in addition to `inv_quad_logdet`

Addresses #1708 