### PR TITLE
Fix LMCVariationalStrategy example in docs

### DIFF
--- a/gpytorch/variational/lmc_variational_strategy.py
+++ b/gpytorch/variational/lmc_variational_strategy.py
@@ -78,11 +78,11 @@ class LMCVariationalStrategy(_VariationalStrategy):
         >>>         )
         >>>         variational_strategy = gpytorch.variational.LMCVariationalStrategy(
         >>>             gpytorch.variational.VariationalStrategy(
-        >>>                 inducing_points, variational_distribution, learn_inducing_locations=True,
+        >>>                 self, inducing_points, variational_distribution, learn_inducing_locations=True,
         >>>             ),
         >>>             num_tasks=5,
         >>>             num_latents=3,
-        >>>             latent_dim=0,
+        >>>             latent_dim=-1,
         >>>         )
         >>>
         >>>         # Each latent function has its own mean/kernel function


### PR DESCRIPTION
The first argument to `VariationalStrategy` should be the model, in this case `self`.

The `latent_dim` argument to `LMCVariationalStrategy` must be negative.