### PR TITLE
fix: replace deprecated scipy.integrate.cumtrapz with cumulative_trapezoid

### DIFF
--- a/gpytorch/kernels/spectral_delta_kernel.py
+++ b/gpytorch/kernels/spectral_delta_kernel.py
@@ -52,7 +52,7 @@ class SpectralDeltaKernel(Kernel):
         """
         import numpy as np
         from scipy.fftpack import fft
-        from scipy.integrate import cumtrapz
+        from scipy.integrate import cumulative_trapezoid
 
         N = train_x.size(-2)
         emp_spect = np.abs(fft(train_y.cpu().detach().numpy())) ** 2 / N
@@ -65,7 +65,7 @@ class SpectralDeltaKernel(Kernel):
         emp_spect = emp_spect[: M + 1]
 
         total_area = np.trapz(emp_spect, freq)
-        spec_cdf = np.hstack((np.zeros(1), cumtrapz(emp_spect, freq)))
+        spec_cdf = np.hstack((np.zeros(1), cumulative_trapezoid(emp_spect, freq)))
         spec_cdf = spec_cdf / total_area
 
         a = np.random.rand(self.raw_Z.size(-2), 1)

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -167,7 +167,7 @@ class SpectralMixtureKernel(Kernel):
 
         import numpy as np
         from scipy.fftpack import fft
-        from scipy.integrate import cumtrapz
+        from scipy.integrate import cumulative_trapezoid
 
         with torch.no_grad():
             if not torch.is_tensor(train_x) or not torch.is_tensor(train_y):
@@ -192,7 +192,7 @@ class SpectralMixtureKernel(Kernel):
             emp_spect = emp_spect[: M + 1]
 
             total_area = np.trapz(emp_spect, freq)
-            spec_cdf = np.hstack((np.zeros(1), cumtrapz(emp_spect, freq)))
+            spec_cdf = np.hstack((np.zeros(1), cumulative_trapezoid(emp_spect, freq)))
             spec_cdf = spec_cdf / total_area
 
             a = np.random.rand(1000, self.ard_num_dims)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ install_requires = [
     "jaxtyping>=0.2.9",
     "mpmath>=0.19,<=1.3",  # avoid incompatibiltiy with torch+sympy with mpmath 1.4
     "scikit-learn",
-    "scipy",
+    "scipy>=1.6.0",
     "linear_operator>=0.5.2",
 ]
 # if recent dev version of PyTorch is installed, no need to install stable


### PR DESCRIPTION
`scipy.integrate.cumulative_trapezoid` was introduced in scipy 1.6.0 and `scipy.integrate.cumtrapz` was removed in scipy 1.14.0

https://scipy.github.io/devdocs/release/1.6.0-notes.html#scipy-integrate-improvements https://scipy.github.io/devdocs/release/1.14.0-notes.html#expired-deprecations

This PR will replace an obsolete method and allow us to keep up with the latest scipy.
Compatibility with scipy<1.6.0 will be lost, but I don't think it will be a problem even if we use python 3.8.