### PR TITLE
Avoid evaluating kernel when adding jitter

### DIFF
--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -300,9 +300,6 @@ class LazyEvaluatedKernelTensor(LinearOperator):
             **self.params,
         )
 
-    def add_jitter(self, jitter_val=1e-3):
-        return super().add_jitter(jitter_val)
-
     def _unsqueeze_batch(self, dim):
         x1 = self.x1.unsqueeze(dim)
         x2 = self.x2.unsqueeze(dim)

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -301,7 +301,7 @@ class LazyEvaluatedKernelTensor(LinearOperator):
         )
 
     def add_jitter(self, jitter_val=1e-3):
-        return self.evaluate_kernel().add_jitter(jitter_val)
+        return super().add_jitter(jitter_val)
 
     def _unsqueeze_batch(self, dim):
         x1 = self.x1.unsqueeze(dim)


### PR DESCRIPTION
The memory usage is much higher as a result of evaluating the kernel on this line.

Is there any reason for not using the parent class method to do this?
