### PR TITLE
Enforce num_classes in DirichletLikelihood to be an integer

### DIFF
--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -309,7 +309,7 @@ class DirichletClassificationLikelihood(FixedNoiseGaussianLikelihood):
     """
 
     def _prepare_targets(self, targets, alpha_epsilon=0.01, dtype=torch.float):
-        num_classes = targets.max() + 1
+        num_classes = int(targets.max() + 1)
         # set alpha = \alpha_\epsilon
         alpha = alpha_epsilon * torch.ones(targets.shape[-1], num_classes, device=targets.device, dtype=dtype)
 


### PR DESCRIPTION
Fixes a small bug on intialization where `num_classes` might not necessarily be an integer if the maximum returned by `train_y` was actually a tensor (which I think is in Pytorch >= 1.9).
