### PR TITLE
Fix latex of gradients in docs

### DIFF
--- a/gpytorch/means/constant_mean_gradgrad.py
+++ b/gpytorch/means/constant_mean_gradgrad.py
@@ -15,8 +15,8 @@ class ConstantMeanGradGrad(Mean):
     .. math::
 
         \mu(\mathbf x) &= C \\
-        \Grad \mu(\mathbf x) &= \mathbf 0 \\
-        \Grad^2 \mu(\mathbf x) &= \mathbf 0
+        \nabla \mu(\mathbf x) &= \mathbf 0 \\
+        \nabla^2 \mu(\mathbf x) &= \mathbf 0
 
     where :math:`C` is a learned constant.
 

--- a/gpytorch/means/linear_mean_grad.py
+++ b/gpytorch/means/linear_mean_grad.py
@@ -12,7 +12,7 @@ class LinearMeanGrad(Mean):
     .. math::
 
         \mu(\mathbf x) &= \mathbf W \cdot \mathbf x + B \\
-        \Grad \mu(\mathbf x) &= \mathbf W
+        \nabla \mu(\mathbf x) &= \mathbf W
 
     where :math:`\mathbf W` and :math:`B` are learned constants.
 

--- a/gpytorch/means/linear_mean_gradgrad.py
+++ b/gpytorch/means/linear_mean_gradgrad.py
@@ -12,8 +12,8 @@ class LinearMeanGradGrad(Mean):
     .. math::
 
         \mu(\mathbf x) &= \mathbf W \cdot \mathbf x + B \\
-        \Grad \mu(\mathbf x) &= \mathbf W \\
-        \Grad^2 \mu(\mathbf x) &= \mathbf 0 \\
+        \nabla \mu(\mathbf x) &= \mathbf W \\
+        \nabla^2 \mu(\mathbf x) &= \mathbf 0 \\
 
     where :math:`\mathbf W` and :math:`B` are learned constants.
 


### PR DESCRIPTION
See https://docs.gpytorch.ai/en/stable/means.html#constantmeangradgrad etc. for the docs.   I think `\nabla` is appropriate?