### PR TITLE
use common notation for normal distribution N(\mu, \sigma^2)

### DIFF
--- a/examples/02_Scalable_Exact_GPs/Simple_GP_Regression_CUDA.ipynb
+++ b/examples/02_Scalable_Exact_GPs/Simple_GP_Regression_CUDA.ipynb
@@ -25,7 +25,7 @@
     "\\end{align}\n",
     "$$\n",
     "\n",
-    "with 11 training examples, and testing on 51 test examples."
+    "with 100 training examples, and testing on 51 test examples."
    ]
   },
   {
@@ -50,7 +50,7 @@
    "source": [
     "### Set up training data\n",
     "\n",
-    "In the next cell, we set up the training data for this example. We'll be using 11 regularly spaced points on [0,1] which we evaluate the function on and add Gaussian noise to get the training labels."
+    "In the next cell, we set up the training data for this example. We'll be using 100 regularly spaced points on [0,1] which we evaluate the function on and add Gaussian noise to get the training labels."
    ]
   },
   {
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Training data is 11 points in [0,1] inclusive regularly spaced\n",
+    "# Training data is 100 points in [0,1] inclusive regularly spaced\n",
     "train_x = torch.linspace(0, 1, 100)\n",
     "# True function is sin(2*pi*x) with Gaussian noise\n",
     "train_y = torch.sin(train_x * (2 * math.pi)) + torch.randn(train_x.size()) * math.sqrt(0.04)"

--- a/examples/02_Scalable_Exact_GPs/Simple_GP_Regression_CUDA.ipynb
+++ b/examples/02_Scalable_Exact_GPs/Simple_GP_Regression_CUDA.ipynb
@@ -21,7 +21,7 @@
     "$$\n",
     "\\begin{align}\n",
     "  y &= \\sin(2\\pi x) + \\epsilon \\\\ \n",
-    "  \\epsilon &\\sim \\mathcal{N}(0, 0.2) \n",
+    "  \\epsilon &\\sim \\mathcal{N}(0, 0.04) \n",
     "\\end{align}\n",
     "$$\n",
     "\n",
@@ -62,7 +62,7 @@
     "# Training data is 11 points in [0,1] inclusive regularly spaced\n",
     "train_x = torch.linspace(0, 1, 100)\n",
     "# True function is sin(2*pi*x) with Gaussian noise\n",
-    "train_y = torch.sin(train_x * (2 * math.pi)) + torch.randn(train_x.size()) * 0.2"
+    "train_y = torch.sin(train_x * (2 * math.pi)) + torch.randn(train_x.size()) * math.sqrt(0.04)"
    ]
   },
   {


### PR DESCRIPTION
also make it consistent with https://docs.gpytorch.ai/en/stable/examples/01_Exact_GPs/Simple_GP_Regression.html