### PR TITLE
Add half and float calls to lazy tensor

### DIFF
--- a/gpytorch/lazy/interpolated_lazy_tensor.py
+++ b/gpytorch/lazy/interpolated_lazy_tensor.py
@@ -386,6 +386,13 @@ class InterpolatedLazyTensor(LazyTensor):
         else:
             return super(InterpolatedLazyTensor, self).diag()
 
+    def double(self, device_id=None):
+        # We need to ensure that the indices remain integers.
+        new_lt = super().double(device_id=device_id)
+        new_lt.left_interp_indices = new_lt.left_interp_indices.type(torch.int64)
+        new_lt.right_interp_indices = new_lt.right_interp_indices.type(torch.int64)
+        return new_lt
+
     def matmul(self, tensor):
         # We're using a custom matmul here, because it is significantly faster than
         # what we get from the function factory.

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1960,6 +1960,16 @@ class LazyTensor(ABC):
 
         return res
 
+    def type(self, dtype):
+        if dtype == torch.float:
+            return self.float()
+        elif dtype == torch.double:
+            return self.double()
+        elif dtype == torch.half:
+            return self.half()
+        else:
+            raise RuntimeError("Dtype", dtype, "not found.")
+
     def unsqueeze(self, dim):
         positive_dim = (self.dim() + dim + 1) if dim < 0 else dim
         if positive_dim > len(self.batch_shape):

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1122,6 +1122,42 @@ class LazyTensor(ABC):
         """
         return self.representation_tree()(*self.representation())
 
+    def float(self, device_id=None):
+        """
+        This method operates identically to :func:`torch.Tensor.float`.
+        """
+        new_args = []
+        new_kwargs = {}
+        for arg in self._args:
+            if hasattr(arg, "float"):
+                new_args.append(arg.float())
+            else:
+                new_args.append(arg)
+        for name, val in self._kwargs.items():
+            if hasattr(val, "float"):
+                new_kwargs[name] = val.float()
+            else:
+                new_kwargs[name] = val
+        return self.__class__(*new_args, **new_kwargs)
+
+    def half(self, device_id=None):
+        """
+        This method operates identically to :func:`torch.Tensor.half`.
+        """
+        new_args = []
+        new_kwargs = {}
+        for arg in self._args:
+            if hasattr(arg, "half"):
+                new_args.append(arg.half())
+            else:
+                new_args.append(arg)
+        for name, val in self._kwargs.items():
+            if hasattr(val, "half"):
+                new_kwargs[name] = val.half()
+            else:
+                new_kwargs[name] = val
+        return self.__class__(*new_args, **new_kwargs)
+
     def inv_matmul(self, right_tensor, left_tensor=None):
         r"""
         Computes a linear solve (w.r.t self = :math:`A`) with several right hand sides :math:`R`.

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -3,6 +3,7 @@
 import math
 import warnings
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from typing import Optional, Tuple
 
 import torch
@@ -1067,12 +1068,18 @@ class LazyTensor(ABC):
         new_kwargs = {}
         for arg in self._args:
             if hasattr(arg, "double"):
-                new_args.append(arg.double())
+                try:
+                    new_args.append(arg.clone().double())
+                except AttributeError:
+                    new_args.append(deepcopy(arg).double())
             else:
                 new_args.append(arg)
         for name, val in self._kwargs.items():
             if hasattr(val, "double"):
-                new_kwargs[name] = val.double()
+                try:
+                    new_kwargs[name] = val.clone().double()
+                except AttributeError:
+                    new_kwargs[name] = deepcopy(val).double()
             else:
                 new_kwargs[name] = val
         return self.__class__(*new_args, **new_kwargs)
@@ -1130,12 +1137,18 @@ class LazyTensor(ABC):
         new_kwargs = {}
         for arg in self._args:
             if hasattr(arg, "float"):
-                new_args.append(arg.float())
+                try:
+                    new_args.append(arg.clone().float())
+                except AttributeError:
+                    new_args.append(deepcopy(arg).float())
             else:
                 new_args.append(arg)
         for name, val in self._kwargs.items():
             if hasattr(val, "float"):
-                new_kwargs[name] = val.float()
+                try:
+                    new_kwargs[name] = val.clone().float()
+                except AttributeError:
+                    new_kwargs[name] = deepcopy(val).float()
             else:
                 new_kwargs[name] = val
         return self.__class__(*new_args, **new_kwargs)
@@ -1148,12 +1161,18 @@ class LazyTensor(ABC):
         new_kwargs = {}
         for arg in self._args:
             if hasattr(arg, "half"):
-                new_args.append(arg.half())
+                try:
+                    new_args.append(arg.clone().half())
+                except AttributeError:
+                    new_args.append(deepcopy(arg).half())
             else:
                 new_args.append(arg)
         for name, val in self._kwargs.items():
             if hasattr(val, "half"):
-                new_kwargs[name] = val.half()
+                try:
+                    new_kwargs[name] = val.clone().half()
+                except AttributeError:
+                    new_kwargs[name] = deepcopy(val).half()
             else:
                 new_kwargs[name] = val
         return self.__class__(*new_args, **new_kwargs)

--- a/gpytorch/test/lazy_tensor_test_case.py
+++ b/gpytorch/test/lazy_tensor_test_case.py
@@ -475,6 +475,14 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
             self.assertAllClose(res, actual, **self.tolerances["cholesky"])
             # TODO: Check gradients
 
+    def test_double(self):
+        lazy_tensor = self.create_lazy_tensor()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        res = lazy_tensor.double()
+        actual = evaluated.double()
+        self.assertEqual(res.dtype, actual.dtype)
+
     def test_diag(self):
         lazy_tensor = self.create_lazy_tensor()
         evaluated = self.evaluate_lazy_tensor(lazy_tensor)
@@ -483,6 +491,25 @@ class LazyTensorTestCase(RectangularLazyTensorTestCase):
         actual = evaluated.diagonal(dim1=-2, dim2=-1)
         actual = actual.view(*lazy_tensor.batch_shape, -1)
         self.assertAllClose(res, actual, **self.tolerances["diag"])
+
+    def test_float(self):
+        lazy_tensor = self.create_lazy_tensor().double()
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        res = lazy_tensor.float()
+        actual = evaluated.float()
+        self.assertEqual(res.dtype, actual.dtype)
+
+    def _test_half(self, lazy_tensor):
+        evaluated = self.evaluate_lazy_tensor(lazy_tensor)
+
+        res = lazy_tensor.half()
+        actual = evaluated.half()
+        self.assertEqual(res.dtype, actual.dtype)
+
+    def test_half(self):
+        lazy_tensor = self.create_lazy_tensor()
+        self._test_half(lazy_tensor)
 
     def test_inv_matmul_vector(self, cholesky=False):
         lazy_tensor = self.create_lazy_tensor()

--- a/test/lazy/test_interpolated_lazy_tensor.py
+++ b/test/lazy/test_interpolated_lazy_tensor.py
@@ -35,8 +35,8 @@ class TestInterpolatedLazyTensor(LazyTensorTestCase, unittest.TestCase):
         )
 
     def evaluate_lazy_tensor(self, lazy_tensor):
-        left_matrix = torch.zeros(4, 6)
-        right_matrix = torch.zeros(4, 6)
+        left_matrix = torch.zeros(4, 6, dtype=lazy_tensor.dtype)
+        right_matrix = torch.zeros(4, 6, dtype=lazy_tensor.dtype)
         left_matrix.scatter_(1, lazy_tensor.left_interp_indices, lazy_tensor.left_interp_values)
         right_matrix.scatter_(1, lazy_tensor.right_interp_indices, lazy_tensor.right_interp_values)
 
@@ -75,8 +75,8 @@ class TestInterpolatedLazyTensorBatch(LazyTensorTestCase, unittest.TestCase):
         left_matrix_comps = []
         right_matrix_comps = []
         for i in range(5):
-            left_matrix_comp = torch.zeros(4, 6)
-            right_matrix_comp = torch.zeros(4, 6)
+            left_matrix_comp = torch.zeros(4, 6, dtype=lazy_tensor.dtype)
+            right_matrix_comp = torch.zeros(4, 6, dtype=lazy_tensor.dtype)
             left_matrix_comp.scatter_(1, lazy_tensor.left_interp_indices[i], lazy_tensor.left_interp_values[i])
             right_matrix_comp.scatter_(1, lazy_tensor.right_interp_indices[i], lazy_tensor.right_interp_values[i])
             left_matrix_comps.append(left_matrix_comp.unsqueeze(0))
@@ -121,8 +121,8 @@ class TestInterpolatedLazyTensorMultiBatch(LazyTensorTestCase, unittest.TestCase
         right_matrix_comps = []
         for i in range(2):
             for j in range(5):
-                left_matrix_comp = torch.zeros(4, 6)
-                right_matrix_comp = torch.zeros(4, 6)
+                left_matrix_comp = torch.zeros(4, 6, dtype=lazy_tensor.dtype)
+                right_matrix_comp = torch.zeros(4, 6, dtype=lazy_tensor.dtype)
                 left_matrix_comp.scatter_(
                     1, lazy_tensor.left_interp_indices[i, j], lazy_tensor.left_interp_values[i, j]
                 )

--- a/test/lazy/test_lazy_evaluated_kernel_tensor.py
+++ b/test/lazy/test_lazy_evaluated_kernel_tensor.py
@@ -127,6 +127,13 @@ class TestLazyEvaluatedKernelTensorBatch(LazyTensorTestCase, unittest.TestCase):
     def test_quad_form_derivative(self):
         pass
 
+    def test_half(self):
+        # many transform operations aren't supported in half so we overwrite
+        # this test
+        lazy_tensor = self.create_lazy_tensor()
+        lazy_tensor.kernel.raw_lengthscale_constraint.transform = lambda x: x + 0.1
+        self._test_half(lazy_tensor)
+
 
 class TestLazyEvaluatedKernelTensorMultitaskBatch(TestLazyEvaluatedKernelTensorBatch):
     seed = 0
@@ -139,6 +146,13 @@ class TestLazyEvaluatedKernelTensorMultitaskBatch(TestLazyEvaluatedKernelTensorB
 
     def test_inv_matmul_matrix_with_checkpointing(self):
         pass
+
+    def test_half(self):
+        # many transform operations aren't supported in half so we overwrite
+        # this test
+        lazy_tensor = self.create_lazy_tensor()
+        lazy_tensor.kernel.data_covar_module.raw_lengthscale_constraint.transform = lambda x: x + 0.1
+        self._test_half(lazy_tensor)
 
 
 class TestLazyEvaluatedKernelTensorAdditive(TestLazyEvaluatedKernelTensorBatch):
@@ -162,3 +176,10 @@ class TestLazyEvaluatedKernelTensorAdditive(TestLazyEvaluatedKernelTensorBatch):
 
     def test_inv_matmul_matrix_with_checkpointing(self):
         pass
+
+    def test_half(self):
+        # many transform operations aren't supported in half so we overwrite
+        # this test
+        lazy_tensor = self.create_lazy_tensor()
+        lazy_tensor.kernel.base_kernel.raw_lengthscale_constraint.transform = lambda x: x + 0.1
+        self._test_half(lazy_tensor)


### PR DESCRIPTION
Adds half and float calls to lazy tensor, mimicking the `.double()` calls that were already implemented.

```python
lazy_tensor.half()
```