### PR TITLE
Upgrade to modern Sphinx

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,5 @@ sphinx:
 python:
   version: 3.7
   install:
+    - requirements: requirements.txt
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ sphinx
 sphinx_rtd_theme
 nbsphinx
 m2r2
+pyro-ppl

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,7 @@
-docutils==0.17.1
 nbformat
 ipython
 ipykernel
-sphinx==1.8.5
+sphinx
 sphinx_rtd_theme
-nbsphinx==0.8.7
-m2r
+nbsphinx
+m2r2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,7 +85,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.autodoc",
     "nbsphinx",
-    "m2r",
+    "m2r2",
 ]
 
 # Disable docstring inheritance
@@ -107,7 +107,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -208,11 +208,3 @@ texinfo_documents = [
         "Miscellaneous",
     )
 ]
-
-
-# Taken from https://github.com/pyro-ppl/pyro/blob/dev/docs/source/conf.py#L213
-# @jpchen's hack to get rtd builder to install latest pytorch
-# See similar line in the install section of .travis.yml
-if "READTHEDOCS" in os.environ:
-    os.system("pip install torch==1.10.0+cpu -f https://download.pytorch.org/whl/torch_stable.html")
-    os.system("pip install pyro-ppl")

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         "dev": ["black", "twine", "pre-commit"],
-        "docs": ["ipython", "ipykernel", "sphinx<3.0.0", "sphinx_rtd_theme", "nbsphinx", "m2r"],
+        "docs": ["ipython", "ipykernel", "sphinx", "sphinx_rtd_theme", "nbsphinx", "m2r2"],
         "examples": ["ipython", "jupyter", "matplotlib", "scipy", "torchvision", "tqdm"],
         "pyro": ["pyro-ppl>=1.8"],
         "keops": ["pykeops>=1.1.1"],

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
     install_requires=install_requires,
     extras_require={
         "dev": ["black", "twine", "pre-commit"],
-        "docs": ["ipython", "ipykernel", "sphinx", "sphinx_rtd_theme", "nbsphinx", "m2r2"],
         "examples": ["ipython", "jupyter", "matplotlib", "scipy", "torchvision", "tqdm"],
         "pyro": ["pyro-ppl>=1.8"],
         "keops": ["pykeops>=1.1.1"],


### PR DESCRIPTION
The docs are currently pinned to an ancient version of Sphinx from 2019. This PR updates the docs to support the latest version of Sphinx.

I'm working on a bunch of other doc fixes and this seemed like the best place to start so as to avoid tracking down known Sphinx issues that were fixed in a later release.