### PR TITLE
tighten test_kissgp_gp_mean_abs_error bound

### DIFF
--- a/test/examples/test_kissgp_multiplicative_regression.py
+++ b/test/examples/test_kissgp_multiplicative_regression.py
@@ -96,7 +96,7 @@ class TestKISSGPMultiplicativeRegression(unittest.TestCase):
         with gpytorch.settings.fast_pred_var():
             test_preds = likelihood(gp_model(test_x)).mean
         mean_abs_error = torch.mean(torch.abs(test_y - test_preds))
-        self.assertLess(mean_abs_error.squeeze().item(), 0.15)
+        self.assertLess(mean_abs_error.squeeze().item(), 0.04)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi,

The test `test_kissgp_gp_mean_abs_error` in `test_kissgp_multiplicative_regression.py` has an assertion bound (`self.assertLess(mean_abs_error.squeeze().item(), 0.15)`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/147425831-ca0fe5f2-9ebe-4a91-911d-d8470dd2165a.png" width="450">
</p>

Here we see that the bound of `0.15` is too loose since the original distribution (in orange) is much less than `0.15`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are below the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/147425843-3744c1d9-9812-4da5-b4fe-7d73df7d195f.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `0.15` (red dotted line) has a catch rate of 0.46.

To improve this test, I propose to tighten the bound to `0.04` (the blue dotted line). The new bound has a catch rate of 0.54 (+0.08 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and had >99 % pass rate). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.6.13
pytorch=1.10.0
```

my gpytorch Experiment SHA:
`19e67f371d4641fd2f9ad7c8a7887361bdaa53d6`