### PR TITLE
Autogenerate parameter types in documentation from python typehints

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@ ipython
 ipykernel
 sphinx
 sphinx_rtd_theme
+sphinx_autodoc_typehints
 nbsphinx
 m2r2
 pyro-ppl

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,8 @@ import re
 import shutil
 import sys
 import sphinx_rtd_theme  # noqa
+import warnings
+from typing import ForwardRef
 
 
 def read(*names, **kwargs):
@@ -80,15 +82,24 @@ release = version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx.ext.autodoc",
     "sphinx.ext.coverage",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     'sphinx.ext.napoleon',
     "sphinx.ext.viewcode",
-    "sphinx.ext.githubpages",
-    "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
     "nbsphinx",
     "m2r2",
 ]
+
+# Configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "torch": ("https://pytorch.org/docs/stable/", None),
+    "linear_operator": ("https://linear-operator.readthedocs.io/en/stable/", None),
+}
 
 # Disable docstring inheritance
 autodoc_inherit_docstrings = False
@@ -210,3 +221,97 @@ texinfo_documents = [
         "Miscellaneous",
     )
 ]
+
+
+# -- Function to format  typehints ----------------------------------------------
+# Adapted from
+# https://github.com/cornellius-gp/linear_operator/blob/2b33b9f83b45f0cb8cb3490fc5f254cc59393c25/docs/source/conf.py
+def _process(annotation, config):
+    """
+    A function to convert a type/rtype typehint annotation into a :type:/:rtype: string.
+    This function is a bit hacky, and specific to the type annotations we use most frequently.
+    This function is recursive.
+    """
+    # Simple/base case: any string annotation is ready to go
+    if type(annotation) == str:
+        return annotation
+
+    # Convert Ellipsis into "..."
+    elif annotation == Ellipsis:
+        return "..."
+
+    # Convert any class (i.e. torch.Tensor, LinearOperator, gpytorch, etc.) into appropriate strings
+    # For external classes, the format will be e.g. "torch.Tensor"
+    # For any linear_operator class, the format will be e.g. "~linear_operator.operators.TriangularLinearOperator"
+    # For any internal class, the format will be e.g. "~gpytorch.kernels.RBFKernel"
+    elif hasattr(annotation, "__name__"):
+        module = annotation.__module__ + "."
+        if module.split(".")[0] == "linear_operator":
+            if annotation.__name__.endswith("LinearOperator"):
+                module = "~linear_operator."
+            elif annotation.__name__.endswith("LinearOperator"):
+                module = "~linear_operator.operators."
+            else:
+                module = "~" + module
+        elif module.split(".")[0] == "gpytorch":
+            module = "~" + module
+        elif module == "builtins.":
+            module = ""
+        res = f"{module}{annotation.__name__}"
+
+    # Convert any Union[*A*, *B*, *C*] into "*A* or *B* or *C*"
+    # Also, convert any Optional[*A*] into "*A*, optional"
+    elif str(annotation).startswith("typing.Union"):
+        is_optional_str = ""
+        args = list(annotation.__args__)
+        # Hack: Optional[*A*] are represented internally as Union[*A*, Nonetype]
+        # This catches this case
+        if args[-1] is type(None):  # noqa E721
+            del args[-1]
+            is_optional_str = ", optional"
+        processed_args = [_process(arg, config) for arg in args]
+        res = " or ".join(processed_args) + is_optional_str
+
+    # Convert any Tuple[*A*, *B*] into "(*A*, *B*)"
+    elif str(annotation).startswith("typing.Tuple"):
+        args = list(annotation.__args__)
+        res = "(" + ", ".join(_process(arg, config) for arg in args) + ")"
+
+    # Convert any List[*A*] into "list(*A*)"
+    elif str(annotation).startswith("typing.List"):
+        arg = annotation.__args__[0]
+        res = "list(" + _process(arg, config) + ")"
+
+    # Convert any Iterable[*A*] into "iterable(*A*)"
+    elif str(annotation).startswith("typing.Iterable"):
+        arg = annotation.__args__[0]
+        res = "iterable(" + _process(arg, config) + ")"
+
+    # Handle "Callable"
+    elif str(annotation).startswith("typing.Callable"):
+        res = "callable"
+
+    # Handle "Any"
+    elif str(annotation).startswith("typing.Any"):
+        res = ""
+
+    # Special cases for forward references.
+    # This is brittle, as it only contains case for a select few forward refs
+    # All others that aren't caught by this are handled by the default case
+    elif isinstance(annotation, ForwardRef):
+        res = str(annotation.__forward_arg__)
+
+    # For everything we didn't catch: use the simplist string representation
+    else:
+        warnings.warn(f"No rule for {annotation}. Using default resolution...", RuntimeWarning)
+        res = str(annotation)
+
+    return res
+
+
+# -- Options for typehints ----------------------------------------------
+always_document_param_types = True
+# typehints_use_rtype = False
+typehints_defaults = None  # or "comma"
+simplify_optional_unions = False
+typehints_formatter = _process

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -36,6 +36,7 @@ MultivariateNormal
 
 .. autoclass:: MultivariateNormal
    :members:
+   :special-members: __getitem__
 
 
 MultitaskMultivariateNormal

--- a/docs/source/kernels.rst
+++ b/docs/source/kernels.rst
@@ -17,6 +17,7 @@ Kernel
 
 .. autoclass:: Kernel
    :members:
+   :special-members: __call__, __getitem__
 
 Standard Kernels
 -----------------------------

--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import math
 import warnings
+from numbers import Number
+from typing import Optional, Tuple, Union
 
 import torch
 from linear_operator import to_dense, to_linear_operator
 from linear_operator.operators import DiagLinearOperator, LinearOperator, RootLinearOperator
+from torch import Tensor
 from torch.distributions import MultivariateNormal as TMultivariateNormal
 from torch.distributions.kl import register_kl
 from torch.distributions.utils import _standard_normal, lazy_property
@@ -23,12 +28,21 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
     Passing a vector mean corresponds to a multivariate normal.
     Passing a matrix mean corresponds to a batch of multivariate normals.
 
-    :param torch.tensor mean: Vector n or matrix b x n mean of mvn distribution.
-    :param ~linear_operator.operators.LinearOperator covar: ... x N X N covariance matrix of
-        mvn distribution.
+    :param mean: `... x N` mean of mvn distribution.
+    :param covariance_matrix: `... x N X N` covariance matrix of mvn distribution.
+    :param validate_args: If True, validate `mean` anad `covariance_matrix` arguments. (Default: False.)
+
+    :ivar torch.Size base_sample_shape: The shape of a base sample (without
+        batching) that is used to generate a single sample.
+    :ivar torch.Tensor covariance_matrix: The covariance matrix, represented as a dense :class:`torch.Tensor`
+    :ivar ~linear_operator.LinearOperator lazy_covariance_matrix: The covariance matrix, represented
+        as a :class:`~linear_operator.LinearOperator`.
+    :ivar torch.Tensor mean: The mean.
+    :ivar torch.Tensor stddev: The standard deviation.
+    :ivar torch.Tensor variance: The variance.
     """
 
-    def __init__(self, mean, covariance_matrix, validate_args=False):
+    def __init__(self, mean: Tensor, covariance_matrix: Union[Tensor, LinearOperator], validate_args: bool = False):
         self._islazy = isinstance(mean, LinearOperator) or isinstance(covariance_matrix, LinearOperator)
         if self._islazy:
             if validate_args:
@@ -50,8 +64,25 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
         else:
             super().__init__(loc=mean, covariance_matrix=covariance_matrix, validate_args=validate_args)
 
+    def _extended_shape(self, sample_shape: torch.Size = torch.Size()) -> torch.Size:
+        """
+        Returns the size of the sample returned by the distribution, given
+        a `sample_shape`. Note, that the batch and event shapes of a distribution
+        instance are fixed at the time of construction. If this is empty, the
+        returned shape is upcast to (1,).
+
+        :param sample_shape: the size of the sample to be drawn.
+        """
+        if not isinstance(sample_shape, torch.Size):
+            sample_shape = torch.Size(sample_shape)
+        return sample_shape + self._batch_shape + self.base_sample_shape
+
+    @staticmethod
+    def _repr_sizes(mean: Tensor, covariance_matrix: Union[Tensor, LinearOperator]) -> str:
+        return f"MultivariateNormal(loc: {mean.size()}, scale: {covariance_matrix.size()})"
+
     @property
-    def _unbroadcasted_scale_tril(self):
+    def _unbroadcasted_scale_tril(self) -> Tensor:
         if self.islazy and self.__unbroadcasted_scale_tril is None:
             # cache root decoposition
             ust = to_dense(self.lazy_covariance_matrix.cholesky())
@@ -59,73 +90,22 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
         return self.__unbroadcasted_scale_tril
 
     @_unbroadcasted_scale_tril.setter
-    def _unbroadcasted_scale_tril(self, ust):
+    def _unbroadcasted_scale_tril(self, ust: Tensor):
         if self.islazy:
             raise NotImplementedError("Cannot set _unbroadcasted_scale_tril for lazy MVN distributions")
         else:
             self.__unbroadcasted_scale_tril = ust
 
-    def add_jitter(self, noise=1e-4):
+    def add_jitter(self, noise: float = 1e-4) -> MultivariateNormal:
+        r"""
+        Adds a small constant diagonal to the MVN covariance matrix for numerical stability.
+
+        :param noise: The size of the constant diagonal.
+        """
         return self.__class__(self.mean, self.lazy_covariance_matrix.add_jitter(noise))
 
-    def expand(self, batch_size):
-        new_loc = self.loc.expand(torch.Size(batch_size) + self.loc.shape[-1:])
-        new_covar = self._covar.expand(torch.Size(batch_size) + self._covar.shape[-2:])
-        res = self.__class__(new_loc, new_covar)
-        return res
-
-    def _extended_shape(self, sample_shape=torch.Size()):
-        """
-        Returns the size of the sample returned by the distribution, given
-        a `sample_shape`. Note, that the batch and event shapes of a distribution
-        instance are fixed at the time of construction. If this is empty, the
-        returned shape is upcast to (1,).
-
-        Args:
-            sample_shape (torch.Size): the size of the sample to be drawn.
-        """
-        if not isinstance(sample_shape, torch.Size):
-            sample_shape = torch.Size(sample_shape)
-        return sample_shape + self._batch_shape + self.base_sample_shape
-
-    def confidence_region(self):
-        """
-        Returns 2 standard deviations above and below the mean.
-
-        :rtype: (torch.Tensor, torch.Tensor)
-        :return: pair of tensors of size (b x d) or (d), where
-            b is the batch size and d is the dimensionality of the random
-            variable. The first (second) Tensor is the lower (upper) end of
-            the confidence region.
-        """
-        std2 = self.stddev.mul_(2)
-        mean = self.mean
-        return mean.sub(std2), mean.add(std2)
-
-    @staticmethod
-    def _repr_sizes(mean, covariance_matrix):
-        return f"MultivariateNormal(loc: {mean.size()}, scale: {covariance_matrix.size()})"
-
-    @lazy_property
-    def covariance_matrix(self):
-        if self.islazy:
-            return self._covar.to_dense()
-        else:
-            return super().covariance_matrix
-
-    def get_base_samples(self, sample_shape=torch.Size()):
-        """Get i.i.d. standard Normal samples (to be used with rsample(base_samples=base_samples))"""
-        with torch.no_grad():
-            shape = self._extended_shape(sample_shape)
-            base_samples = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device)
-        return base_samples
-
     @property
-    def base_sample_shape(self):
-        """
-        Returns the shape of a base sample (without batching) that is used to
-        generate a single sample.
-        """
+    def base_sample_shape(self) -> torch.Size:
         base_sample_shape = self.event_shape
         if isinstance(self.lazy_covariance_matrix, RootLinearOperator):
             base_sample_shape = self.lazy_covariance_matrix.root.shape[-1:]
@@ -133,16 +113,60 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
         return base_sample_shape
 
     @lazy_property
-    def lazy_covariance_matrix(self):
+    def covariance_matrix(self) -> Tensor:
+        if self.islazy:
+            return self._covar.to_dense()
+        else:
+            return super().covariance_matrix
+
+    def confidence_region(self) -> Tuple[Tensor, Tensor]:
         """
-        The covariance_matrix, represented as a LinearOperator
+        Returns 2 standard deviations above and below the mean.
+
+        :return: Pair of tensors of size `... x N`, where N is the
+            dimensionality of the random variable. The first (second) Tensor is the
+            lower (upper) end of the confidence region.
         """
+        std2 = self.stddev.mul_(2)
+        mean = self.mean
+        return mean.sub(std2), mean.add(std2)
+
+    def expand(self, batch_size: torch.Size) -> MultivariateNormal:
+        r"""
+        See :py:meth:`torch.distributions.Distribution.expand
+        <torch.distributions.distribution.Distribution.expand>`.
+        """
+        new_loc = self.loc.expand(torch.Size(batch_size) + self.loc.shape[-1:])
+        new_covar = self._covar.expand(torch.Size(batch_size) + self._covar.shape[-2:])
+        res = self.__class__(new_loc, new_covar)
+        return res
+
+    def get_base_samples(self, sample_shape: torch.Size = torch.Size()) -> Tensor:
+        r"""
+        Returns i.i.d. standard Normal samples to be used with
+        :py:meth:`MultivariateNormal.rsample(base_samples=base_samples)
+        <gpytorch.distributions.MultivariateNormal.rsample>`.
+
+        :param sample_shape: The number of samples to generate. (Default: `torch.Size([])`.)
+        :return: A `*sample_shape x *batch_shape x N` tensor of i.i.d. standard Normal samples.
+        """
+        with torch.no_grad():
+            shape = self._extended_shape(sample_shape)
+            base_samples = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device)
+        return base_samples
+
+    @lazy_property
+    def lazy_covariance_matrix(self) -> LinearOperator:
         if self.islazy:
             return self._covar
         else:
             return to_linear_operator(super().covariance_matrix)
 
-    def log_prob(self, value):
+    def log_prob(self, value: Tensor) -> Tensor:
+        r"""
+        See :py:meth:`torch.distributions.Distribution.log_prob
+        <torch.distributions.distribution.Distribution.log_prob>`.
+        """
         if settings.fast_computations.log_prob.off():
             return super().log_prob(value)
 
@@ -171,7 +195,29 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
         res = -0.5 * sum([inv_quad, logdet, diff.size(-1) * math.log(2 * math.pi)])
         return res
 
-    def rsample(self, sample_shape=torch.Size(), base_samples=None):
+    def rsample(self, sample_shape: torch.Size = torch.Size(), base_samples: Optional[Tensor] = None) -> Tensor:
+        r"""
+        Generates a `sample_shape` shaped reparameterized sample or `sample_shape`
+        shaped batch of reparameterized samples if the distribution parameters
+        are batched.
+
+        For the MultivariateNormal distribution, this is accomplished through:
+
+        .. math::
+            \boldsymbol \mu + \mathbf L \boldsymbol \epsilon
+
+        where :math:`\boldsymbol \mu \in \mathcal R^N` is the MVN mean,
+        :math:`\mathbf L \in \mathcal R^{N \times N}` is a "root" of the
+        covariance matrix :math:`\mathbf K` (i.e. :math:`\mathbf L \mathbf
+        L^\top = \mathbf K`), and :math:`\boldsymbol \epsilon \in \mathcal R^N` is a
+        vector of (approximately) i.i.d. standard Normal random variables.
+
+        :param sample_shape: The number of samples to generate. (Default: `torch.Size([])`.)
+        :param base_samples: The `*sample_shape x *batch_shape x N` tensor of
+            i.i.d. (or approximately i.i.d.) standard Normal samples to
+            reparameterize. (Defualt: None.)
+        :return: A `*sample_shape x *batch_shape x N` tensor of i.i.d. reparameterized samples.
+        """
         covar = self.lazy_covariance_matrix
         if base_samples is None:
             # Create some samples
@@ -217,16 +263,35 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
 
         return res
 
-    def sample(self, sample_shape=torch.Size(), base_samples=None):
+    def sample(self, sample_shape: torch.Size = torch.Size(), base_samples: Optional[Tensor] = None) -> Tensor:
+        r"""
+        Generates a `sample_shape` shaped sample or `sample_shape`
+        shaped batch of samples if the distribution parameters
+        are batched.
+
+        Note that these samples are not reparameterized and therefore cannot be backpropagated through.
+
+        :param sample_shape: The number of samples to generate. (Default: `torch.Size([])`.)
+        :param base_samples: The `*sample_shape x *batch_shape x N` tensor of
+            i.i.d. (or approximately i.i.d.) standard Normal samples to
+            reparameterize. (Defualt: None.)
+        :return: A `*sample_shape x *batch_shape x N` tensor of i.i.d. samples.
+        """
         with torch.no_grad():
             return self.rsample(sample_shape=sample_shape, base_samples=base_samples)
 
-    def to_data_independent_dist(self):
-        """
-        Convert a MVN into a batched Normal distribution
+    @property
+    def stddev(self) -> Tensor:
+        # self.variance is guaranteed to be positive, because we do clamping.
+        return self.variance.sqrt()
 
-        :returns: the bached data-independent Normal
-        :rtype: gpytorch.distributions.Normal
+    def to_data_independent_dist(self) -> torch.distributions.Normal:
+        """
+        Convert a `... x N` MVN distribution into a batch of independent Normal distributions.
+        Essentially, this throws away all covariance information
+        and treats all dimensions as batch dimensions.
+
+        :returns: A (data-independent) Normal distribution with batch shape `*batch_shape x N`.
         """
         # Create batch distribution where all data are independent, but the tasks are dependent
         try:
@@ -238,12 +303,7 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
         return base_distributions.Normal(self.mean, self.stddev)
 
     @property
-    def stddev(self):
-        # self.variance is guaranteed to be positive, because we do clamping.
-        return self.variance.sqrt()
-
-    @property
-    def variance(self):
+    def variance(self) -> Tensor:
         if self.islazy:
             # overwrite this since torch MVN uses unbroadcasted_scale_tril for this
             diag = self.lazy_covariance_matrix.diagonal(dim1=-1, dim2=-2)
@@ -265,7 +325,7 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
             variance = variance.clamp_min(min_variance)
         return variance
 
-    def __add__(self, other):
+    def __add__(self, other: MultivariateNormal) -> MultivariateNormal:
         if isinstance(other, MultivariateNormal):
             return self.__class__(
                 mean=self.mean + other.mean,
@@ -276,22 +336,16 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
         else:
             raise RuntimeError("Unsupported type {} for addition w/ MultivariateNormal".format(type(other)))
 
-    def __radd__(self, other):
-        if other == 0:
-            return self
-        return self.__add__(other)
+    def __getitem__(self, idx) -> MultivariateNormal:
+        r"""
+        Constructs a new MultivariateNormal that represents a random variable
+        modified by an indexing operation.
 
-    def __mul__(self, other):
-        if not (isinstance(other, int) or isinstance(other, float)):
-            raise RuntimeError("Can only multiply by scalars")
-        if other == 1:
-            return self
-        return self.__class__(mean=self.mean * other, covariance_matrix=self.lazy_covariance_matrix * (other**2))
+        The mean and covariance matrix arguments are indexed accordingly.
 
-    def __truediv__(self, other):
-        return self.__mul__(1.0 / other)
+        :param idx: Index to apply.
+        """
 
-    def __getitem__(self, idx):
         if not isinstance(idx, tuple):
             idx = (idx,)
         rest_idx = idx[:-1]
@@ -317,9 +371,24 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
                 new_cov = self.lazy_covariance_matrix[(*rest_idx, last_idx, slice(None, None, None))][..., last_idx]
         return self.__class__(mean=new_mean, covariance_matrix=new_cov)
 
+    def __mul__(self, other: Number) -> MultivariateNormal:
+        if not (isinstance(other, int) or isinstance(other, float)):
+            raise RuntimeError("Can only multiply by scalars")
+        if other == 1:
+            return self
+        return self.__class__(mean=self.mean * other, covariance_matrix=self.lazy_covariance_matrix * (other**2))
+
+    def __radd__(self, other: MultivariateNormal) -> MultivariateNormal:
+        if other == 0:
+            return self
+        return self.__add__(other)
+
+    def __truediv__(self, other: Number) -> MultivariateNormal:
+        return self.__mul__(1.0 / other)
+
 
 @register_kl(MultivariateNormal, MultivariateNormal)
-def kl_mvn_mvn(p_dist, q_dist):
+def kl_mvn_mvn(p_dist: MultivariateNormal, q_dist: MultivariateNormal) -> Tensor:
     output_shape = torch.broadcast_shapes(p_dist.batch_shape, q_dist.batch_shape)
     if output_shape != p_dist.batch_shape:
         p_dist = p_dist.expand(output_shape)


### PR DESCRIPTION
For example: if the method is...

```python
def forward(self, x1: Tensor, x2: Optional[Tensor]) -> Union[Tensor, LinearOperator]:
    r"""
    Does the forward thing.

    :param x1: The x1 arg
    :param x2: The x2 arg
    :return: The forward stuff.
    """
    # ...
```

The resulting documentation will include the appropriate types:

```
Parameters:
  - x1 (torch.Tensor) - The x1 arg
  - x2 (torch.Tensor, optional) - The x2 arg

Return type: torch.Tensor or LinearOperator

Returns: The forward stuff.
```

This (hopefully) should prevent a lot of duplicate effort on our end.

This PR also refactors the gpytorch.kernels.Kernel and gpytorch.distributions.MultivariateNormal docs to utilize auto-typing.