### PR TITLE
Pin pyro to <=1.8 in CI workflows

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         pip install pytest nbval jupyter tqdm matplotlib torchvision scipy
         python setup.py build develop
-        pip install git+https://github.com/pyro-ppl/pyro@master;
+        pip install "pyro-ppl<=1.8";
     - name: Run example notebooks
       run: |
         grep -l smoke_test examples/**/*.ipynb | xargs grep -L 'smoke_test = False' | CI=true xargs pytest --nbval-lax --current-env

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -31,7 +31,7 @@ jobs:
           pip install torch==1.9+cpu -f https://download.pytorch.org/whl/torch_stable.html;
         fi
         if [[ ${{ matrix.pyro }} == "with-pyro" ]]; then
-          pip install git+https://github.com/pyro-ppl/pyro@master;
+          pip install "pyro-ppl<=1.8";
         fi
         pip install -r requirements.txt
     - name: Run unit tests


### PR DESCRIPTION
Pyro 1.8.1 requires torch 1.11, which caused issues during install in the CI workflows.