### PR TITLE
Fixed documentation of CG's tolerance parameter

### DIFF
--- a/gpytorch/utils/contour_integral_quad.py
+++ b/gpytorch/utils/contour_integral_quad.py
@@ -21,7 +21,7 @@ def contour_integral_quad(
     shift_offset=0,
 ):
     r"""
-    Performs :math:`\mathbf K^{1/2} \mathbf b` or `\mathbf K^{-1/2} \mathbf b`
+    Performs :math:`\mathbf K^{1/2} \mathbf b` or :math:`\mathbf K^{-1/2} \mathbf b`
     using contour integral quadrature.
 
     :param gpytorch.lazy.LazyTensor lazy_tensor: LazyTensor representing :math:`\mathbf K`

--- a/gpytorch/utils/linear_cg.py
+++ b/gpytorch/utils/linear_cg.py
@@ -109,7 +109,7 @@ def linear_cg(
       - matmul_closure - a function which performs a left matrix multiplication with lhs_mat
       - rhs - the right-hand side of the equation
       - n_tridiag - returns a tridiagonalization of the first n_tridiag columns of rhs
-      - tolerance - stop the solve when the max residual is less than this
+      - tolerance - stop the solve when the average absolute residual is less than this
       - eps - noise to add to prevent division by zero
       - stop_updating_after - will stop updating a vector after this residual norm is reached
       - max_iter - the maximum number of CG iterations

--- a/gpytorch/utils/linear_cg.py
+++ b/gpytorch/utils/linear_cg.py
@@ -109,7 +109,7 @@ def linear_cg(
       - matmul_closure - a function which performs a left matrix multiplication with lhs_mat
       - rhs - the right-hand side of the equation
       - n_tridiag - returns a tridiagonalization of the first n_tridiag columns of rhs
-      - tolerance - stop the solve when the average absolute residual is less than this
+      - tolerance - stop the solve when the (average) norm of the residual(s) is less than this
       - eps - noise to add to prevent division by zero
       - stop_updating_after - will stop updating a vector after this residual norm is reached
       - max_iter - the maximum number of CG iterations


### PR DESCRIPTION
# In a Nutshell
The `tolerance` parameter of `linear_cg` was incorrectly documented as controlling the maximum residual, while the iteration stops when the average residual is below the `tolerance`. 

https://github.com/cornellius-gp/gpytorch/blob/306d7332d74b0d337552911d69d97d939991d031/gpytorch/utils/linear_cg.py#L285-L291