### PR TITLE
Fix handling of re-used priors

### DIFF
--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -169,7 +169,7 @@ class Module(nn.Module):
                 - a tuple of tuples (param, transform), one for each of the parameters associated with the prior
                 - the prior's transform to be called on the parameters
         """
-        return _extract_named_priors(module=self, memo=None, prefix="")
+        return _extract_named_priors(module=self, prefix="")
 
     def named_constraints(self, memo=None, prefix=""):
         return _extract_named_constraints(module=self, memo=None, prefix="")
@@ -523,20 +523,15 @@ def _extract_named_added_loss_terms(module, memo=None, prefix=""):
             yield name, strategy
 
 
-def _extract_named_priors(module, memo=None, prefix=""):
-    if memo is None:
-        memo = set()
+def _extract_named_priors(module, prefix=""):
     if hasattr(module, "_priors"):
         for name, (prior, closure, inv_closure) in module._priors.items():
-            if prior is not None and prior not in memo:
-                memo.add(prior)
+            if prior is not None:
                 full_name = ("." if prefix else "").join([prefix, name])
                 yield full_name, module, prior, closure, inv_closure
     for mname, module_ in module.named_children():
         submodule_prefix = prefix + ("." if prefix else "") + mname
-        for name, parent_module, prior, closure, inv_closure in _extract_named_priors(
-            module_, memo=memo, prefix=submodule_prefix
-        ):
+        for name, parent_module, prior, closure, inv_closure in _extract_named_priors(module_, prefix=submodule_prefix):
             yield name, parent_module, prior, closure, inv_closure
 
 


### PR DESCRIPTION
Previously, we would use a `memo` set in `_extract_named_priors` that would cause issues / wrong results if the same prior instance was used on different modules. I don't actually understand the reason for having this `memo`, and removing it fies this issue.

Separately, we should probably audit similar behavior in `_extract_named_constraints` and `_extract_named_added_loss_terms`.

Addresses #2263