### PR TITLE
[RFC] Move input transforms to GPyTorch

### DIFF
--- a/gpytorch/models/approximate_gp.py
+++ b/gpytorch/models/approximate_gp.py
@@ -105,4 +105,5 @@ class ApproximateGP(GP, _PyroMixin):
     def __call__(self, inputs, prior=False, **kwargs):
         if inputs.dim() == 1:
             inputs = inputs.unsqueeze(-1)
+        inputs = self.apply_input_transforms(X=inputs, is_training_input=self.training)
         return self.variational_strategy(inputs, prior=prior, **kwargs)

--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -210,7 +210,11 @@ class ExactGP(GP):
         except KeyError:
             fantasy_kwargs = {}
 
-        full_output = super(ExactGP, self).__call__(*full_inputs, **kwargs)
+        # Prediction strategy should have transformed train inputs.
+        prediction_strategy_inputs = [
+            self.apply_input_transforms(X=t_input, is_training_input=True) for t_input in full_inputs
+        ]
+        full_output = super(ExactGP, self).__call__(*prediction_strategy_inputs, **kwargs)
 
         # Copy model without copying training data or prediction strategy (since we'll overwrite those)
         old_pred_strat = self.prediction_strategy
@@ -229,7 +233,7 @@ class ExactGP(GP):
 
         new_model.likelihood = old_likelihood.get_fantasy_likelihood(**fantasy_kwargs)
         new_model.prediction_strategy = old_pred_strat.get_fantasy_strategy(
-            inputs, targets, full_inputs, full_targets, full_output, **fantasy_kwargs
+            inputs, targets, prediction_strategy_inputs, full_targets, full_output, **fantasy_kwargs
         )
 
         # if the fantasies are at the same points, we need to expand the inputs for the new model
@@ -242,8 +246,17 @@ class ExactGP(GP):
         return new_model
 
     def __call__(self, *args, **kwargs):
-        train_inputs = list(self.train_inputs) if self.train_inputs is not None else []
-        inputs = [i.unsqueeze(-1) if i.ndimension() == 1 else i for i in args]
+        train_inputs = (
+            [self.apply_input_transforms(X=t_input, is_training_input=True) for t_input in self.train_inputs]
+            if self.train_inputs is not None
+            else []
+        )
+        inputs = [
+            self.apply_input_transforms(
+                X=i.unsqueeze(-1) if i.ndimension() == 1 else i, is_training_input=self.training
+            )
+            for i in args
+        ]
 
         # Training mode: optimizing
         if self.training:

--- a/gpytorch/models/gp.py
+++ b/gpytorch/models/gp.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python3
 
+from torch import Tensor
+
 from ..module import Module
 
 
 class GP(Module):
-    pass
+    def apply_input_transforms(self, X: Tensor, is_training_input: bool) -> Tensor:
+        input_transform = getattr(self, "input_transform", None)
+        if input_transform is not None:
+            return input_transform(X=X, is_training_input=is_training_input)
+        else:
+            return X


### PR DESCRIPTION
This diff presents a minimal implementation of input transforms in GPyTorch, as requested in #1652. This should be viewed together with pytorch/botorch#1372. The input transforms themselves are currently implemented in https://github.com/pytorch/botorch/blob/cdd668d18b2a7e35bed09b7a2b2fca40e5fd2067/botorch/models/transforms/input.py

What this does:
* Moves the `transform_inputs` from BoTorch `Model` to GPyTorch `GP` class, with some modifications to explicitly identify whether given inputs are train or test inputs.
* Modifies the `InputTransform.forward` call to use `is_training_input` argument instead of `self.training` check to apply the transforms that have `transform_on_train=True`.
* Removes `preprocess_transform` method since this is no-longer needed.
* For `ExactGP` models, it transforms both train and test inputs in `__call__`. For `train_inputs` it always uses `is_training_input=True`. For generic `inputs`, it uses `is_training_input=self.training` which signals that these are training inputs when the model is in `train` mode, and that these are test inputs when the model is in `eval` mode.
* For `ApproximateGP` models, it applies the transform to `inputs` in `__call__` using `is_training_input=self.training`. This again signifies whether the given inputs are train or test inputs based on the mode of the model. Note that this NEVER transforms `inducing_points`, thus fixes the previous bug with `inducing_points` getting transformed in `train` but not getting transformed in `eval`. It is expected that the user will define inducing points in the appropriate space (mostly the normalized space / unit cube).
* For BoTorch `SingleTaskVariationalGP`, it moves the `input_transform` attribute down to `_SingleTaskVariationalGP`, which is the actual `ApproximateGP` instance. This makes the transform accessible from GPyTorch.

What this doesn't do:
* It doesn't do anything about `DeterministicModel`s. Those will still need to deal with their own transforms, which is not implemented here. If we make `Model` inherit from `GP`, we can keep the existing setup with very minimal changes.
* It does not clean up the call sites for `self.transform_inputs`. This is just made into a no-op and the clean-up is left for later.
* It does not upstream the abstract `InputTransform` classes to GPyTorch. That'll be done if we decide to go forward with this design.
* It does not touch `PairwiseGP`. `PairwiseGP` has some non-standard use of input transforms, so it needs an audit to make sure things still work fine.
* I didn't look into `ApproximateGP.fantasize`. This may need some changes similar to `ExactGP.get_fantasy_model`.
* It does not support `PyroGP` and `DeepGP`.