### PR TITLE
Retiring deprecated versions of`psd_safe_cholesky`, `NotPSDError`, and `assert_allclose`

### DIFF
--- a/gpytorch/kernels/inducing_point_kernel.py
+++ b/gpytorch/kernels/inducing_point_kernel.py
@@ -12,6 +12,7 @@ from linear_operator.operators import (
     LowRankRootLinearOperator,
     MatmulLinearOperator,
 )
+from linear_operator.utils.cholesky import psd_safe_cholesky
 from torch import Tensor
 
 from .. import settings
@@ -19,7 +20,6 @@ from ..distributions import MultivariateNormal
 from ..likelihoods import Likelihood
 from ..mlls import InducingPointKernelAddedLossTerm
 from ..models import exact_prediction_strategies
-from ..utils.cholesky import psd_safe_cholesky
 from .kernel import Kernel
 
 

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -17,12 +17,12 @@ from linear_operator.operators import (
     RootLinearOperator,
     ZeroLinearOperator,
 )
+from linear_operator.utils.cholesky import psd_safe_cholesky
 from linear_operator.utils.interpolation import left_interp, left_t_interp
 from torch import Tensor
 
 from .. import settings
 from ..lazy import LazyEvaluatedKernelTensor
-from ..utils.cholesky import psd_safe_cholesky
 from ..utils.memoize import add_to_cache, cached, clear_cache_hook, pop_from_cache
 
 

--- a/gpytorch/priors/lkj_prior.py
+++ b/gpytorch/priors/lkj_prior.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
 import torch
+from linear_operator.utils.cholesky import psd_safe_cholesky
 from torch.distributions import LKJCholesky, constraints
 from torch.nn import Module as TModule
 
 from .. import settings
-from ..utils.cholesky import psd_safe_cholesky
 from .prior import Prior
 
 

--- a/gpytorch/variational/natural_variational_distribution.py
+++ b/gpytorch/variational/natural_variational_distribution.py
@@ -4,9 +4,9 @@ import abc
 
 import torch
 from linear_operator.operators import CholLinearOperator, TriangularLinearOperator
+from linear_operator.utils.cholesky import psd_safe_cholesky
 
 from ..distributions import MultivariateNormal
-from ..utils.cholesky import psd_safe_cholesky
 from ._variational_distribution import _VariationalDistribution
 
 

--- a/gpytorch/variational/nearest_neighbor_variational_strategy.py
+++ b/gpytorch/variational/nearest_neighbor_variational_strategy.py
@@ -4,10 +4,10 @@
 import torch
 from linear_operator import to_dense
 from linear_operator.operators import DiagLinearOperator, TriangularLinearOperator
+from linear_operator.utils.cholesky import psd_safe_cholesky
 
 from .. import settings
 from ..distributions import MultivariateNormal
-from ..utils.cholesky import psd_safe_cholesky
 from ..utils.errors import CachingError
 from ..utils.memoize import add_to_cache, cached, pop_from_cache
 from ..utils.nearest_neighbors import NNUtil

--- a/gpytorch/variational/unwhitened_variational_strategy.py
+++ b/gpytorch/variational/unwhitened_variational_strategy.py
@@ -12,11 +12,11 @@ from linear_operator.operators import (
     TriangularLinearOperator,
     ZeroLinearOperator,
 )
+from linear_operator.utils.cholesky import psd_safe_cholesky
+from linear_operator.utils.errors import NotPSDError
 
 from .. import settings
 from ..distributions import MultivariateNormal
-from ..utils.cholesky import psd_safe_cholesky
-from ..utils.errors import NotPSDError
 from ..utils.memoize import add_to_cache, cached
 from ._variational_strategy import _VariationalStrategy
 from .cholesky_variational_distribution import CholeskyVariationalDistribution

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -12,18 +12,17 @@ from linear_operator.operators import (
     SumLinearOperator,
     TriangularLinearOperator,
 )
+from linear_operator.utils.cholesky import psd_safe_cholesky
+from linear_operator.utils.errors import NotPSDError
 
 from gpytorch.variational._variational_strategy import _VariationalStrategy
 from gpytorch.variational.cholesky_variational_distribution import CholeskyVariationalDistribution
 
 from ..distributions import MultivariateNormal
 from ..settings import _linalg_dtype_cholesky, trace_mode
-from ..utils.cholesky import psd_safe_cholesky
-from ..utils.errors import CachingError, NotPSDError
+from ..utils.errors import CachingError
 from ..utils.memoize import cached, clear_cache_hook, pop_from_cache_ignore_args
 from ..utils.warnings import OldVersionWarning
-
-# from ._variational_strategy import _VariationalStrategy
 
 
 def _ensure_updated_strategy_flag_set(

--- a/test/likelihoods/test_gaussian_likelihood.py
+++ b/test/likelihoods/test_gaussian_likelihood.py
@@ -202,7 +202,7 @@ class TestGaussianLikelihoodwithMissingObs(BaseLikelihoodTestCase, unittest.Test
         likelihood.MISSING_VALUE_FILL = -999.0
         like_init_minus = likelihood.log_marginal(samples, mvn).sum().data
 
-        torch.testing.assert_allclose(like_init_plus, like_init_minus)
+        torch.testing.assert_close(like_init_plus, like_init_minus)
 
         # check that the correct noise sd is recovered
 


### PR DESCRIPTION
This PR retires
1) GPyTorch's `psd_safe_cholesky` in favor of the LinearOperator version
2) GPyTorch's `NotPSDError` in favor of the LinearOperator version
3) `torch.testing.assert_allclose` in favor of `torch.testing.assert_close`. `assert_close` has been in torch since 1.9 and since GPyTorch requires torch>=1.11, this should not cause any bad behavior, [see here for details](https://github.com/pytorch/pytorch/issues/61844).