### PR TITLE
torch.triangular_solve: fix deprecation warning

### DIFF
--- a/gpytorch/functions/_pivoted_cholesky.py
+++ b/gpytorch/functions/_pivoted_cholesky.py
@@ -112,16 +112,11 @@ class PivotedCholesky(Function):
             # Compute (Krows * L^{-T}) - the (pivoted) result of Pivoted Cholesky
             if hasattr(torch.linalg, "solve_triangular"):
                 # PyTorch 1.11+
-                res_pivoted = torch.cat(
-                    [L, torch.linalg.solve_triangular(L, Krows[..., m:, :].transpose(-1, -2), upper=False).transpose(-1, -2)],
-                    dim=-2,
-                )
+                solution = torch.linalg.solve_triangular(L, Krows[..., m:, :].transpose(-1, -2), upper=False)
             else:
                 # PyTorch 1.10
-                res_pivoted = torch.cat(
-                    [L, torch.triangular_solve(Krows[..., m:, :].transpose(-1, -2), L, upper=False)[0].transpose(-1, -2)],
-                    dim=-2,
-                )
+                solution = torch.triangular_solve(Krows[..., m:, :].transpose(-1, -2), L, upper=False)[0]
+            res_pivoted = torch.cat([L, solution.transpose(-1, -2)], dim=-2)
             res = apply_permutation(res_pivoted, left_permutation=_inverse_permutation, right_permutation=None)
 
             # Now compute the backward pass of res

--- a/gpytorch/kernels/inducing_point_kernel.py
+++ b/gpytorch/kernels/inducing_point_kernel.py
@@ -60,7 +60,7 @@ class InducingPointKernel(Kernel):
             eye = torch.eye(chol.size(-1), device=chol.device, dtype=chol.dtype)
             if hasattr(torch.linalg, "solve_triangular"):
                 # PyTorch 1.11+
-                inv_root = torch.linalg.solve_triangular(chol, eye)
+                inv_root = torch.linalg.solve_triangular(chol, eye, upper=True)
             else:
                 # PyTorch 1.10
                 inv_root = torch.triangular_solve(eye, chol)[0]

--- a/gpytorch/kernels/inducing_point_kernel.py
+++ b/gpytorch/kernels/inducing_point_kernel.py
@@ -58,7 +58,12 @@ class InducingPointKernel(Kernel):
         else:
             chol = psd_safe_cholesky(self._inducing_mat, upper=True)
             eye = torch.eye(chol.size(-1), device=chol.device, dtype=chol.dtype)
-            inv_root = torch.triangular_solve(eye, chol)[0]
+            if hasattr(torch.linalg, "solve_triangular"):
+                # PyTorch 1.11+
+                inv_root = torch.linalg.solve_triangular(chol, eye)
+            else:
+                # PyTorch 1.10
+                inv_root = torch.triangular_solve(eye, chol)[0]
 
             res = inv_root
             if not self.training:

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1807,7 +1807,12 @@ class LazyTensor(ABC):
             # we know L is triangular, so inverting is a simple triangular solve agaist the identity
             # we don't need the batch shape here, thanks to broadcasting
             Eye = torch.eye(L.shape[-2], device=L.device, dtype=L.dtype)
-            Linv = torch.triangular_solve(Eye, L, upper=False).solution
+            if hasattr(torch.linalg, "solve_triangular"):
+                # PyTorch 1.11+
+                Linv = torch.linalg.solve_triangular(L, Eye, upper=False)
+            else:
+                # PyTorch 1.10
+                Linv = torch.triangular_solve(Eye, L, upper=False).solution
             res = lazify(Linv.transpose(-1, -2))
             inv_root = res
         elif method == "lanczos":

--- a/gpytorch/lazy/triangular_lazy_tensor.py
+++ b/gpytorch/lazy/triangular_lazy_tensor.py
@@ -133,7 +133,12 @@ class TriangularLazyTensor(LazyTensor, _TriangularLazyTensorBase):
 
     def inv_matmul(self, right_tensor: Tensor, left_tensor: Optional[Tensor] = None) -> Tensor:
         if isinstance(self._tensor, NonLazyTensor):
-            res = torch.triangular_solve(right_tensor, self.evaluate(), upper=self.upper).solution
+            if hasattr(torch.linalg, "solve_triangular"):
+                # PyTorch 1.11+
+                res = torch.linalg.solve_triangular(self.evaluate(), right_tensor, upper=self.upper)
+            else:
+                # PyTorch 1.10
+                res = torch.triangular_solve(right_tensor, self.evaluate(), upper=self.upper).solution
         elif isinstance(self._tensor, BatchRepeatLazyTensor):
             res = self._tensor.base_lazy_tensor.inv_matmul(right_tensor, left_tensor)
             # TODO: Proper broadcasting

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -731,9 +731,16 @@ class SGPRPredictionStrategy(DefaultPredictionStrategy):
         # Form LT using woodbury
         ones = torch.tensor(1.0, dtype=root.dtype, device=root.device)
         chol_factor = lazify(root.transpose(-1, -2) @ (inv_diag @ root)).add_diag(ones)  # (I + \sigma^{-2} R^T R)^{-1}
-        woodbury_term = inv_diag @ torch.triangular_solve(
-            root.transpose(-1, -2), chol_factor.cholesky().evaluate(), upper=False
-        )[0].transpose(-1, -2)
+        if hasattr(torch.linalg, "solve_triangular"):
+            # PyTorch 1.11+
+            woodbury_term = inv_diag @ torch.linalg.solve_triangular(
+                chol_factor.cholesky().evaluate(), root.transpose(-1, -2), upper=False
+            ).transpose(-1, -2)
+        else:
+            # PyTorch 1.10
+            woodbury_term = inv_diag @ torch.triangular_solve(
+                root.transpose(-1, -2), chol_factor.cholesky().evaluate(), upper=False
+            )[0].transpose(-1, -2)
         # woodbury_term @ woodbury_term^T = \sigma^{-2} R (I + \sigma^{-2} R^T R)^{-1} R^T \sigma^{-2}
 
         inverse = AddedDiagLazyTensor(inv_diag, MatmulLazyTensor(-woodbury_term, woodbury_term.transpose(-1, -2)))

--- a/gpytorch/utils/pinverse.py
+++ b/gpytorch/utils/pinverse.py
@@ -11,8 +11,18 @@ def stable_pinverse(A: Tensor) -> Tensor:
     if A.shape[-2] >= A.shape[-1]:
         # skinny (or square) matrix
         Q, R = stable_qr(A)
-        return torch.triangular_solve(Q.transpose(-1, -2), R).solution
+        if hasattr(torch.linalg, "solve_triangular"):
+            # PyTorch 1.11+
+            return torch.linalg.solve_triangular(R, Q.transpose(-1, -2))
+        else:
+            # PyTorch 1.10
+            return torch.triangular_solve(Q.transpose(-1, -2), R).solution
     else:
         # fat matrix
         Q, R = stable_qr(A.transpose(-1, -2))
-        return torch.triangular_solve(Q.transpose(-1, -2), R).solution.transpose(-1, -2)
+        if hasattr(torch.linalg, "solve_triangular"):
+            # PyTorch 1.11+
+            return torch.linalg.solve_triangular(R, Q.transpose(-1, -2)).transpose(-1, -2)
+        else:
+            # PyTorch 1.10
+            return torch.triangular_solve(Q.transpose(-1, -2), R).solution.transpose(-1, -2)

--- a/gpytorch/utils/pinverse.py
+++ b/gpytorch/utils/pinverse.py
@@ -13,7 +13,7 @@ def stable_pinverse(A: Tensor) -> Tensor:
         Q, R = stable_qr(A)
         if hasattr(torch.linalg, "solve_triangular"):
             # PyTorch 1.11+
-            return torch.linalg.solve_triangular(R, Q.transpose(-1, -2))
+            return torch.linalg.solve_triangular(R, Q.transpose(-1, -2), upper=True)
         else:
             # PyTorch 1.10
             return torch.triangular_solve(Q.transpose(-1, -2), R).solution
@@ -22,7 +22,7 @@ def stable_pinverse(A: Tensor) -> Tensor:
         Q, R = stable_qr(A.transpose(-1, -2))
         if hasattr(torch.linalg, "solve_triangular"):
             # PyTorch 1.11+
-            return torch.linalg.solve_triangular(R, Q.transpose(-1, -2)).transpose(-1, -2)
+            return torch.linalg.solve_triangular(R, Q.transpose(-1, -2), upper=True).transpose(-1, -2)
         else:
             # PyTorch 1.10
             return torch.triangular_solve(Q.transpose(-1, -2), R).solution.transpose(-1, -2)

--- a/gpytorch/variational/natural_variational_distribution.py
+++ b/gpytorch/variational/natural_variational_distribution.py
@@ -73,7 +73,12 @@ class NaturalVariationalDistribution(_NaturalVariationalDistribution):
 
 def _triangular_inverse(A, upper=False):
     eye = torch.eye(A.size(-1), dtype=A.dtype, device=A.device)
-    return eye.triangular_solve(A, upper=upper).solution
+    if hasattr(torch.linalg, "solve_triangular"):
+        # PyTorch 1.11+
+        return torch.linalg.solve_triangular(A, eye, upper=upper)
+    else:
+        # PyTorch 1.10
+        return eye.triangular_solve(A, upper=upper).solution
 
 
 def _phi_for_cholesky_(A):


### PR DESCRIPTION
Every time I run my code with PyTorch 1.12, I see the following UserWarning printed:
```
~/lib/python3.9/site-packages/gpytorch/lazy/triangular_lazy_tensor.py:136: UserWarning: torch.triangular_solve is deprecated in favor of torch.linalg.solve_triangularand will be removed in a future PyTorch release.
torch.linalg.solve_triangular has its arguments reversed and does not return a copy of one of the inputs.
X = torch.triangular_solve(B, A).solution
should be replaced with
X = torch.linalg.solve_triangular(A, B). (Triggered internally at  ~/src/aten/src/ATen/native/BatchLinearAlgebra.cpp:2189.)
  res = torch.triangular_solve(right_tensor, self.evaluate(), upper=self.upper).solution
```
This PR fixes that by using `torch.linalg.triangular_solve` if it exists and falling back to `torch.solve_triangular` if it does not.

This isn't the cleanest solution. Maybe we should introduce a `compat.py` file to create a wrapper around this? If/when you drop PyTorch 1.10 support this will no longer be needed.