### PR TITLE
Make it possible to pickle constant mean with prior

### DIFF
--- a/gpytorch/means/constant_mean.py
+++ b/gpytorch/means/constant_mean.py
@@ -12,7 +12,13 @@ class ConstantMean(Mean):
         self.batch_shape = batch_shape
         self.register_parameter(name="constant", parameter=torch.nn.Parameter(torch.zeros(*batch_shape, 1)))
         if prior is not None:
-            self.register_prior("mean_prior", prior, "constant")
+            self.register_prior("mean_prior", prior, self._constant_param, self._constant_closure)
+
+    def _constant_param(self, m):
+        return m.constant
+
+    def _constant_closure(self, m, value):
+        return m.constant.data.fill_(value)
 
     def forward(self, input):
         if input.shape[:-2] == self.batch_shape:

--- a/test/means/test_constant_mean.py
+++ b/test/means/test_constant_mean.py
@@ -1,16 +1,26 @@
 #!/usr/bin/env python3
 
+import pickle
 import unittest
 
 import torch
 
 from gpytorch.means import ConstantMean
+from gpytorch.priors import NormalPrior
 from gpytorch.test.base_mean_test_case import BaseMeanTestCase
 
 
 class TestConstantMean(BaseMeanTestCase, unittest.TestCase):
     def create_mean(self):
         return ConstantMean()
+
+    def test_prior(self):
+        prior = NormalPrior(0.0, 1.0)
+        mean = ConstantMean(prior=prior)
+        self.assertEqual(mean.mean_prior, prior)
+        pickle.loads(pickle.dumps(mean))  # Should be able to pickle and unpickle with a prior
+        mean._constant_closure(mean, 1.234)
+        self.assertAlmostEqual(mean.constant.item(), 1.234)
 
 
 class TestConstantMeanBatch(BaseMeanTestCase, unittest.TestCase):


### PR DESCRIPTION
If we try to pickle a constant mean with a prior we end up with an `AttributeError: Can't pickle local object 'Module.register_prior.<locals>.closure'` error. The issue is that pickle doesn't seem to play well with specifying parameters by name (string). This PR makes it possible to pickle a constant mean with a simple prior (related: #1876 which made similar changes to some of the kernels to make it possible to pickle them).