### PR TITLE
Add more informative error message when train targets and the train prior distribution mismatch

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -46,8 +46,8 @@ class DefaultPredictionStrategy(object):
             )
         except RuntimeError:
             raise RuntimeError(
-                "Flattening the training labels failed. This most common cause of this error "
-                + "is because shapes of the prior mean and the training labels are mismatched."
+                "Flattening the training labels failed. The most common cause of this error "
+                + "is that the shapes of the prior mean and the training labels are mismatched."
                 + "The shape of the train targets is {0}, ".format(train_labels.shape)
                 + "while the reported shape of the mean is {0}.".format(train_prior_dist.mean.shape)
             )

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -40,7 +40,17 @@ class DefaultPredictionStrategy(object):
         self._train_shape = train_prior_dist.event_shape
 
         # Flatten the training labels
-        train_labels = train_labels.reshape(*train_labels.shape[: -len(self.train_shape)], self._train_shape.numel())
+        try:
+            train_labels = train_labels.reshape(
+                *train_labels.shape[: -len(self.train_shape)], self._train_shape.numel()
+            )
+        except RuntimeError:
+            raise RuntimeError(
+                "Flattening the training labels failed. This most common cause of this error "
+                + "is because shapes of the prior mean and the training labels are mismatched."
+                + "The shape of the train targets is {0}, ".format(train_labels.shape)
+                + "while the reported shape of the mean is {0}.".format(train_prior_dist.mean.shape)
+            )
 
         self.train_inputs = train_inputs
         self.train_prior_dist = train_prior_dist

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -46,8 +46,8 @@ class DefaultPredictionStrategy(object):
             )
         except RuntimeError:
             raise RuntimeError(
-                "Flattening the training labels failed. The most common cause of this error "
-                + "is that the shapes of the prior mean and the training labels are mismatched."
+                "Flattening the training labels failed. The most common cause of this error is "
+                + "that the shapes of the prior mean and the training labels are mismatched. "
                 + "The shape of the train targets is {0}, ".format(train_labels.shape)
                 + "while the reported shape of the mean is {0}.".format(train_prior_dist.mean.shape)
             )


### PR DESCRIPTION
Followup to #1903 about leaving a more informative error message when the training prior distribution is incorrectly shaped.

MWE from that issue:

```
import numpy as np
import torch
from botorch.models import SingleTaskGP, FixedNoiseGP
from botorch.utils.transforms import standardize, normalize, unnormalize
from botorch.fit import fit_gpytorch_model
from botorch.sampling import SobolQMCNormalSampler
from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
import matplotlib.pyplot as plt
import math
from botorch.models.gpytorch import GPyTorchModel
from botorch.models.gp_regression import SingleTaskGP
import gpytorch

class PriorMean(gpytorch.means.Mean):                                                                                                                                                                        
    def __init__(self, batch_shape=None):
        super().__init__()
        self.mean_func = self.f
        
    def forward(self, x):
        return self.mean_func(x)
    
    def f(self, t, noise_var = 0.):
        noise_var = torch.tensor(noise_var, dtype=torch.float32)
        return torch.sin(2* math.pi *t) * torch.exp(-.1*(10 - t)) + noise_var.sqrt() * torch.randn(t.shape)
    
class ExactGPModel(SingleTaskGP, GPyTorchModel):
    _num_outputs = 1  # to inform the BoTorch api

    def __init__(self, train_x, train_y, likelihood):
        super(ExactGPModel, self).__init__(train_x, train_y, likelihood)
#         self.mean_module = gpytorch.means.ConstantMean()
        self.mean_module = PriorMean()
        self.covar_module = gpytorch.kernels.ScaleKernel(gpytorch.kernels.RBFKernel())

    def forward(self, x):
        mean_x = self.mean_module(x)
        covar_x = self.covar_module(x)
        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)

train_t = torch.linspace(0, 4, 20).reshape(-1,1)
train_y = PriorMean.f(None, train_t, 0.01)
test_t  = torch.linspace(0, 10, 100).reshape(-1,1)
likelihood = gpytorch.likelihoods.GaussianLikelihood()
gp = ExactGPModel(train_t, train_y, likelihood)
mll     = ExactMarginalLogLikelihood(gp.likelihood, gp)
fit_gpytorch_model(mll);

pred = gp.likelihood(gp(test_t))
```

which now produces the following error message:
```
RuntimeError: Flattening the training labels failed. This most likely means that your training targets had an incorrect batch shape, such as an extra batch dimension. The shape of train_labels is torch.Size([20]).while the reported shape of the mean is torch.Size([20, 1]).
```
as compared to the previous error message:
```
RuntimeError: shape '[1]' is invalid for input of size 20
```