### PR TITLE
Fixed `mean_cache` data extraction for dKG

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -339,7 +339,7 @@ class DefaultPredictionStrategy(object):
         # see https://github.com/cornellius-gp/gpytorch/pull/2317#discussion_r1157994719
         mean_cache = self.mean_cache
         if len(mean_cache.shape) == 4:
-            mean_cache = mean_cache.squeeze(1)
+            mean_cache = mean_cache.permute(2, 0, 1, 3)[:, 0, 0:1, :]
 
         # Handle NaNs
         nan_policy = settings.observation_nan_policy.value()

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -339,7 +339,7 @@ class DefaultPredictionStrategy(object):
         # see https://github.com/cornellius-gp/gpytorch/pull/2317#discussion_r1157994719
         mean_cache = self.mean_cache
         if len(mean_cache.shape) == 4:
-            mean_cache = mean_cache.permute(2,0,1,3)[:,0:1,0,:]
+            mean_cache = mean_cache.permute(2, 0, 1, 3)[:, 0:1, 0, :]
 
         # Handle NaNs
         nan_policy = settings.observation_nan_policy.value()

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -339,7 +339,7 @@ class DefaultPredictionStrategy(object):
         # see https://github.com/cornellius-gp/gpytorch/pull/2317#discussion_r1157994719
         mean_cache = self.mean_cache
         if len(mean_cache.shape) == 4:
-            mean_cache = mean_cache.permute(2, 0, 1, 3)[:, 0:1, 0, :]
+            mean_cache = mean_cache.permute(2, 0, 1, 3)[:, 0, 0:1, :]
 
         # Handle NaNs
         nan_policy = settings.observation_nan_policy.value()

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -339,7 +339,6 @@ class DefaultPredictionStrategy(object):
         # see https://github.com/cornellius-gp/gpytorch/pull/2317#discussion_r1157994719
         mean_cache = self.mean_cache
         if len(mean_cache.shape) == 4:
-            #mean_cache = mean_cache.permute(2, 0, 1, 3)[:, 0, 0:1, :]
             mean_cache = mean_cache.squeeze(1)
 
         # Handle NaNs

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -339,7 +339,8 @@ class DefaultPredictionStrategy(object):
         # see https://github.com/cornellius-gp/gpytorch/pull/2317#discussion_r1157994719
         mean_cache = self.mean_cache
         if len(mean_cache.shape) == 4:
-            mean_cache = mean_cache.permute(2, 0, 1, 3)[:, 0, 0:1, :]
+            #mean_cache = mean_cache.permute(2, 0, 1, 3)[:, 0, 0:1, :]
+            mean_cache = mean_cache.squeeze(1)
 
         # Handle NaNs
         nan_policy = settings.observation_nan_policy.value()

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -339,7 +339,7 @@ class DefaultPredictionStrategy(object):
         # see https://github.com/cornellius-gp/gpytorch/pull/2317#discussion_r1157994719
         mean_cache = self.mean_cache
         if len(mean_cache.shape) == 4:
-            mean_cache = mean_cache.squeeze(1)
+            mean_cache = mean_cache.permute(2,0,1,3)[:,0:1,0,:]
 
         # Handle NaNs
         nan_policy = settings.observation_nan_policy.value()


### PR DESCRIPTION
Issue: dKG in BoTorch no longer works since I last ran it a few months ago. It appears to be from the `mean_cache` going from size `[num_fantasies, 1, 1, num_data]` to `[num_fantasies, num_fantasies, num_fantasies, num_data]`. What this change does is extract the relevant data of `mean_cache` while keeping the expected shape for the rest of the code (ie. `[num_fantasies, 1, num_data]`).

Not sure about a unit test for this since it depends on having BoTorch's `qKnowledgeGradient` class, among other dependencies.

See https://github.com/pytorch/botorch/pull/2137