### PR TITLE
Use raw strings to avoid "DeprecationWarning: invalid escape sequence"

### DIFF
--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -165,7 +165,7 @@ class GaussianLikelihoodWithMissingObs(GaussianLikelihood):
 
 
 class FixedNoiseGaussianLikelihood(_GaussianLikelihoodBase):
-    """
+    r"""
     A Likelihood that assumes fixed heteroscedastic noise. This is useful when you have fixed, known observation
     noise for each training example.
 

--- a/gpytorch/mlls/leave_one_out_pseudo_likelihood.py
+++ b/gpytorch/mlls/leave_one_out_pseudo_likelihood.py
@@ -9,7 +9,7 @@ from .exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 
 
 class LeaveOneOutPseudoLikelihood(ExactMarginalLogLikelihood):
-    """
+    r"""
     The leave one out cross-validation (LOO-CV) likelihood from RW 5.4.2 for an exact Gaussian process with a
     Gaussian likelihood. This offers an alternative to the exact marginal log likelihood where we
     instead maximize the sum of the leave one out log probabilities :math:`\log p(y_i | X, y_{-i}, \theta)`.

--- a/gpytorch/priors/horseshoe_prior.py
+++ b/gpytorch/priors/horseshoe_prior.py
@@ -11,7 +11,7 @@ from gpytorch.priors.prior import Prior
 
 
 class HorseshoePrior(Prior):
-    """Horseshoe prior.
+    r"""Horseshoe prior.
 
     There is no analytical form for the horeshoe prior's pdf, but it
     satisfies a tight bound of the form `lb(x) <= pdf(x) <= ub(x)`, where

--- a/gpytorch/variational/ciq_variational_strategy.py
+++ b/gpytorch/variational/ciq_variational_strategy.py
@@ -254,7 +254,7 @@ class CiqVariationalStrategy(_VariationalStrategy):
         return MultivariateNormal(predictive_mean, predictive_covar)
 
     def kl_divergence(self):
-        """
+        r"""
         Compute the KL divergence between the variational inducing distribution :math:`q(\mathbf u)`
         and the prior inducing distribution :math:`p(\mathbf u)`.
 


### PR DESCRIPTION
This currently produces the following warnings:
```
.../gpytorch/gpytorch/likelihoods/gaussian_likelihood.py:168: DeprecationWarning: invalid escape sequence \s
  """
.../gpytorch/gpytorch/mlls/leave_one_out_pseudo_likelihood.py:12: DeprecationWarning: invalid escape sequence \l
  """
.../gpytorch/gpytorch/priors/horseshoe_prior.py:14: DeprecationWarning: invalid escape sequence \s
  """Horseshoe prior.
.../gpytorch/gpytorch/variational/ciq_variational_strategy.py:257: DeprecationWarning: invalid escape sequence \m
```