### PR TITLE
Add check in PolynomialKernel forwards if offset is batched

### DIFF
--- a/gpytorch/kernels/polynomial_kernel.py
+++ b/gpytorch/kernels/polynomial_kernel.py
@@ -93,7 +93,7 @@ class PolynomialKernel(Kernel):
         if diag:
             return ((x1 * x2).sum(dim=-1) + self.offset).pow(self.power)
 
-        if x1.dim() == 2 and x2.dim() == 2:
+        if (x1.dim() == 2 and x2.dim() == 2) and offset.dim() == 2:
             return torch.addmm(offset, x1, x2.transpose(-2, -1)).pow(self.power)
         else:
             return (torch.matmul(x1, x2.transpose(-2, -1)) + offset).pow(self.power)


### PR DESCRIPTION
Resolves #1964. 

The following code now runs:
```python
import torch
import gpytorch

class MultitaskGPModel(gpytorch.models.ApproximateGP):
    def __init__(self, grid_size=4, num_latents=2, grid_bounds=[(0., 31.)], num_tasks=256):
        variational_distribution = gpytorch.variational.CholeskyVariationalDistribution(
            grid_size, batch_shape=torch.Size([num_latents])
        )
        variational_strategy = gpytorch.variational.LMCVariationalStrategy(
            gpytorch.variational.GridInterpolationVariationalStrategy(
                self, grid_size, grid_bounds, variational_distribution
            ),
            num_tasks=num_tasks,
            num_latents=num_latents,
            latent_dim=-1
        )
        super().__init__(variational_strategy)

        self.mean_module = gpytorch.means.ConstantMean(batch_shape=torch.Size([num_latents]))
        self.covar_module = gpytorch.kernels.ScaleKernel(
            gpytorch.kernels.PolynomialKernel(batch_shape=torch.Size([num_latents]), power=2),
            # gpytorch.kernels.RBFKernel(batch_shape=torch.Size([num_latents])),
            batch_shape=torch.Size([num_latents])
        )
        
    def forward(self, x):
        mean_x = self.mean_module(x)
        covar_x = self.covar_module(x)
        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
    
gp_layer = MultitaskGPModel()
likelihood = gpytorch.likelihoods.MultitaskGaussianLikelihood(num_tasks=256)

x = torch.randint(32, size=(1,), dtype=torch.float32).unsqueeze(1)

noise = gp_layer(x)
noise = likelihood(noise)
noise = noise.rsample(torch.Size((3,3,)))
```