### PR TITLE
Bugfix: double added log noise prior

### DIFF
--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -40,7 +40,7 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
 
         # Add log probs of priors on the (functions of) parameters
         res_ndim = res.ndim
-        for name, module, prior, closure, _ in self.named_priors():
+        for name, module, prior, closure, _ in self.model.named_priors():
             prior_term = prior.log_prob(closure(module))
             res.add_(prior_term.view(*prior_term.shape[:res_ndim], -1).sum(dim=-1))
 

--- a/test/mlls/test_exact_marginal_log_likelihood.py
+++ b/test/mlls/test_exact_marginal_log_likelihood.py
@@ -67,3 +67,25 @@ class TestExactMarginalLogLikelihood(unittest.TestCase):
         self.assertEqual(non_batch_mll_eval.shape, torch.Size())
         self.assertEqual(batch_mll_eval.shape, torch.Size([10]))
         self.assertTrue(torch.allclose(non_batch_mll_eval.expand(10), batch_mll_eval))
+
+    def test_mll_computation(self):
+        train_x, train_y = (torch.rand(10, 2), torch.rand(10))
+        model = ExactGPModel(train_x, train_y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        output = model(train_x)
+        marginal_log_likelihood = mll(output, train_y)
+
+        marginal_likelihood = model.likelihood(output)
+        noise_prior = next(model.likelihood.named_priors())[2]
+        outputscale_prior = next(model.covar_module.named_priors())[2]
+        lengthscale_prior = next(model.covar_module.base_kernel.named_priors())[2]
+
+        log_probs = [
+            marginal_likelihood.log_prob(train_y),
+            noise_prior.log_prob(model.likelihood.noise),
+            outputscale_prior.log_prob(model.covar_module.outputscale),
+            lengthscale_prior.log_prob(model.covar_module.base_kernel.lengthscale).sum(),
+        ]
+        marginal_log_likelihood_by_hand = sum(log_probs) / train_y.shape[0]
+
+        self.assertTrue(torch.allclose(marginal_log_likelihood, marginal_log_likelihood_by_hand))


### PR DESCRIPTION
There was an issue #2340 with the mll computation when using a noise prior. 
The `MarginalLogLikelihood` class contains the likelihood twice - once as a direct child and once as child of the model.
```python
class gpytorch.mlls.MarginalLogLikelihood(Module):
    def __init__(self, likelihood, model):
        self.likelihood = likelihood
        self.model = model
```
 Previously the `_add_other_terms()` method iterated over all submodules of the MarginalLogLikelihood class, resulting in the noise prior of the likelihood being added twice.
With the proposed fix the `_add_other_terms()` method now only iterates over the submodules of the model. 