### PR TITLE
Minor patch to Matern covariances

### DIFF
--- a/gpytorch/functions/matern_covariance.py
+++ b/gpytorch/functions/matern_covariance.py
@@ -13,7 +13,7 @@ class MaternCovariance(torch.autograd.Function):
         # Subtract mean for numerical stability. Won't affect computations
         # because covariance matrix is stationary.
         needs_grad = any(ctx.needs_input_grad)
-        mean = x1.reshape(-1, x1.size(-1)).mean(0)[(None,) * (x1.dim() - 1)]
+        mean = x1.mean(dim=-2, keepdim=True)
         x1_ = (x1 - mean).div(lengthscale)
         x2_ = (x2 - mean).div(lengthscale)
         scaled_unitless_dist = dist_func(x1_, x2_).mul_(math.sqrt(2 * nu))

--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -92,7 +92,7 @@ class MaternKernel(Kernel):
             or params.get("last_dim_is_batch", False)
             or trace_mode.on()
         ):
-            mean = x1.reshape(-1, x1.size(-1)).mean(0)[(None,) * (x1.dim() - 1)]
+            mean = x1.mean(dim=-2, keepdim=True)
 
             x1_ = (x1 - mean).div(self.lengthscale)
             x2_ = (x2 - mean).div(self.lengthscale)


### PR DESCRIPTION
This PR is intended as a minor patch to ensure that `MaternCovariance` and `MaternKernel` both produce identical outputs in batched and non-batched settings. Currently, these methods produce slightly different batched vs non-batched outputs due to how a shift is handled internally. Examples are given below.

Pre-PR:
```
kernel = MaternKernel(nu=2.5)
X = torch.rand(2, 4, 2)
kernel(X).to_dense()[0] - kernel(X[0]).to_dense()
> tensor([[ 0.0000e+00,  0.0000e+00,  0.0000e+00,  1.1102e-16],
        [ 0.0000e+00,  0.0000e+00,  0.0000e+00,  0.0000e+00],
        [ 0.0000e+00,  0.0000e+00,  0.0000e+00,  0.0000e+00],
        [ 1.1102e-16, -2.2204e-16,  0.0000e+00,  0.0000e+00]],
       grad_fn=<SubBackward0>)
```

Post-PR:
```
kernel = MaternKernel(nu=2.5)
X = torch.rand(2, 4, 2)
kernel(X).to_dense()[0] - kernel(X[0]).to_dense()
> tensor([[0., 0., 0., 0.],
        [0., 0., 0., 0.],
        [0., 0., 0., 0.],
        [0., 0., 0., 0.]], grad_fn=<SubBackward0>)
```