### PR TITLE
Corrected configuration of ``exclude`` statements in ``pre-commit`` configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
     -   id: flake8
         args: [--config=setup.cfg]
-        exclude: ^(examples/*)|(docs/*)
+        exclude: ^(examples/.*)|(docs/.*)
 -   repo: https://github.com/omnilib/ufmt
     rev: v2.0.0
     hooks:
@@ -24,15 +24,15 @@ repos:
         additional_dependencies:
         - black == 22.3.0
         - usort == 1.0.3
-        exclude: ^(build/*)|(docs/*)|(examples/*)
+        exclude: ^(build/.*)|(docs/.*)|(examples/.*)
 -   repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.6
     hooks:
     -   id: require-ascii
-        exclude: ^(examples/.*\.ipynb)|(.github/ISSUE_TEMPLATE/*)
+        exclude: ^(examples/.*\.ipynb)|(.github/ISSUE_TEMPLATE/.*)
     -   id: script-must-have-extension
     -   id: forbid-binary
-        exclude: ^(examples/*)|(test/examples/old_variational_strategy_model.pth)
+        exclude: ^(examples/.*)|(test/examples/old_variational_strategy_model.pth)
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.13
     hooks:


### PR DESCRIPTION
**Description**
Currently the pre-commit configuration assumes glob matching in the [``exclude`` statements](https://pre-commit.com/#top_level-exclude), even though these are assumed to be regular expressions. This causes the exclude statements to match the wrong files and shows warnings when running ``pre-commit``.

```bash
[WARNING] The 'exclude' field in hook 'flake8' is a regex, not a glob -- matching '/*' probably isn't what you want here
```

This PR replaces the glob statements with regular expressions in the pre-commit configuration.

**Related Issues**
This seems to be a [common error](https://github.com/pre-commit/pre-commit/issues/1702) and similar PRs have been made to other libraries (e.g. https://github.com/openml/openml-python/pull/1129)
