### PR TITLE
Remove num_outputs from IndependentModelList

### DIFF
--- a/gpytorch/models/model_list.py
+++ b/gpytorch/models/model_list.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-from abc import ABC, abstractproperty
+from abc import ABC
 
 import torch
 from torch.nn import ModuleList
@@ -11,17 +11,12 @@ from gpytorch.utils.generic import length_safe_zip
 
 
 class AbstractModelList(GP, ABC):
-    @abstractproperty
-    def num_outputs(self):
-        """The model's number of outputs"""
-        pass
-
     def forward_i(self, i, *args, **kwargs):
-        """Forward restricted to the i-th output only"""
+        """Forward restricted to the i-th model only."""
         raise NotImplementedError
 
     def likelihood_i(self, i, *args, **kwargs):
-        """Evaluate likelihood of the i-th output only"""
+        """Evaluate likelihood of the i-th model only."""
         raise NotImplementedError
 
 
@@ -35,10 +30,6 @@ class IndependentModelList(AbstractModelList):
                     "IndependentModelList currently only supports models that have a likelihood (e.g. ExactGPs)"
                 )
         self.likelihood = LikelihoodList(*[m.likelihood for m in models])
-
-    @property
-    def num_outputs(self):
-        return len(self.models)
 
     def forward_i(self, i, *args, **kwargs):
         return self.models[i].forward(*args, **kwargs)


### PR DESCRIPTION
`IndependentModelList.num_outputs` makes a strong assumption that the underlying models are single-output, so it returns the # of sub-models. However, `IndependentModelList` works perfectly fine with multi-output sub-models, leading to the `num_outputs` attribute returning the wrong value. Since GPyTorch models do not define a consistent `num_outputs` attribute, I don't see an easy way of correcting this.

This becomes an issue in BoTorch where `ModelListGP` has `IndependentModelList` ahead of `ModelList` in its MRO, which correctly defines `num_outputs` as the sum of `num_outputs` of the sub-models. Removing the property from `IndependentModelList` should allow us to use the correct definition from `ModelList`.