### PR TITLE
Enable Gradients for All keops forward calls

### DIFF
--- a/gpytorch/kernels/keops/matern_kernel.py
+++ b/gpytorch/kernels/keops/matern_kernel.py
@@ -43,7 +43,7 @@ try:
             # We only should use KeOps on big kernel matrices
             # If we would otherwise be performing Cholesky inference, (or when just computing a kernel matrix diag)
             # then don't apply KeOps
-            # enable gradients to ensure that test time caches on small predictions are still 
+            # enable gradients to ensure that test time caches on small predictions are still
             # backprop-able
             with torch.autograd.enable_grad():
                 if (

--- a/gpytorch/kernels/keops/matern_kernel.py
+++ b/gpytorch/kernels/keops/matern_kernel.py
@@ -43,19 +43,21 @@ try:
             # We only should use KeOps on big kernel matrices
             # If we would otherwise be performing Cholesky inference, (or when just computing a kernel matrix diag)
             # then don't apply KeOps
-            if (
-                diag
-                or x1.size(-2) < settings.max_cholesky_size.value()
-                or x2.size(-2) < settings.max_cholesky_size.value()
-            ):
-                return self._nonkeops_covar_func(x1, x2, diag=diag)
-            # TODO: x1 / x2 size checks are a work around for a very minor bug in KeOps.
-            # This bug is fixed on KeOps master, and we'll remove that part of the check
-            # when they cut a new release.
-            elif x1.size(-2) == 1 or x2.size(-2) == 1:
-                return self._nonkeops_covar_func(x1, x2, diag=diag)
-            else:
-                with torch.autograd.enable_grad():
+            # enable gradients to ensure that test time caches on small predictions are still 
+            # backprop-able
+            with torch.autograd.enable_grad():
+                if (
+                    diag
+                    or x1.size(-2) < settings.max_cholesky_size.value()
+                    or x2.size(-2) < settings.max_cholesky_size.value()
+                ):
+                    return self._nonkeops_covar_func(x1, x2, diag=diag)
+                # TODO: x1 / x2 size checks are a work around for a very minor bug in KeOps.
+                # This bug is fixed on KeOps master, and we'll remove that part of the check
+                # when they cut a new release.
+                elif x1.size(-2) == 1 or x2.size(-2) == 1:
+                    return self._nonkeops_covar_func(x1, x2, diag=diag)
+                else:
                     # We only should use KeOps on big kernel matrices
                     # If we would otherwise be performing Cholesky inference, then don't apply KeOps
                     if (

--- a/gpytorch/kernels/keops/rbf_kernel.py
+++ b/gpytorch/kernels/keops/rbf_kernel.py
@@ -22,15 +22,19 @@ try:
 
         def _nonkeops_covar_func(self, x1, x2, diag=False):
             return self.covar_dist(
-                x1, x2, square_dist=True, diag=diag, 
-                dist_postprocess_func=postprocess_rbf, postprocess=True
+                x1,
+                x2,
+                square_dist=True,
+                diag=diag,
+                dist_postprocess_func=postprocess_rbf,
+                postprocess=True,
             )
 
         def covar_func(self, x1, x2, diag=False):
             # We only should use KeOps on big kernel matrices
             # If we would otherwise be performing Cholesky inference, (or when just computing a kernel matrix diag)
             # then don't apply KeOps
-            # enable gradients to ensure that test time caches on small predictions are still 
+            # enable gradients to ensure that test time caches on small predictions are still
             # backprop-able
             with torch.autograd.enable_grad():
                 if (


### PR DESCRIPTION
Resolves #1885 .

This places the enable_grad flag in the top of the covar_func call for both keops RBF and Matern kernels. 

This behavior now is fine:
```python
import torch
from gpytorch.kernels.keops import RBFKernel
from gpytorch.kernels import ScaleKernel

train_x = torch.linspace(0, 1, 510).cuda().contiguous()
train_y = 3. * train_x

test_x = torch.linspace(0, 1, 52, requires_grad = True).cuda().contiguous()

kernel = ScaleKernel(RBFKernel()).cuda()
kxx = kernel(train_x)
solve = kxx.add_jitter(0.1).inv_matmul(train_y)

pred_mean = kernel(test_x, train_x).matmul(solve.detach())
print("fwds finished")
value = torch.autograd.grad(pred_mean.sum(), test_x)
# output is a tuple of length 52
```