### PR TITLE
Fix issues with indexing broadcasted LazyEvaluatedKernelTensors

### DIFF
--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -137,6 +137,9 @@ class LazyEvaluatedKernelTensor(LazyTensor):
         if len(batch_indices) == 0 or all(ind == slice(None, None, None) for ind in batch_indices):
             new_kernel = self.kernel  # Avoid unnecessary copying when we aren't explicitly indexing batch dims
         else:
+            # Deal with the fact that the batch shape could be different from the kernel's batch shape (e.g. due to broadcasting))
+            while len(batch_indices) > len(self.kernel._batch_shape) and batch_indices[0] == _noop_index:
+                batch_indices = batch_indices[1:]
             new_kernel = self.kernel.__getitem__(batch_indices)
 
         # Now construct a kernel with those indices

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -137,7 +137,8 @@ class LazyEvaluatedKernelTensor(LazyTensor):
         if len(batch_indices) == 0 or all(ind == slice(None, None, None) for ind in batch_indices):
             new_kernel = self.kernel  # Avoid unnecessary copying when we aren't explicitly indexing batch dims
         else:
-            # Deal with the fact that the batch shape could be different from the kernel's batch shape (e.g. due to broadcasting))
+            # Deal with the fact that the batch shape could be different from the kernel's batch shape
+            # (e.g. this can happen due to broadcasting)
             while len(batch_indices) > len(self.kernel._batch_shape) and batch_indices[0] == _noop_index:
                 batch_indices = batch_indices[1:]
             new_kernel = self.kernel.__getitem__(batch_indices)


### PR DESCRIPTION
When batch-evaluating the posterior of a model (i.e.when, in eval mode, passing in a tensor with a batch shape that has more dimensions than the batch shape of the training data), then, if the kernel is lazily evaluated, this leads to obscure indexing errors. The issue is that the raw parameters of the lazy evaluated kernel have different batch shapes than the batch shape of the covariance matrix.

Specifically, if train_batch_shape is the batch shape of the kernel (unbroadcasted, as used for computing the train-train covariance)` and the posterior is evaluated with some batch shape that has more dimensions, e.g. `eval_batch_shape = add_batch_shape + train_batch_shape`, then under the hood when the `LazyEvaluatedKernelTensor` is indexed, we use a batch index meant for the `eval_batch_shape` to index the underlyig ernel parameters (e.g. lengthscales) who only have the leading `train_batch_shape`, which casues indexing issues. This doesn't happen in the case of eager evaluations of the kernel, since the parameters are appropriately broadcasted to the new larger `eval_batch_shape` before indexing happens (i.e. when computing the kernel the parameters are automatically "broadcasted up" to the shape that's required to produce the kernel with the `eval_batch_shape`.

It's not entirely clear how to best fix this. The path pursued with this PR is to check pre-indexing whether the dimension of the batch shapes are different, and then automatically modify the indices that are passed to the `__getitem__` function of kernel (and thus subsequently to the various lazy tensors that the kernel consists of). It appears to work but seems quite dicey and easy to break, so open for alternative suggestions.

There likely will be similar issues if the posterior of a batchd model evaluated on a non-batch input is indexed while lazilyt evaluated, but that's something for an separate PR.