### PR TITLE
Added optional `kwargs` to `ExactMarginalLogLikelihood` call

### DIFF
--- a/gpytorch/mlls/exact_marginal_log_likelihood.py
+++ b/gpytorch/mlls/exact_marginal_log_likelihood.py
@@ -49,7 +49,7 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
 
         return res
 
-    def forward(self, function_dist, target, *params):
+    def forward(self, function_dist, target, *params, **kwargs):
         r"""
         Computes the MLL given :math:`p(\mathbf f)` and :math:`\mathbf y`.
 
@@ -63,7 +63,7 @@ class ExactMarginalLogLikelihood(MarginalLogLikelihood):
             raise RuntimeError("ExactMarginalLogLikelihood can only operate on Gaussian random variables")
 
         # Determine output likelihood
-        output = self.likelihood(function_dist, *params)
+        output = self.likelihood(function_dist, *params, **kwargs)
 
         # Remove NaN values if enabled
         if settings.observation_nan_policy.value() == "mask":


### PR DESCRIPTION
Added optional `**kwargs` to `ExactMarginalLogLikelihood.forward` call, so that optional keyword arguments can be passed on to the likelihood model. This is required, for example, when using it with `FixedNoiseGaussianLikelihood` on data that are not part of the training set, as mentioned in this issue: #2516 .