### PR TITLE
Migrate trace_mode to linear_operators and disable conditional control flow

### DIFF
--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -319,7 +319,10 @@ class Kernel(Module):
             x1 = x1.transpose(-1, -2).unsqueeze(-1)
             x2 = x2.transpose(-1, -2).unsqueeze(-1)
 
-        x1_eq_x2 = torch.equal(x1, x2)
+        if settings.trace_mode.on():
+            x1_eq_x2 = False
+        else:
+            x1_eq_x2 = torch.equal(x1, x2)
 
         # torch scripts expect tensors
         postprocess = torch.tensor(postprocess)

--- a/gpytorch/settings.py
+++ b/gpytorch/settings.py
@@ -23,6 +23,7 @@ from linear_operator.settings import (
     preconditioner_tolerance,
     skip_logdet_forward,
     terminate_cg_by_size,
+    trace_mode,
     tridiagonal_jitter,
     use_toeplitz,
     verbose_linalg,
@@ -360,24 +361,6 @@ class skip_posterior_variances(_feature_flag):
     forward pass. If this is on, the returned gpytorch MultivariateNormal will have a
     ZeroLinearOperator as its covariance matrix. This allows gpytorch to not compute
     the covariance matrix when it is not needed, speeding up computations.
-
-    (Default: False)
-    """
-
-    _default = False
-
-
-class trace_mode(_feature_flag):
-    """
-    If set to True, we will generally try to avoid calling our built in PyTorch functions, because these cannot
-    be run through torch.jit.trace.
-
-    Note that this will sometimes involve explicitly evaluating lazy tensors and various other slowdowns and
-    inefficiencies. As a result, you really shouldn't use this feature context unless you are calling torch.jit.trace
-    on a GPyTorch model.
-
-    Our hope is that this flag will not be necessary long term, once https://github.com/pytorch/pytorch/issues/22329
-    is fixed.
 
     (Default: False)
     """


### PR DESCRIPTION
We would like to [use gpytorch in our NUTS sampler](https://github.com/facebookresearch/beanmachine/blob/main/tests/ppl/experimental/gp/inference_test.py#L61-L70). While the linked code works, it does not utilize JIT compilation (`use_nnc`) because of control flow.

I understand `trace_mode` was originally used to disable custom pytorch functions back when JIT did not support compiling through them. This PR (along with https://github.com/cornellius-gp/linear_operator/pull/27) revives the setting for the AoT JIT compiler (https://pytorch.org/functorch/nightly/aot_autograd.html).

 * Moves `settings.trace_mode` from `gpytorch` to `linear_operators`
 * Skips conditional control flow when `trace_mode` is true, currently:
   * PSD check / jitter in `linear_operators.utils.cholesky`
   * Diagonal `x1_eq_x2` check in `gpytorch.kernels.kernel`