### PR TITLE
fix custom dtype_value_context setting

### DIFF
--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -56,13 +56,13 @@ class _dtype_value_context:
         if half_value is not None:
             cls._global_half_value = half_value
 
-    def __init__(self, float=None, double=None, half=None):
-        self._orig_float_value = self.__class__.value()
-        self._instance_float_value = float
-        self._orig_double_value = self.__class__.value()
-        self._instance_double_value = double
-        self._orig_half_value = self.__class__.value()
-        self._instance_half_value = half
+    def __init__(self, float_value=None, double_value=None, half_value=None):
+        self._orig_float_value = self.__class__.value(torch.float)
+        self._instance_float_value = float_value if float_value is not None else self._orig_float_value
+        self._orig_double_value = self.__class__.value(torch.double)
+        self._instance_double_value = double_value if double_value is not None else self._orig_double_value
+        self._orig_half_value = self.__class__.value(torch.half)
+        self._instance_half_value = half_value if half_value is not None else self._orig_half_value
 
     def __enter__(
         self,

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -2,6 +2,8 @@
 
 import unittest
 
+import torch
+
 from gpytorch import settings
 from gpytorch.test.base_test_case import BaseTestCase
 
@@ -16,3 +18,35 @@ class TestSettings(BaseTestCase, unittest.TestCase):
         with settings.fast_pred_var(False):
             self.assertFalse(settings.fast_pred_var.is_default())
             self.assertFalse(settings.fast_pred_var.on())
+
+    def test_dtype_value_context(self):
+        # test custom settings
+        x = torch.zeros(1, dtype=torch.float)
+        with settings.min_fixed_noise(float_value=0.1, double_value=0.2, half_value=0.3):
+            self.assertEqual(settings.min_fixed_noise.value(x), 0.1)
+            self.assertEqual(settings.min_fixed_noise.value(x.double()), 0.2)
+            self.assertEqual(settings.min_fixed_noise.value(x.half()), 0.3)
+        # test defaults are restored
+        self.assertEqual(
+            settings.min_fixed_noise.value(x),
+            settings.min_fixed_noise._global_float_value,
+        )
+        self.assertEqual(
+            settings.min_fixed_noise.value(x.double()),
+            settings.min_fixed_noise._global_double_value,
+        )
+        self.assertEqual(
+            settings.min_fixed_noise.value(x.half()),
+            settings.min_fixed_noise._global_half_value,
+        )
+        # test setting one dtype
+        with settings.min_fixed_noise(double_value=0.2):
+            self.assertEqual(settings.min_fixed_noise.value(x.double()), 0.2)
+            self.assertEqual(
+                settings.min_fixed_noise.value(x),
+                settings.min_fixed_noise._global_float_value,
+            )
+            self.assertEqual(
+                settings.min_fixed_noise.value(x.half()),
+                settings.min_fixed_noise._global_half_value,
+            )


### PR DESCRIPTION
Previously, setting custom values in `dtype_value_context` was broken because `dtype_value_context.value` requires a `dtype` argument and no `dtype` argument was provided in the calls in `dtype_value_context.__init__`.