### PR TITLE
Bug: Exploit Structure in get_fantasy_strategy

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -10,7 +10,6 @@ from linear_operator.operators import (
     AddedDiagLinearOperator,
     BatchRepeatLinearOperator,
     ConstantMulLinearOperator,
-    DenseLinearOperator,
     InterpolatedLinearOperator,
     LinearOperator,
     LowRankRootAddedDiagLinearOperator,
@@ -222,7 +221,7 @@ class DefaultPredictionStrategy(object):
             full_inputs = [fi.expand(fant_batch_shape + fi.shape) for fi in full_inputs]
             full_mean = full_mean.expand(fant_batch_shape + full_mean.shape)
             full_covar = BatchRepeatLinearOperator(full_covar, repeat_shape)
-            new_root = BatchRepeatLinearOperator(DenseLinearOperator(new_root.to_dense()), repeat_shape)
+            new_root = BatchRepeatLinearOperator(new_root, repeat_shape)
             # no need to repeat the covar cache, broadcasting will do the right thing
 
         if isinstance(full_output, MultitaskMultivariateNormal):

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -222,7 +222,7 @@ class DefaultPredictionStrategy(object):
             full_inputs = [fi.expand(fant_batch_shape + fi.shape) for fi in full_inputs]
             full_mean = full_mean.expand(fant_batch_shape + full_mean.shape)
             full_covar = BatchRepeatLinearOperator(full_covar, repeat_shape)
-            new_root = BatchRepeatLinearOperator(DenseLinearOperator(new_root), repeat_shape)
+            new_root = BatchRepeatLinearOperator(DenseLinearOperator(new_root.to_dense()), repeat_shape)
             # no need to repeat the covar cache, broadcasting will do the right thing
 
         if isinstance(full_output, MultitaskMultivariateNormal):

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -211,8 +211,8 @@ class DefaultPredictionStrategy(object):
 
         # now update the root and root inverse
         new_lt = self.lik_train_train_covar.cat_rows(fant_train_covar, fant_fant_covar)
-        new_root = new_lt.root_decomposition().root.to_dense()
-        new_covar_cache = new_lt.root_inv_decomposition().root.to_dense()
+        new_root = new_lt.root_decomposition().root
+        new_covar_cache = new_lt.root_inv_decomposition().root
 
         # Expand inputs accordingly if necessary (for fantasies at the same points)
         if full_inputs[0].dim() <= full_targets.dim():
@@ -238,7 +238,7 @@ class DefaultPredictionStrategy(object):
             inv_root=new_covar_cache,
         )
         add_to_cache(fant_strat, "mean_cache", fant_mean_cache)
-        add_to_cache(fant_strat, "covar_cache", new_covar_cache)
+        add_to_cache(fant_strat, "covar_cache", new_covar_cache.to_dense())
         return fant_strat
 
     @property


### PR DESCRIPTION
Hello :)

This PR is related to #2468 and cornellius-gp/linear_operator#93.

The `DefaultPredictionStrategy`'s `get_fantasy_model` updates the gram matrix with new datapoints and updates the `lik_train_train_covar`'s `root_decomposition` and `root_inv_decomposition` caches by passing them to the constructor. However by using `to_dense` in lines 214-215, the caches in the `__init__` on line 69 and 72 respectively are constructed with `root` and `inv_root` of type `torch.tensor` which in [`RootLinearOperator.__init__`](https://github.com/cornellius-gp/linear_operator/blob/a00c08e1b85b6eb8499a7b64083058df8d2a00ab/linear_operator/operators/root_linear_operator.py#L19) will assign a `DenseLinearOperator` to `self.root` since `to_linear_operator` defaults to `DenseLinearOperator` if provided with a `torch.tensor`.

As a result in [`LinearOperator.cat_rows`](https://github.com/cornellius-gp/linear_operator/blob/a00c08e1b85b6eb8499a7b64083058df8d2a00ab/linear_operator/operators/_linear_operator.py#L1265), the object `E` will be of type `DenseLinearOperator` which in turn will fail the check for for triangular matrices [here](https://github.com/cornellius-gp/linear_operator/blob/a00c08e1b85b6eb8499a7b64083058df8d2a00ab/linear_operator/operators/_linear_operator.py#L1281). This once again leads to a `stable_pinverse` with QR decomposition instead of exploiting a fast triangular solve to compute the inverse.