### PR TITLE
Fix bug with Multitask DeepGP predictive variances.

### DIFF
--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -111,7 +111,7 @@ class _MultitaskGaussianLikelihoodBase(_GaussianLikelihoodBase):
         return function_dist.__class__(mean, covar, interleaved=function_dist._interleaved)
 
     def _shaped_noise_covar(
-        self, shape: torch.Size, add_noise: Optional[bool] = True, interleaved=True, *params, **kwargs
+        self, shape: torch.Size, add_noise: Optional[bool] = True, interleaved: bool = True, *params, **kwargs
     ) -> LinearOperator:
         if not self.has_task_noise:
             noise = ConstantDiagLinearOperator(self.noise, diag_shape=shape[-2] * self.num_tasks)

--- a/test/likelihoods/test_multitask_gaussian_likelihood.py
+++ b/test/likelihoods/test_multitask_gaussian_likelihood.py
@@ -3,7 +3,7 @@
 import unittest
 
 import torch
-from linear_operator.operators import KroneckerProductLinearOperator, RootLinearOperator
+from linear_operator.operators import KroneckerProductLinearOperator, RootLinearOperator, ToeplitzLinearOperator
 
 from gpytorch.distributions import MultitaskMultivariateNormal
 from gpytorch.likelihoods import MultitaskGaussianLikelihood
@@ -17,9 +17,9 @@ class TestMultitaskGaussianLikelihood(BaseLikelihoodTestCase, unittest.TestCase)
         return torch.randn(*batch_shape, 5, 4)
 
     def _create_marginal_input(self, batch_shape=torch.Size([])):
-        mat = torch.randn(*batch_shape, 5, 5)
-        mat2 = torch.randn(*batch_shape, 4, 4)
-        covar = KroneckerProductLinearOperator(RootLinearOperator(mat), RootLinearOperator(mat2))
+        data_mat = ToeplitzLinearOperator(torch.tensor([1, 0.6, 0.4, 0.2, 0.1]))
+        task_mat = RootLinearOperator(torch.tensor([[1.0], [2.0], [3.0], [4.0]]))
+        covar = KroneckerProductLinearOperator(data_mat, task_mat)
         return MultitaskMultivariateNormal(torch.randn(*batch_shape, 5, 4), covar)
 
     def _create_targets(self, batch_shape=torch.Size([])):
@@ -27,6 +27,22 @@ class TestMultitaskGaussianLikelihood(BaseLikelihoodTestCase, unittest.TestCase)
 
     def create_likelihood(self):
         return MultitaskGaussianLikelihood(num_tasks=4, rank=2)
+
+    def test_marginal_variance(self):
+        likelihood = MultitaskGaussianLikelihood(num_tasks=4, rank=0, has_global_noise=False)
+        likelihood.task_noises = torch.tensor([[0.1], [0.2], [0.3], [0.4]])
+
+        input = self._create_marginal_input()
+        variance = likelihood(input).variance
+        self.assertAllClose(variance, torch.tensor([1.1, 4.2, 9.3, 16.4]).repeat(5, 1))
+
+        likelihood = MultitaskGaussianLikelihood(num_tasks=4, rank=1, has_global_noise=True)
+        likelihood.noise = torch.tensor(0.1)
+        likelihood.task_noise_covar_factor.data = torch.tensor([[1.0], [2.0], [3.0], [4.0]])
+
+        input = self._create_marginal_input()
+        variance = likelihood(input).variance
+        self.assertAllClose(variance, torch.tensor([2.1, 8.1, 18.1, 32.1]).repeat(5, 1))
 
     def test_setters(self):
         likelihood = MultitaskGaussianLikelihood(num_tasks=3, rank=0)
@@ -57,6 +73,16 @@ class TestMultitaskGaussianLikelihood(BaseLikelihoodTestCase, unittest.TestCase)
         with self.assertRaises(AttributeError) as context:
             likelihood.task_noises = torch.tensor([0.04, 0.04, 0.04])
         self.assertTrue("task noises" in str(context.exception))
+
+
+class TestMultitaskGaussianLikelihoodNonInterleaved(TestMultitaskGaussianLikelihood, unittest.TestCase):
+    seed = 2
+
+    def _create_marginal_input(self, batch_shape=torch.Size([])):
+        data_mat = ToeplitzLinearOperator(torch.tensor([1, 0.6, 0.4, 0.2, 0.1]))
+        task_mat = RootLinearOperator(torch.tensor([[1.0], [2.0], [3.0], [4.0]]))
+        covar = KroneckerProductLinearOperator(task_mat, data_mat)
+        return MultitaskMultivariateNormal(torch.randn(*batch_shape, 5, 4), covar, interleaved=False)
 
 
 class TestMultitaskGaussianLikelihoodBatch(TestMultitaskGaussianLikelihood):


### PR DESCRIPTION
The latent variances of multitask DeepGP models are stored in non-interleaved covariance matrices.
Previously, the MultitaskMultivariateNormal.marginal method implicitly assumed that the function
covariance matrices were interleaved.

In particular, this affects multitask DeepGP models which use a
non-interleaved latent covariance matrix.

With this PR, MultitaskMultivariateNormal.marginal now checks if the input covariance matrix is
interleaved, and makes sure that the returned predictive covariance matrix matches the
interleaved/non-interleaved pattern of the latent covariance matrix.

[Fixes #2702]