### PR TITLE
Run unittests with and without the faiss library.

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         pytorch-version: ["master", "stable"]
-        pyro: ["with-pyro", "no-pyro"]
+        extras: ["with-extras", "no-extras"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -51,8 +51,9 @@ jobs:
         else
           pip install torch==1.10+cpu -f https://download.pytorch.org/whl/torch_stable.html;
         fi
-        if [[ ${{ matrix.pyro }} == "with-pyro" ]]; then
+        if [[ ${{ matrix.extras }} == "with-extras" ]]; then
           pip install "pyro-ppl>=1.8";
+          pip install faiss-cpu;  # Unofficial pip release: https://pypi.org/project/faiss-cpu/#history
         fi
         pip install -r requirements.txt
     - name: Run unit tests
@@ -73,6 +74,7 @@ jobs:
         pip install -r requirements.txt
         python setup.py build develop
         pip install "pyro-ppl>=1.8";
+          pip install faiss-cpu;  # Unofficial pip release: https://pypi.org/project/faiss-cpu/#history
     - name: Run example notebooks
       run: |
         grep -l smoke_test examples/**/*.ipynb | xargs grep -L 'smoke_test = False' | CI=true xargs pytest --nbval-lax --current-env


### PR DESCRIPTION
faiss is now an optional package for GPyTorch, to be used in conjunction with the
VNNGP model (#2026) and hopefully more nearest neighbor GP methods in the future.
This PR ensures that our test suite tests the functionality of GPyTorch with and
without the faiss library.