### PR TITLE
MultitaskMultivariateNormal: fix tensor reshape issue

### DIFF
--- a/gpytorch/distributions/multitask_multivariate_normal.py
+++ b/gpytorch/distributions/multitask_multivariate_normal.py
@@ -208,7 +208,7 @@ class MultitaskMultivariateNormal(MultivariateNormal):
             # flip shape of last two dimensions
             new_shape = value.shape[:-2] + value.shape[:-3:-1]
             value = value.view(new_shape).transpose(-1, -2).contiguous()
-        return super().log_prob(value.view(*value.shape[:-2], -1))
+        return super().log_prob(value.reshape(*value.shape[:-2], -1))
 
     @property
     def mean(self):


### PR DESCRIPTION
I'm experimenting with a multitask modeling problem and encountered the following error message:
```
Traceback (most recent call last):
  File "train.py", line 239, in multi
    loss = -criterion(predict_y, train_y)
  File "~/lib/python3.9/site-packages/gpytorch/module.py", line 30, in __call__
    outputs = self.forward(*inputs, **kwargs)
  File "~/lib/python3.9/site-packages/gpytorch/mlls/exact_marginal_log_likelihood.py", line 62, in forward
    res = output.log_prob(target)
  File "~/lib/python3.9/site-packages/gpytorch/distributions/multitask_multivariate_normal.py", line 211, in log_prob
    return super().log_prob(value.view(*value.shape[:-2], -1))
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```
I'm not sure exactly what is causing this issue, but replacing `view` with `reshape` solved the issue for me.

Unfortunately I can't share the code or data used to reproduce this issue since it's in-progress research, but I can try to find a minimal reproducible example if you need one.