### PR TITLE
tighten test_unwhitened_svgp_regression.py::test_regression_error bound

### DIFF
--- a/test/examples/test_unwhitened_svgp_regression.py
+++ b/test/examples/test_unwhitened_svgp_regression.py
@@ -79,7 +79,7 @@ class TestSVGPRegression(BaseTestCase, unittest.TestCase):
         likelihood.eval()
         test_preds = likelihood(model(train_x)).mean.squeeze()
         mean_abs_error = torch.mean(torch.abs(train_y - test_preds) / 2)
-        self.assertLess(mean_abs_error.item(), 1e-1)
+        self.assertLess(mean_abs_error.item(), 0.014)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The test `test_regression_error` in `test_unwhitened_svgp_regression.py` has an assertion bound (`self.assertLess(mean_abs_error.item(), 1e-1)`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. Each mutant is generated using simple mutation operators (e.g. > can become < ) on source code covered by the test. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/150871651-b14794ff-0750-4d59-9905-55e1e01f3fdc.png" width="450">
</p>

Here we see that the bound of `0.1` is too loose since the original distribution (in orange) is less than `0.1`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are below the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/150871694-2cebf319-b6e9-482f-a0de-53a0803d9b6b.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `0.1` (red dotted line) has a catch rate of 0.28.

To improve this test, I propose to tighten the bound to `0.014` (the blue dotted line). The new bound has a catch rate of 0.43 (+0.15 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and observed 100 % pass rate). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.6.13
pytorch=1.10.0
```

my gpytorch Experiment SHA:
`19e67f371d4641fd2f9ad7c8a7887361bdaa53d6`