### PR TITLE
Fix bug in preconditioned KISS-GP / Hadamard Multitask GPs

### DIFF
--- a/examples/02_Scalable_Exact_GPs/KISSGP_Regression.ipynb
+++ b/examples/02_Scalable_Exact_GPs/KISSGP_Regression.ipynb
@@ -53,7 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_x = torch.linspace(0, 1, 1000)\n",
+    "train_x = torch.linspace(0, 1, 2000)\n",
     "train_y = torch.sin(train_x * (4 * math.pi) + torch.randn(train_x.size()) * 0.2)"
    ]
   },
@@ -120,7 +120,7 @@
     "# this is for running the notebook in our testing framework\n",
     "import os\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "training_iterations = 1 if smoke_test else 30\n",
+    "training_iterations = 2 if smoke_test else 30\n",
     "\n",
     "\n",
     "# Find optimal model hyperparameters\n",

--- a/examples/03_Multitask_Exact_GPs/Hadamard_Multitask_GP_Regression.ipynb
+++ b/examples/03_Multitask_Exact_GPs/Hadamard_Multitask_GP_Regression.ipynb
@@ -58,8 +58,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_x1 = torch.rand(50)\n",
-    "train_x2 = torch.rand(50)\n",
+    "train_x1 = torch.rand(2000)\n",
+    "train_x2 = torch.rand(2000)\n",
     "\n",
     "train_y1 = torch.sin(train_x1 * (2 * math.pi)) + torch.randn(train_x1.size()) * 0.2\n",
     "train_y2 = torch.cos(train_x2 * (2 * math.pi)) + torch.randn(train_x2.size()) * 0.2"
@@ -296,7 +296,7 @@
   },
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -310,7 +310,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/examples/06_PyTorch_NN_Integration_DKL/KISSGP_Deep_Kernel_Regression_CUDA.ipynb
+++ b/examples/06_PyTorch_NN_Integration_DKL/KISSGP_Deep_Kernel_Regression_CUDA.ipynb
@@ -60,7 +60,7 @@
     "\n",
     "\n",
     "if smoke_test:  # this is for running the notebook in our testing framework\n",
-    "    X, y = torch.randn(20, 3), torch.randn(20)\n",
+    "    X, y = torch.randn(2000, 3), torch.randn(2000)\n",
     "else:\n",
     "    data = torch.Tensor(loadmat('../elevators.mat')['data'])\n",
     "    X = data[:, :-1]\n",

--- a/gpytorch/functions/_pivoted_cholesky.py
+++ b/gpytorch/functions/_pivoted_cholesky.py
@@ -98,7 +98,11 @@ class PivotedCholesky(Function):
 
         with torch.enable_grad():
             # Create a new set of matrix args that we can backpropagate through
-            matrix_args = [matrix_arg.detach().requires_grad_(True) for matrix_arg in _matrix_args]
+            matrix_args = []
+            for matrix_arg in _matrix_args:
+                if matrix_arg.dtype in (torch.float, torch.double, torch.half):
+                    matrix_arg = matrix_arg.detach().requires_grad_(True)
+                matrix_args.append(matrix_arg)
 
             # Create new linear operator using new matrix args
             matrix = ctx.representation_tree(*matrix_args)

--- a/gpytorch/lazy/lazy_tensor.py
+++ b/gpytorch/lazy/lazy_tensor.py
@@ -1651,7 +1651,8 @@ class LazyTensor(ABC):
                     arg.requires_grad_(val)
         for arg in self._kwargs.values():
             if hasattr(arg, "requires_grad"):
-                arg.requires_grad_(val)
+                if arg.dtype in (torch.float, torch.double, torch.half):
+                    arg.requires_grad_(val)
 
     @requires_grad.setter
     def requires_grad(self, val):


### PR DESCRIPTION
Previously in PyTorch, calling  on a int/long matrix was a no-op.
At some point in the PyTorch releases, this line started throwing an error (since only
floating point operations can have gradients).

Our implementation of pivoted cholesky previously called
`matrix_arg.requires_grad_(True)` on all LazyTensor/LinearOperator
arguments, without first checking whether `matrix_arg` was a floating
point dtype.

KISS-GP makes use of InterpolatedLazyTensor (to become InterpolatedLinearOperator), which
has integer matrices (the index matrices for interpolation). This
therefore produced an error message when it was used in conjunction with
the pivoted cholesky preconditioner. A similar bug exists for
preconditioned Hadamard Multitask GPs.

(The reason this bug went undetected is because our tests for KISS-GP
models and multitask models all use small datasets (N < 100).
Preconditioners are not used until N > 2000 or so.)

[Fixes #2056]