### PR TITLE
Fix missing tilde in docs

### DIFF
--- a/gpytorch/likelihoods/likelihood.py
+++ b/gpytorch/likelihoods/likelihood.py
@@ -83,7 +83,7 @@ try:
         distribution, as :math:`y(\mathbf x)` is equal to :math:`f(\mathbf x)` plus Gaussian noise:
 
         .. math::
-            y(\mathbf x) = f(\mathbf x) + \epsilon, \:\:\:\: \epsilon ~ N(0,\sigma^{2}_{n} \mathbf I)
+            y(\mathbf x) = f(\mathbf x) + \epsilon, \:\:\:\: \epsilon \sim N(0,\sigma^{2}_{n} \mathbf I)
 
         In the case of classification, this might be a Bernoulli distribution,
         where the probability that :math:`y=1` is given by the latent function

--- a/gpytorch/priors/horseshoe_prior.py
+++ b/gpytorch/priors/horseshoe_prior.py
@@ -21,7 +21,7 @@ class HorseshoePrior(Prior):
 
     with `K = 1 / sqrt(2 pi^3)`. Here, we simply use
 
-        pdf(x) ~ (lb(x) + ub(x)) / 2
+        pdf(x) \sim (lb(x) + ub(x)) / 2
 
     Reference: C. M. Carvalho, N. G. Polson, and J. G. Scott.
         The horseshoe estimator for sparse signals. Biometrika, 2010.

--- a/gpytorch/priors/lkj_prior.py
+++ b/gpytorch/priors/lkj_prior.py
@@ -16,7 +16,7 @@ class LKJCholeskyFactorPrior(Prior, LKJCholesky):
     .. math:
 
         \begin{equation*}
-            pdf(\Sigma) ~ |\Sigma| ^ (\eta  - 1)
+            pdf(\Sigma) \sim |\Sigma| ^ (\eta  - 1)
         \end{equation*}
 
     where :math:`\eta > 0` is a shape parameter and n is the dimension of the
@@ -44,7 +44,7 @@ class LKJPrior(LKJCholeskyFactorPrior):
     .. math:
 
         \begin{equation*}
-            pdf(\Sigma) ~ |\Sigma| ^ (\eta  - 1)
+            pdf(\Sigma) \sim |\Sigma| ^ (\eta  - 1)
         \end{equation*}
 
     where :math:`\eta > 0` is a shape parameter.

--- a/gpytorch/priors/smoothed_box_prior.py
+++ b/gpytorch/priors/smoothed_box_prior.py
@@ -22,7 +22,7 @@ class SmoothedBoxPrior(Prior):
         \begin{equation*}
             B = {x: a_i <= x_i <= b_i}
             d(x, B) = min_{x' in B} |x - x'|
-            pdf(x) ~ exp(- d(x, B)**2 / sqrt(2 * sigma^2))
+            pdf(x) \sim exp(- d(x, B)**2 / sqrt(2 * sigma^2))
         \end{equation*}
 
     """

--- a/gpytorch/priors/wishart_prior.py
+++ b/gpytorch/priors/wishart_prior.py
@@ -13,7 +13,7 @@ from .prior import Prior
 class WishartPrior(Prior):
     """Wishart prior over n x n positive definite matrices
 
-    pdf(Sigma) ~ |Sigma|^(nu - n - 1)/2 * exp(-0.5 * Trace(K^-1 Sigma))
+    pdf(Sigma) \sim |Sigma|^(nu - n - 1)/2 * exp(-0.5 * Trace(K^-1 Sigma))
 
     where nu > n - 1 are the degrees of freedom and K > 0 is the p x p scale matrix
 
@@ -65,7 +65,7 @@ class WishartPrior(Prior):
 class InverseWishartPrior(Prior):
     """Inverse Wishart prior over n x n positive definite matrices
 
-    pdf(Sigma) ~ |Sigma|^-(nu + 2 * n)/2 * exp(-0.5 * Trace(K Sigma^-1))
+    pdf(Sigma) \sim |Sigma|^-(nu + 2 * n)/2 * exp(-0.5 * Trace(K Sigma^-1))
 
     where nu > 0 are the degrees of freedom and K > 0 is the p x p scale matrix
 


### PR DESCRIPTION
The tilde in "ε ~ 𝑁(...)" was missing. Solution is to use the `\sim` character in LaTeX. See [before](https://docs.gpytorch.ai/en/latest/likelihoods.html#gpytorch.likelihoods.Likelihood) vs. [after](https://gpytorch--2073.org.readthedocs.build/en/2073/likelihoods.html#gpytorch.likelihoods.Likelihood).

Many of these equations aren't wrapped in math mode so aren't being rendered at all...