### PR TITLE
Remove Module.__getattr__

### DIFF
--- a/gpytorch/module.py
+++ b/gpytorch/module.py
@@ -429,15 +429,6 @@ class Module(nn.Module):
         for _, param in self.named_variational_parameters():
             yield param
 
-    def __getattr__(self, name):
-        try:
-            return super().__getattr__(name)
-        except AttributeError as e:
-            try:
-                return super().__getattribute__(name)
-            except AttributeError:
-                raise e
-
 
 def _validate_module_outputs(outputs):
     if isinstance(outputs, tuple):


### PR DESCRIPTION
GPyTorch `Module` class defines a custom `__getattr__` method that used to serve a purpose, but now only calls `super().__getattr__`. This leads to deepening of stack trace and can cause mild confusion. Since it is a no-op, removing it seems like the right move to me.

Aside: First calling `__getattr__` then falling back to `__getattribute__` is a bit strange on its own. Python first calls `__getattribute__` and if an attribute is not found `__getattr__` is invoked, in case there's some custom logic. Looking at the changelog, it seems like `__getattribute__` was called using some `base_name` when this wasn't a no-op, so it's probably a relic from those times.