### PR TITLE
Allow pickle of IndexKernels

### DIFF
--- a/gpytorch/kernels/index_kernel.py
+++ b/gpytorch/kernels/index_kernel.py
@@ -72,7 +72,7 @@ class IndexKernel(Kernel):
         if prior is not None:
             if not isinstance(prior, Prior):
                 raise TypeError("Expected gpytorch.priors.Prior but got " + type(prior).__name__)
-            self.register_prior("IndexKernelPrior", prior, lambda m: m._eval_covar_matrix())
+            self.register_prior("IndexKernelPrior", prior, _index_kernel_prior_closure)
 
         self.register_constraint("raw_var", var_constraint)
 
@@ -109,3 +109,7 @@ class IndexKernel(Kernel):
             right_interp_indices=i2.expand(batch_shape + i2.shape[-2:]),
         )
         return res
+
+
+def _index_kernel_prior_closure(m):
+    return m._eval_covar_matrix()


### PR DESCRIPTION
Currently, index kernels cannot be pickled. This PR moves an anonymous function to the module-level to allow pickling.

Current behaviour is that index kernels *with a prior* throw an error when pickling.
```python
from gpytorch.kernels import IndexKernel
from gpytorch.priors import LKJPrior
import pickle

kernel = IndexKernel(2, prior=LKJPrior(2, 1))
pickle.dumps(kernel)
```
This throws
` > AttributeError: Can't pickle local object 'IndexKernel.__init__.<locals>.<lambda>'`

There isn't an open issue for this in particular, but there is a request for pickle-able kernels. (#907, #2264)