### PR TITLE
Skip the warning in `gpytorch.lazy.__getattr__` if name starts with `_`

### DIFF
--- a/gpytorch/lazy/__init__.py
+++ b/gpytorch/lazy/__init__.py
@@ -66,11 +66,12 @@ __all__ = [
 
 
 def __getattr__(name: str) -> Any:
-    warnings.warn(
-        "GPyTorch will be replacing all LazyTensor functionality with the linear operator package. "
-        "Replace all references to gpytorch.lazy.*LazyTensor with linear_operator.operators.*LinearOperator.",
-        DeprecationWarning,
-    )
+    if not name.startswith("_"):
+        warnings.warn(
+            "GPyTorch will be replacing all LazyTensor functionality with the linear operator package. "
+            "Replace all references to gpytorch.lazy.*LazyTensor with linear_operator.operators.*LinearOperator.",
+            DeprecationWarning,
+        )
     if name == "LazyTensor":
         from .lazy_tensor import LazyTensor
 


### PR DESCRIPTION
The current setup leads to the unittest `self.assertWarns...` to wrongly trigger a warning when entering `_AssertWarnsContext` (calls `getattr` on all modules: https://github.com/python/cpython/blob/main/Lib/unittest/case.py#L292-L294). Filtering out based on name starting with `_` eliminates the needless warning and keeps the correct behavior.