### PR TITLE
Fix VNNGP with batches

### DIFF
--- a/gpytorch/variational/nearest_neighbor_variational_strategy.py
+++ b/gpytorch/variational/nearest_neighbor_variational_strategy.py
@@ -9,7 +9,6 @@ from linear_operator.operators import DiagLinearOperator, LinearOperator, Triang
 from linear_operator.utils.cholesky import psd_safe_cholesky
 from torch import LongTensor, Tensor
 
-from .. import settings
 from ..distributions import MultivariateNormal
 from ..models import ApproximateGP, ExactGP
 from ..module import Module
@@ -325,8 +324,7 @@ class NNVariationalStrategy(UnwhitenedVariationalStrategy):
         variational_inducing_covar = DiagLinearOperator(variational_covar_fisrtk)
 
         variational_distribution = MultivariateNormal(inducing_values, variational_inducing_covar)
-        with settings.max_preconditioner_size(0):
-            kl = torch.distributions.kl.kl_divergence(variational_distribution, prior_dist)  # model_batch_shape
+        kl = torch.distributions.kl.kl_divergence(variational_distribution, prior_dist)  # model_batch_shape
         return kl
 
     def _stochastic_kl_helper(self, kl_indices: Float[Tensor, "n_batch"]) -> Float[Tensor, "..."]:  # noqa: F821

--- a/gpytorch/variational/nearest_neighbor_variational_strategy.py
+++ b/gpytorch/variational/nearest_neighbor_variational_strategy.py
@@ -98,8 +98,8 @@ class NNVariationalStrategy(UnwhitenedVariationalStrategy):
         self.inducing_points = inducing_points
         self.M, self.D = inducing_points.shape[-2:]
         self.k = k
-        assert self.k <= self.M, (
-            f"Number of nearest neighbors k must be smaller than or equal to number of inducing points, "
+        assert self.k < self.M, (
+            f"Number of nearest neighbors k must be smaller than the number of inducing points, "
             f"but got k = {k}, M = {self.M}."
         )
 
@@ -441,7 +441,7 @@ class NNVariationalStrategy(UnwhitenedVariationalStrategy):
         else:
             # compute a stochastic estimate
             assert kl_indices is not None
-            if (self._training_indices_iter == 1) or (self.M == self.k):
+            if self._training_indices_iter == 1:
                 assert len(kl_indices) == self.k, (
                     f"kl_indices sould be the first batch data of length k, "
                     f"but got len(kl_indices) = {len(kl_indices)} and k = {self.k}."
@@ -461,7 +461,6 @@ class NNVariationalStrategy(UnwhitenedVariationalStrategy):
         with torch.no_grad():
             inducing_points_fl = self.inducing_points.data.float()
             self.nn_util.set_nn_idx(inducing_points_fl)
-            if self.k < self.M:
-                self.nn_xinduce_idx = self.nn_util.build_sequential_nn_idx(inducing_points_fl)
-                #  shape (*_inducing_batch_shape, M-k, k)
+            self.nn_xinduce_idx = self.nn_util.build_sequential_nn_idx(inducing_points_fl)
+            #  shape (*_inducing_batch_shape, M-k, k)
         return self

--- a/gpytorch/variational/nearest_neighbor_variational_strategy.py
+++ b/gpytorch/variational/nearest_neighbor_variational_strategy.py
@@ -155,7 +155,7 @@ class NNVariationalStrategy(UnwhitenedVariationalStrategy):
                     torch.randn_like(prior_dist.mean), alpha=self._variational_distribution.mean_init_std
                 )
                 # initialize with a small variational stddev for quicker conv. of kl divergence
-                self._variational_distribution._variational_stddev.data.copy_(1e-2)
+                self._variational_distribution._variational_stddev.data.copy_(torch.tensor(1e-2))
                 self.variational_params_initialized.fill_(1)
 
             return self.forward(

--- a/test/variational/test_nearest_neighbor_variational_strategy.py
+++ b/test/variational/test_nearest_neighbor_variational_strategy.py
@@ -113,7 +113,7 @@ class TestVNNGP(VariationalTestCase, unittest.TestCase):
         return output, loss
 
     def _eval_iter(self, model, cuda=False):
-        inducing_batch_shape = model.variational_strategy.inducing_points.shape[:-2]
+        inducing_batch_shape = model.variational_strategy._inducing_batch_shape
         test_x = torch.randn(*inducing_batch_shape, 32, 2).clamp(-2.5, 2.5)
         if cuda:
             test_x = test_x.cuda()


### PR DESCRIPTION
- Fix VNNGP in batch settings #2300 
- In addition, set default jitter value to 1e-3 and variational stddev init value to 1e-2. 
- Change initialization strategy
- Special-case behaviour when training_batch_size = M (ensure we only have one minibatch and that we compute the full KL)
- Remove the option to set `k == M`