### PR TITLE
Stop rbf_kernel_grad and rbf_kernel_gradgrad creating the full covariance matrix unnecessarily

### DIFF
--- a/gpytorch/kernels/rbf_kernel_grad.py
+++ b/gpytorch/kernels/rbf_kernel_grad.py
@@ -57,9 +57,9 @@ class RBFKernelGrad(RBFKernel):
         n1, d = x1.shape[-2:]
         n2 = x2.shape[-2]
 
-        K = torch.zeros(*batch_shape, n1 * (d + 1), n2 * (d + 1), device=x1.device, dtype=x1.dtype)
-
         if not diag:
+            K = torch.zeros(*batch_shape, n1 * (d + 1), n2 * (d + 1), device=x1.device, dtype=x1.dtype)
+
             # Scale the inputs by the lengthscale (for stability)
             x1_ = x1.div(self.lengthscale)
             x2_ = x2.div(self.lengthscale)

--- a/gpytorch/kernels/rbf_kernel_gradgrad.py
+++ b/gpytorch/kernels/rbf_kernel_gradgrad.py
@@ -57,9 +57,9 @@ class RBFKernelGradGrad(RBFKernel):
         n1, d = x1.shape[-2:]
         n2 = x2.shape[-2]
 
-        K = torch.zeros(*batch_shape, n1 * (2 * d + 1), n2 * (2 * d + 1), device=x1.device, dtype=x1.dtype)
-
         if not diag:
+            K = torch.zeros(*batch_shape, n1 * (2 * d + 1), n2 * (2 * d + 1), device=x1.device, dtype=x1.dtype)
+
             # Scale the inputs by the lengthscale (for stability)
             x1_ = x1.div(self.lengthscale)
             x2_ = x2.div(self.lengthscale)


### PR DESCRIPTION
The master implementation creates a PyTorch tensor of zeros to store the full covariance matrix, even if only the diagonal elements are needed.

If diag=True then the (potentially very large) tensor K is created but never used. This can result in a GPU running out of memory in an avoidable situation.

I have moved the creation of the tensor to store the full covariance matrix into the if diag=False branch of the code.