### PR TITLE
Unpin sklearn dependency version

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   run:
     - pytorch>=1.10
     - numpy
-    - scikit-learn<=1.0.2  # newer versions require py3.8
+    - scikit-learn
     - scipy
 
 test:

--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,5 @@ channels:
 dependencies:
   - pytorch
   - numpy
-  - scikit-learn<=1.0.2  # newer versions require py3.8
+  - scikit-learn
   - scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 torch>=1.10
 numpy
-scikit-learn<=1.0.2  # newer versions require py3.8
+scikit-learn
 scipy

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ try:
         install_requires = []
 except ImportError:
     pass
-install_requires += ["numpy", "scikit-learn<=1.0.2", "scipy"]
+install_requires += ["numpy", "scikit-learn", "scipy"]
 
 
 # Run the setup


### PR DESCRIPTION
I just ran the unit tests and it seems like scikit-learn 1.1.1 works fine with gpytorch. If the only reason for pinning is because scikit-learn no longer supports Python 3.7, that shouldn't affect Python 3.8+ users as well. Package managers like pip and [Spack](https://spack.io) will automatically select the version of scikit-learn that works for your Python version. Not sure about conda though.

@gpleiss @Balandat 

Closes #2052 @ngam 