### PR TITLE
Clean up deprecation warnings

### DIFF
--- a/gpytorch/likelihoods/bernoulli_likelihood.py
+++ b/gpytorch/likelihoods/bernoulli_likelihood.py
@@ -47,7 +47,7 @@ class BernoulliLikelihood(_OneDimensionalLikelihood):
         return marginal.log_prob(observations)
 
     def marginal(self, function_dist: MultivariateNormal, *args: Any, **kwargs: Any) -> Bernoulli:
-        """
+        r"""
         :return: Analytic marginal :math:`p(\mathbf y)`.
         """
         mean = function_dist.mean

--- a/gpytorch/likelihoods/gaussian_likelihood.py
+++ b/gpytorch/likelihoods/gaussian_likelihood.py
@@ -130,7 +130,7 @@ class GaussianLikelihood(_GaussianLikelihoodBase):
         self.noise_covar.initialize(raw_noise=value)
 
     def marginal(self, function_dist: MultivariateNormal, *args: Any, **kwargs: Any) -> MultivariateNormal:
-        """
+        r"""
         :return: Analytic marginal :math:`p(\mathbf y)`.
         """
         return super().marginal(function_dist, *args, **kwargs)
@@ -186,7 +186,7 @@ class GaussianLikelihoodWithMissingObs(GaussianLikelihood):
         return res * ~missing_idx
 
     def marginal(self, function_dist: MultivariateNormal, *args: Any, **kwargs: Any) -> MultivariateNormal:
-        """
+        r"""
         :return: Analytic marginal :math:`p(\mathbf y)`.
         """
         return super().marginal(function_dist, *args, **kwargs)
@@ -306,14 +306,14 @@ class FixedNoiseGaussianLikelihood(_GaussianLikelihoodBase):
         return res
 
     def marginal(self, function_dist: MultivariateNormal, *args: Any, **kwargs: Any) -> MultivariateNormal:
-        """
+        r"""
         :return: Analytic marginal :math:`p(\mathbf y)`.
         """
         return super().marginal(function_dist, *args, **kwargs)
 
 
 class DirichletClassificationLikelihood(FixedNoiseGaussianLikelihood):
-    """
+    r"""
     A classification likelihood that treats the labels as regression targets with fixed heteroscedastic noise.
     From Milios et al, NeurIPS, 2018 [https://arxiv.org/abs/1805.10915].
 
@@ -408,7 +408,7 @@ class DirichletClassificationLikelihood(FixedNoiseGaussianLikelihood):
         return fantasy_liklihood
 
     def marginal(self, function_dist: MultivariateNormal, *args: Any, **kwargs: Any) -> MultivariateNormal:
-        """
+        r"""
         :return: Analytic marginal :math:`p(\mathbf y)`.
         """
         return super().marginal(function_dist, *args, **kwargs)

--- a/gpytorch/likelihoods/multitask_gaussian_likelihood.py
+++ b/gpytorch/likelihoods/multitask_gaussian_likelihood.py
@@ -293,7 +293,7 @@ class MultitaskGaussianLikelihood(_MultitaskGaussianLikelihoodBase):
     def marginal(
         self, function_dist: MultitaskMultivariateNormal, *args: Any, **kwargs: Any
     ) -> MultitaskMultivariateNormal:
-        """
+        r"""
         :return: Analytic marginal :math:`p(\mathbf y)`.
         """
         return super().marginal(function_dist, *args, **kwargs)


### PR DESCRIPTION
Cleans up several instances of `DeprecationWarning: invalid escape sequence \m`.