### PR TITLE
Avoid unit test naming convention in non-test classes

### DIFF
--- a/test/kernels/test_additive_and_product_kernels.py
+++ b/test/kernels/test_additive_and_product_kernels.py
@@ -9,7 +9,7 @@ import gpytorch
 from gpytorch.kernels import LinearKernel, MaternKernel, RBFKernel, RFFKernel
 
 
-class TestModel(gpytorch.models.ExactGP):
+class _TestModel(gpytorch.models.ExactGP):
     def __init__(self, train_x, train_y):
         likelihood = gpytorch.likelihoods.GaussianLikelihood()
         super().__init__(train_x, train_y, likelihood)
@@ -24,7 +24,7 @@ class TestModel(gpytorch.models.ExactGP):
         return gpytorch.distributions.MultivariateNormal(mean, covar)
 
 
-class TestModelNoStructure(gpytorch.models.ExactGP):
+class _TestModelNoStructure(gpytorch.models.ExactGP):
     def __init__(self, train_x, train_y):
         likelihood = gpytorch.likelihoods.GaussianLikelihood()
         super().__init__(train_x, train_y, likelihood)
@@ -330,7 +330,7 @@ class TestAdditiveAndProductKernel(unittest.TestCase):
     def test_kernel_output(self):
         train_x = torch.randn(1000, 3)
         train_y = torch.randn(1000)
-        model = TestModel(train_x, train_y)
+        model = _TestModel(train_x, train_y)
 
         # Make sure that the prior kernel is the correct type
         model.train()
@@ -345,7 +345,7 @@ class TestAdditiveAndProductKernel(unittest.TestCase):
     def test_kernel_output_no_structure(self):
         train_x = torch.randn(1000, 3)
         train_y = torch.randn(1000)
-        model = TestModelNoStructure(train_x, train_y)
+        model = _TestModelNoStructure(train_x, train_y)
 
         # Make sure that the prior kernel is the correct type
         model.train()

--- a/test/kernels/test_inducing_point_kernel.py
+++ b/test/kernels/test_inducing_point_kernel.py
@@ -9,7 +9,7 @@ import gpytorch
 from gpytorch.kernels import InducingPointKernel, RBFKernel, ScaleKernel
 
 
-class TestModel(gpytorch.models.ExactGP):
+class _TestModel(gpytorch.models.ExactGP):
     def __init__(self, train_x, train_y):
         likelihood = gpytorch.likelihoods.GaussianLikelihood()
         super().__init__(train_x, train_y, likelihood)
@@ -31,7 +31,7 @@ class TestInducingPointKernel(unittest.TestCase):
         train_x = torch.randn(1000, 3)
         train_y = torch.randn(1000)
         test_x = torch.randn(500, 3)
-        model = TestModel(train_x, train_y)
+        model = _TestModel(train_x, train_y)
 
         # Make sure that the prior kernel is the correct type
         model.train()


### PR DESCRIPTION
This gets rid of warnings of the kind
```
PytestCollectionWarning: cannot collect test class 'TestModel' because it has a __init__ constructor (from: test/kernels/test_inducing_point_kernel.py)
    class TestModel(gpytorch.models.ExactGP):
```