### PR TITLE
Fix `_psd_safe_cholesky` on CUDA

### DIFF
--- a/gpytorch/utils/cholesky.py
+++ b/gpytorch/utils/cholesky.py
@@ -19,7 +19,7 @@ try:
             settings.verbose_linalg.logger.debug(f"Running Cholesky on a matrix of size {A.shape}.")
 
         if out is not None:
-            out = (out, torch.empty(A.shape[:-2], dtype=torch.int32))
+            out = (out, torch.empty(A.shape[:-2], dtype=torch.int32, device=out.device))
 
         L, info = torch.linalg.cholesky_ex(A, out=out)
         if not torch.any(info):


### PR DESCRIPTION
This was causing a test failure:

```python
_________________________________ TestPSDSafeCholesky.test_psd_safe_cholesky_pd_cuda __________________________________

self = <test.utils.test_cholesky.TestPSDSafeCholesky testMethod=test_psd_safe_cholesky_pd_cuda>, cuda = False

    def test_psd_safe_cholesky_pd_cuda(self, cuda=False):
        if torch.cuda.is_available():
                with least_used_cuda_device():
>                       self.test_psd_safe_cholesky_pd(cuda=True)

test\utils\test_cholesky.py:65:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test\utils\test_cholesky.py:50: in test_psd_safe_cholesky_pd
    psd_safe_cholesky(A, out=L_safe)
gpytorch\utils\cholesky.py:108: in psd_safe_cholesky
    L = _psd_safe_cholesky(A, out=out, jitter=jitter, max_tries=max_tries)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

A = tensor([[ 1.2500, -0.7500],
        [-0.7500,  3.2500]], device='cuda:0')
out = (tensor([[ 1.1180, -0.6708],
        [ 0.0000,  1.6733]], device='cuda:0'), tensor(1, dtype=torch.int32))
jitter = None, max_tries = 3

    def _psd_safe_cholesky(A, out=None, jitter=None, max_tries=3):
        # Maybe log
        if settings.verbose_linalg.on():
                settings.verbose_linalg.logger.debug(f"Running Cholesky on a matrix of size {A.shape}.")

        if out is not None:
                out = (out, torch.empty(A.shape[:-2], dtype=torch.int32))

>       L, info = torch.linalg.cholesky_ex(A, out=out)
E    RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking arugment for argument info in method wrapper_linalg_cholesky_ex_out_L)

gpytorch\utils\cholesky.py:24: RuntimeError
```

Also, `torch>=1.9` since https://github.com/cornellius-gp/gpytorch/commit/452443a000c6e043c11618c49479a8bb37af3c80, so https://github.com/cornellius-gp/gpytorch/blob/7289e7d43fc74f8e8dcfc3325fb2871ef5e828a0/gpytorch/utils/cholesky.py#L51-L90 can be removed as well as `CHOLESKY_METHOD`. I can do that too, either in this PR or in a separate one.