### PR TITLE
Use raw strings to avoid "DeprecationWarning: invalid escape sequence"

### DIFF
--- a/gpytorch/variational/ciq_variational_strategy.py
+++ b/gpytorch/variational/ciq_variational_strategy.py
@@ -258,7 +258,7 @@ class CiqVariationalStrategy(_VariationalStrategy):
         return MultivariateNormal(predictive_mean, predictive_covar)
 
     def kl_divergence(self) -> Tensor:
-        """
+        r"""
         Compute the KL divergence between the variational inducing distribution :math:`q(\mathbf u)`
         and the prior inducing distribution :math:`p(\mathbf u)`.
 


### PR DESCRIPTION
This was fixed in https://github.com/cornellius-gp/gpytorch/pull/2282 but looks like it made its way back. 