### PR TITLE
Deprecate last_dim_is_batch (bump PyTorch version to >= 2.0)

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -17,7 +17,7 @@ requirements:
 
   run:
     - python>=3.8
-    - pytorch>=1.11
+    - pytorch>=2.0
     - scikit-learn
     - jaxtyping>=0.2.9
     - linear_operator>=0.5.2

--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -50,7 +50,7 @@ jobs:
         if [[ ${{ matrix.pytorch-version }} = "master" ]]; then
           pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html;
         else
-          pip install torch==1.11+cpu -f https://download.pytorch.org/whl/torch_stable.html;
+          pip install torch==2.0.1 --index-url https://download.pytorch.org/whl/cpu
         fi
         pip install -e .
         if [[ ${{ matrix.extras }} == "with-extras" ]]; then

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See our [**documentation, examples, tutorials**](https://gpytorch.readthedocs.io
 
 **Requirements**:
 - Python >= 3.8
-- PyTorch >= 1.11
+- PyTorch >= 2.0
 
 Install GPyTorch using pip or conda:
 

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -20,6 +20,12 @@ Interpolation Utilities
 .. automodule:: gpytorch.utils.interpolation
    :members:
 
+Nearest Neighbors Utilities
+---------------------------------
+
+.. automodule:: gpytorch.utils.nearest_neighbors
+   :members:
+
 Quadrature Utilities
 ----------------------------
 
@@ -30,10 +36,4 @@ Transform Utilities
 --------------------------
 
 .. automodule:: gpytorch.utils.transforms
-   :members:
-
-Nearest Neighbors Utilities
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: gpytorch.utils.nearest_neighbors
    :members:

--- a/examples/00_Basic_Usage/index.rst
+++ b/examples/00_Basic_Usage/index.rst
@@ -10,7 +10,7 @@ Before checking these out, you may want to check out our `simple GP regression t
   parameters, constraints, priors and more.
 * The `Saving and Loading Models`_ notebook details how to save and load GPyTorch models
   on disk.
-* The `Kernels with Additive or Product Structure`_ notebook describes how to compose kernels additively or multiplicitavely,
+* The `Kernels with Additive or Product Structure`_ notebook describes how to compose kernels additively or multiplicatively,
   whether for expressivity, sample efficiency, or scalability.
 * The `Implementing a Custom Kernel`_ notebook details how to write your own custom kernel in GPyTorch.
 * The `Tutorial on Metrics`_ describes various metrics provided by GPyTorch for assessing the generalization of GP models.

--- a/examples/00_Basic_Usage/index.rst
+++ b/examples/00_Basic_Usage/index.rst
@@ -6,10 +6,14 @@ parameter constraints and priors, and saving and loading models.
 
 Before checking these out, you may want to check out our `simple GP regression tutorial`_ that details the anatomy of a GPyTorch model.
 
-- Check out our `Tutorial on Hyperparameters`_ for information on things like raw versus actual
+* Check out our `Tutorial on Hyperparameters`_ for information on things like raw versus actual
   parameters, constraints, priors and more.
-- The `Saving and Loading Models`_ notebook details how to save and load GPyTorch models
+* The `Saving and Loading Models`_ notebook details how to save and load GPyTorch models
   on disk.
+* The `Kernels with Additive or Product Structure`_ notebook describes how to compose kernels additively or multiplicitavely,
+  whether for expressivity, sample efficiency, or scalability.
+* The `Implementing a Custom Kernel`_ notebook details how to write your own custom kernel in GPyTorch.
+* The `Tutorial on Metrics`_ describes various metrics provided by GPyTorch for assessing the generalization of GP models.
 
 .. toctree::
    :maxdepth: 1
@@ -17,6 +21,7 @@ Before checking these out, you may want to check out our `simple GP regression t
 
    Hyperparameters.ipynb
    Saving_and_Loading_Models.ipynb
+   kernels_with_additive_or_product_structure.ipynb
    Implementing_a_custom_Kernel.ipynb
    Metrics.ipynb
 
@@ -28,6 +33,9 @@ Before checking these out, you may want to check out our `simple GP regression t
 
 .. _Saving and Loading Models:
   Saving_and_Loading_Models.ipynb
+
+.. _Kernels with Additive or Product Structure:
+  kernels_with_additive_or_product_structure.ipynb
 
 .. _Implementing a custom Kernel:
   Implementing_a_custom_Kernel.ipynb

--- a/examples/00_Basic_Usage/kernels_with_additive_or_product_structure.ipynb
+++ b/examples/00_Basic_Usage/kernels_with_additive_or_product_structure.ipynb
@@ -1,0 +1,565 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6f63eab6-9d70-497c-9743-2acd652b7b8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# smoke_test = True\n",
+    "\n",
+    "import gpytorch\n",
+    "import torch\n",
+    "\n",
+    "from torch.utils import benchmark"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "057df92a-445c-4d33-b914-4fb39d9b7c7b",
+   "metadata": {},
+   "source": [
+    "# Kernels with Additive or Product Structure\n",
+    "\n",
+    "One of the most powerful properties of kernels is their closure under various composition operation.\n",
+    "Many important covariance functions can be written as the sum or the product of $m$ component kernels:\n",
+    "\n",
+    "$$\n",
+    "    k_\\mathrm{sum}(\\boldsymbol x, \\boldsymbol x') = \\sum_{i=1}^m k_i(\\boldsymbol x, \\boldsymbol x'), \\qquad\n",
+    "    k_\\mathrm{prod}(\\boldsymbol x, \\boldsymbol x') = \\prod_{i=1}^m k_i(\\boldsymbol x, \\boldsymbol x')\n",
+    "$$\n",
+    "\n",
+    "Additive and product kernels are used for a variety of reasons.\n",
+    "1. They are often more interpretable, as argued in [Duvenaud et al. (2011)](https://arxiv.org/pdf/1112.4394).\n",
+    "2. They can be extremely powerful and expressive, as demonstrated by [Wilson and Adams (2013)](https://proceedings.mlr.press/v28/wilson13.pdf).\n",
+    "3. They can be extremely sample efficient for Bayesian optimization, as demonstrated by [Kandasamy et al. (2015)](https://arxiv.org/pdf/1503.01673) and [Gardner et al. (2017)](https://proceedings.mlr.press/v54/gardner17a/gardner17a.pdf).\n",
+    "\n",
+    "We will discuss various ways to perform additive and product compositions of kernels in GPyTorch.\n",
+    "The simplest mechanism is to add/multiply the kernel objects together, or add/multiply their outputs.\n",
+    "However, there are more complex but **far more efficient ways** for adding/multiplying kernels with similar functional forms, which will enable significant parallelism especially on GPUs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "610e82ae-227b-4c0d-b817-9cd6baa73d92",
+   "metadata": {},
+   "source": [
+    "## Simple Sums and Products\n",
+    "\n",
+    "As an example, consider the [spectral mixture kernel](https://docs.gpytorch.ai/en/stable/kernels.html#spectralmixturekernel) with two components on a univariate input.\n",
+    "If we remove the scaling components, it can be implemented as:\n",
+    "\n",
+    "$$\n",
+    "    k_\\mathrm{SM}(x, x') =\n",
+    "    k_\\mathrm{RBF}(x, x', \\ell_1) k_\\mathrm{cos}(x, x'; \\omega_1) +\n",
+    "    k_\\mathrm{RBF}(x, x', \\ell_2) k_\\mathrm{cos}(x, x'; \\omega_2),\n",
+    "$$\n",
+    "\n",
+    "where $\\ell_1, \\ell_2, \\omega_1, \\omega_2$ are hyperparameters. We can naively implement this kernel in two ways..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e060386d-5192-4d03-9002-2f4169be7507",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Toy data\n",
+    "X = torch.randn(10, 1)\n",
+    "\n",
+    "# Base kernels\n",
+    "rbf_kernel_1 = gpytorch.kernels.RBFKernel()\n",
+    "cos_kernel_1 = gpytorch.kernels.CosineKernel()\n",
+    "rbf_kernel_2 = gpytorch.kernels.RBFKernel()\n",
+    "cos_kernel_2 = gpytorch.kernels.CosineKernel()\n",
+    "\n",
+    "# Implementation 1:\n",
+    "spectral_mixture_kernel = (rbf_kernel_1 * cos_kernel_1) + (rbf_kernel_2 * cos_kernel_2)\n",
+    "covar = spectral_mixture_kernel(X)\n",
+    "\n",
+    "# Implementation 2:\n",
+    "covar = rbf_kernel_1(X) * cos_kernel_1(X) + rbf_kernel_2(X) * cos_kernel_2(X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddf6ee94-f7eb-4bb2-935a-7a76787fa596",
+   "metadata": {},
+   "source": [
+    "Implementation 1 constructs a `spectral_mixture_kernel` object by applying `+` and `*` directly to the component kernel objects.\n",
+    "Implementation 2 constructrs the resulting covariance matrix by applying `+` and `*` to the outputs of the component kernels.\n",
+    "Both implementations are equivalent (the `spectral_mixture_kernel` object created by Implementation 1 essentially performs Implementation 2) under the hood.\n",
+    "\n",
+    "(Of course, neither implementation should be used in practice for the spectral mixture kernel. The built-in [SpectralMixtureKernel](https://docs.gpytorch.ai/en/stable/kernels.html#spectralmixturekernel) class is far more efficient.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfbc6181-752d-4905-8e08-df27fb5a93d5",
+   "metadata": {},
+   "source": [
+    "## Efficient Parallel Implementations of Additive Structure or Product Structure Kernels   \n",
+    "\n",
+    "Above we considered the sum and products of kernels with different functional forms.\n",
+    "However, often we are considering the sum/product over kernels with \n",
+    "The above example is simple to read, but quite slow in practice.\n",
+    "Under the hood, each of the kernels (and their compositions) are computed sequentially.\n",
+    "GPyTorch will compute the first cosine kernel, followed by the first RBF kernel, followed by their product, and so on.\n",
+    "\n",
+    "When the component kernels have the same function form,\n",
+    "we can get massive efficieny gains by exploiting parallelism.\n",
+    "We combine all of the component kernels into a **batch kernel**\n",
+    "so that each component kernel can be computed simultaneously.\n",
+    "We then compute the `sum` or `prod` over the batch dimension.\n",
+    "This strategy will yield significant speedups especially on the GPU."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "731fc597-ccbc-441a-830d-0b8d4efe100d",
+   "metadata": {},
+   "source": [
+    "### Example #1: Efficient Summations of Univariate Kernels\n",
+    "\n",
+    "As an example, let's assume that we have $d$-dimensional input data $\\boldsymbol x, \\boldsymbol x' \\in \\mathbb R^d$.\n",
+    "We can define an *additive kernel* that is the sum of $d$ univariate RBF kernels, each of which acts on a single dimension of $\\boldsymbol x$ and $\\boldsymbol x'$.\n",
+    "\n",
+    "$$\n",
+    "    k_\\mathrm{additive}(\\boldsymbol x, \\boldsymbol x') =  \\prod_{i=1}^d k_\\mathrm{RBF}(x^{(i)}, x^{\\prime(i)}; \\ell^{(i)}).\n",
+    "$$\n",
+    "\n",
+    "Here, $\\ell^{(i)}$ is the lengthscale associated with dimension $i$.\n",
+    "Note that we are using a different lengthscale for each of the component kernels.\n",
+    "Nevertheless, we can efficiently compute each of the component kernels in parallel using batching.\n",
+    "First we define a RBFKernel object designed to compute a **batch of $d$ univariate kernels**:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "90e52419-38cd-43e7-a599-bfb7abea89b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d = 3\n",
+    "\n",
+    "batch_univariate_rbf_kernel = gpytorch.kernels.RBFKernel(\n",
+    "    batch_shape=torch.Size([d]),  # A batch of d...\n",
+    "    ard_num_dims=1,  # ...univariate kernels\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba66b398-7429-408f-af23-d64ad6930df6",
+   "metadata": {},
+   "source": [
+    "Including the `batch_shape` argument ensures that the `lengthscale` parameter of the `batch_univariate_rbf_kernel` is a `d x 1 x 1` tensor; i.e. each univariate kernel will have its own lengthscale. (We could instead have each univariate kernel share the same lengthscale by omitting the `batch_shape` argument.)\n",
+    "\n",
+    "To compute the univariate kernel matrices, we need to feed the appropriate dimensions of $\\boldsymbol X$ into each of the component kernels.\n",
+    "We accomplish this by reshaping the `n x d` matrix representing $\\boldsymbol X$ into a batch of $d$ `n x 1` matrices\n",
+    "(i.e. a `d x n x 1` tensor)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0edaca08-df1e-423d-b76c-e5f8f9fc5338",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 10\n",
+    "\n",
+    "X = torch.randn(n, d)  # Some random data in a n x d matrix\n",
+    "batched_dimensions_of_X = X.mT.unsqueeze(-1)  # Now a d x n x 1 tensor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b40265f-a450-42fc-bcd4-f033750a8f7b",
+   "metadata": {},
+   "source": [
+    "We then feed the batches of univariate data into the batched kernel object to get our batch of univariate kernel matrices:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e0988873-93fa-4016-880c-d9dff3344032",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([3, 10, 10])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "univariate_rbf_covars = batch_univariate_rbf_kernel(batched_dimensions_of_X)\n",
+    "univariate_rbf_covars.shape  # d x n x n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a61442cb-a575-44d9-ae97-cc396bc48a53",
+   "metadata": {},
+   "source": [
+    "And finally, to get the multivariate kernel, we can compute the sum over the batch (i.e. the sum over the univariate kernels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "65cbeb00-4dde-4720-8d80-8a8b683caf8e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([10, 10])"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "additive_covar = univariate_rbf_covars.sum(dim=-3)  # Computes the sum over the batch dimension\n",
+    "additive_covar.shape  # n x n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e52b2c1-35f2-4074-a5f5-36fd826d3b2e",
+   "metadata": {},
+   "source": [
+    "On a small dataset, this approach is comparable to the naive approach described above. However, it will become much faster on a larger and more high dimensional dataset, especially on the GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6a5d9b77-cd31-40b4-bc89-d913a601ea9b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<torch.utils.benchmark.utils.common.Measurement object at 0x7f35cc074640>\n",
+      "naive_additive_kernel(X)\n",
+      "  3.37 ms\n",
+      "  1 measurement, 100 runs , 1 thread\n"
+     ]
+    }
+   ],
+   "source": [
+    "d = 10\n",
+    "n = 500\n",
+    "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")\n",
+    "\n",
+    "X = torch.randn(n, d, device=device)\n",
+    "\n",
+    "naive_additive_kernel = (\n",
+    "    gpytorch.kernels.RBFKernel(ard_num_dims=1, active_dims=[0]) +\n",
+    "    gpytorch.kernels.RBFKernel(ard_num_dims=1, active_dims=[1]) +\n",
+    "    gpytorch.kernels.RBFKernel(ard_num_dims=1, active_dims=[2]) +\n",
+    "    gpytorch.kernels.RBFKernel(ard_num_dims=1, active_dims=[3]) +\n",
+    "    gpytorch.kernels.RBFKernel(ard_num_dims=1, active_dims=[4]) +\n",
+    "    gpytorch.kernels.RBFKernel(ard_num_dims=1, active_dims=[5]) +\n",
+    "    gpytorch.kernels.RBFKernel(ard_num_dims=1, active_dims=[6]) +\n",
+    "    gpytorch.kernels.RBFKernel(ard_num_dims=1, active_dims=[7]) +\n",
+    "    gpytorch.kernels.RBFKernel(ard_num_dims=1, active_dims=[8]) +\n",
+    "    gpytorch.kernels.RBFKernel(ard_num_dims=1, active_dims=[9])\n",
+    ").to(device=device)\n",
+    "\n",
+    "with gpytorch.settings.lazily_evaluate_kernels(False):\n",
+    "    print(benchmark.Timer(\n",
+    "        stmt=\"naive_additive_kernel(X)\",\n",
+    "        globals={\"naive_additive_kernel\": naive_additive_kernel, \"X\": X}\n",
+    "    ).timeit(100))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8ce95d7a-0419-4d15-b48c-892df4c7711e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<torch.utils.benchmark.utils.common.Measurement object at 0x7f35cc076ec0>\n",
+      "batch_univariate_rbf_kernel(X.mT.unsqueeze(-1)).sum(dim=-3)\n",
+      "  940.30 us\n",
+      "  1 measurement, 100 runs , 1 thread\n"
+     ]
+    }
+   ],
+   "source": [
+    "batch_univariate_rbf_kernel = gpytorch.kernels.RBFKernel(\n",
+    "    batch_shape=torch.Size([d]), ard_num_dims=1,\n",
+    ").to(device=device)\n",
+    "with gpytorch.settings.lazily_evaluate_kernels(False):\n",
+    "    print(benchmark.Timer(\n",
+    "        stmt=\"batch_univariate_rbf_kernel(X.mT.unsqueeze(-1)).sum(dim=-3)\",\n",
+    "        globals={\"batch_univariate_rbf_kernel\": batch_univariate_rbf_kernel, \"X\": X}\n",
+    "    ).timeit(100))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa47ff89-dd55-44cf-b267-ac28ba0a9c27",
+   "metadata": {},
+   "source": [
+    "### Full Example\n",
+    "\n",
+    "Putting it all together, a GP using this efficient additive kernel would look something like..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c32b0df1-1fa8-4b27-ab12-2d352ea80064",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class AdditiveKernelGP(gpytorch.models.ExactGP):\n",
+    "    def __init__(self, X_train, y_train, d):\n",
+    "        likelihood = gpytorch.likelihoods.GaussianLikelihood()\n",
+    "        super().__init__(X_train, y_train, likelihood)\n",
+    "\n",
+    "        self.mean_module = gpytorch.means.ConstantMean()\n",
+    "        self.covar_module = gpytorch.kernels.ScaleKernel(\n",
+    "            gpytorch.kernels.RBFKernel(batch_shape=torch.Size([d]), ard_num_dims=1)\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, X):\n",
+    "        mean = self.mean_module(X)\n",
+    "        batched_dimensions_of_X = X.mT.unsqueeze(-1)  # Now a d x n x 1 tensor\n",
+    "        covar = self.covar_module(batched_dimensions_of_X).sum(dim=-3)\n",
+    "        return gpytorch.distributions.MultivariateNormal(mean, covar)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a9c2497-1200-44ed-b398-18a424976ea3",
+   "metadata": {},
+   "source": [
+    "### Example #2: Efficient Products of Univariate Kernels\n",
+    "\n",
+    "As another example, we can consider a multivariate kernel defined as the product of univariate kernels, i.e.:\n",
+    "\n",
+    "$$\n",
+    "    k_\\mathrm{RBF}(\\boldsymbol x, \\boldsymbol x'; \\boldsymbol \\ell) =  \\prod_{i=1}^d k_\\mathrm{RBF}(x^{(i)}, x^{\\prime(i)}; \\ell^{(i)}).\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8122f229-c7ff-49df-a4ff-2cb3f9f05fe4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([10, 10])"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = 3\n",
+    "n = 10\n",
+    "\n",
+    "batch_univariate_rbf_kernel = gpytorch.kernels.RBFKernel(\n",
+    "    batch_shape=torch.Size([d]), ard_num_dims=1,\n",
+    ")\n",
+    "X = torch.randn(n, d)\n",
+    "\n",
+    "univariate_rbf_covars = batch_univariate_rbf_kernel(X.mT.unsqueeze(-1))\n",
+    "with gpytorch.settings.lazily_evaluate_kernels(False):\n",
+    "    prod_covar = univariate_rbf_covars.prod(dim=-3)\n",
+    "prod_covar.shape  # n x n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68eaaa54-c481-45bb-aa77-fe79b6a6957d",
+   "metadata": {},
+   "source": [
+    "This particular example is a bit silly, since the multivariate RBF kernel is exactly equivalent to the product of $d$ univariate RBF kernels,\n",
+    "\n",
+    "$$\n",
+    "    k_\\mathrm{RBF}(\\boldsymbol x, \\boldsymbol x') =  \\prod_{i=1}^d k_\\mathrm{RBF}(x^{(i)}, x^{\\prime(i)}).\n",
+    "$$\n",
+    "\n",
+    "However, this strategy can actually become advantageous when we approximate each of the univariate component kernels using a scalable $\\ll \\mathcal O(n^3)$ approximation for each of the univariate kernels.\n",
+    "See [the tutorial on SKIP (structured kernel interpolation of products)](../02_Scalable_Exact_GPs/Scalable_Kernel_Interpolation_for_Products_CUDA.ipynb) for an example of exploiting product structure for scalability."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e83a742f-c24b-4cb2-be86-0c6e0cd67026",
+   "metadata": {},
+   "source": [
+    "## Summing Higher Order Interactions Between Univariate Kernels (Additive Gaussian Processes)\n",
+    "\n",
+    "[Duvenaud et al. (2011)](https://arxiv.org/pdf/1112.4394) introduce \"Additive Gaussian Processes,\" which are GPs that additively compose interaction terms between univariate kernels.\n",
+    "For example, with $d$-dimensional data and a max-degree of $3$ interaction terms, the corresponding kernel would be:\n",
+    "\n",
+    "$$\n",
+    "\\begin{align*}\n",
+    "    k(\\boldsymbol x, \\boldsymbol x')\n",
+    "    &= \\sum_{i=1}^d k_i(x^{(i)}, x^{\\prime(i)}; \\ell^{(i)}) \\\\\n",
+    "    &+ \\sum_{i \\ne j} k_i(x^{(i)}, x^{\\prime(i)}; \\ell^{(i)}) k_j(x^{(j)}, x^{\\prime(j)}; \\ell^{(j)}) \\\\\n",
+    "    &+ \\sum_{h \\ne i \\ne j} k_h(x^{(h)}, x^{\\prime(h)}; \\ell^{(h)}) k_i(x^{(i)}, x^{\\prime(i)}; \\ell^{(j)}) k_j(x^{(j)}, x^{\\prime(j)}; \\ell^{(j)})\n",
+    "\\end{align*}\n",
+    "$$\n",
+    "\n",
+    "Despite the summations having an exponential number of terms, this kernel can be computed in $\\mathcal O(d^2)$ time using the Newton-Girard formula.\n",
+    "\n",
+    "To compute this kernel in GPyTorch, we begin with a batch of the univariate covariance matrices (stored in a `d x n x n` Tensor or LinearOperator). We follow the same techniques as we used before:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7ea7337c-6375-4287-8133-6117316e0791",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([4, 10, 10])"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = 4\n",
+    "n = 10\n",
+    "\n",
+    "batch_univariate_rbf_kernel = gpytorch.kernels.RBFKernel(\n",
+    "    batch_shape=torch.Size([d]), ard_num_dims=1,\n",
+    ")\n",
+    "X = torch.randn(n, d)\n",
+    "\n",
+    "with gpytorch.settings.lazily_evaluate_kernels(False):\n",
+    "    univariate_rbf_covars = batch_univariate_rbf_kernel(X.mT.unsqueeze(-1))\n",
+    "univariate_rbf_covars.shape  # d x n x n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd7ba35a-87e3-4a86-acd7-de44184462cc",
+   "metadata": {},
+   "source": [
+    "We then use the `gpytorch.utils.sum_interaction_terms` to compute and sum all of the higher-order interaction terms in $\\mathcal O(d^2)$ time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "7f6cb2da-46b6-4cd5-9e46-6e3ae49e8444",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([10, 10])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "covar = gpytorch.utils.sum_interaction_terms(univariate_rbf_covars, max_degree=3, dim=-3)\n",
+    "covar.shape  # n x n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1492c4cc-874b-4423-aab3-ea97501730bc",
+   "metadata": {},
+   "source": [
+    "The full GP proposed by [Duvenaud et al. (2011)](https://arxiv.org/pdf/1112.4394) would then look like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f6dc72f7-d077-426c-9219-15b5cb371198",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class AdditiveGP(gpytorch.models.ExactGP):\n",
+    "    def __init__(self, X_train, y_train, d, max_degree):\n",
+    "        likelihood = gpytorch.likelihoods.GaussianLikelihood()\n",
+    "        super().__init__(X_train, y_train, likelihood)\n",
+    "\n",
+    "        self.mean_module = gpytorch.means.ConstantMean()\n",
+    "        self.covar_module = gpytorch.kernels.ScaleKernel(\n",
+    "            gpytorch.kernels.RBFKernel(batch_shape=torch.Size([d]), ard_num_dims=1)\n",
+    "        )\n",
+    "        self.max_degree = max_degree\n",
+    "\n",
+    "    def forward(self, X):\n",
+    "        mean = self.mean_module(X)\n",
+    "        batched_dimensions_of_X = X.mT.unsqueeze(-1)  # Now a d x n x 1 tensor\n",
+    "        univariate_rbf_covars = self.covar_module(batched_dimensions_of_X)\n",
+    "        covar = gpytorch.utils.sum_interaction_terms(\n",
+    "            univariate_rbf_covars, max_degree=self.max_degree, dim=-3\n",
+    "        )\n",
+    "        return gpytorch.distributions.MultivariateNormal(mean, covar)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba613c79-92a4-41e7-92f7-4b6f598286bd",
+   "metadata": {},
+   "source": [
+    "*(For those familiar with previous versions of GPyTorch, `sum_interaction_terms` replaces what was previously implemented by `NewtonGirardAdditiveKernel`.)*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/02_Scalable_Exact_GPs/KISSGP_Regression.ipynb
+++ b/examples/02_Scalable_Exact_GPs/KISSGP_Regression.ipynb
@@ -424,77 +424,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## KISS-GP for higher dimensional data w/ Additive Structure"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The method above won't scale to data with much more than ~4 dimensions, since the cost of creating the grid grows exponentially in the amount of data. Therefore, we'll need to make some additional approximations.\n",
+    "## Scaling to more dimensions\n",
     "\n",
-    "If the function you are modeling has additive structure across its dimensions, then SKI can be one of the most efficient methods for your problem.\n",
-    "\n",
-    "To set this up, we'll wrap the `GridInterpolationKernel` used in the previous two models with one additional kernel: the `AdditiveStructureKernel`. The model will look something like this:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class GPRegressionModel(gpytorch.models.ExactGP):\n",
-    "    def __init__(self, train_x, train_y, likelihood):\n",
-    "        super(GPRegressionModel, self).__init__(train_x, train_y, likelihood)\n",
-    "        \n",
-    "        # SKI requires a grid size hyperparameter. This util can help with that\n",
-    "        # We're setting Kronecker structure to False because we're using an additive structure decomposition\n",
-    "        grid_size = gpytorch.utils.grid.choose_grid_size(train_x, kronecker_structure=False)\n",
-    "        \n",
-    "        self.mean_module = gpytorch.means.ConstantMean()\n",
-    "        self.covar_module = gpytorch.kernels.AdditiveStructureKernel(\n",
-    "            gpytorch.kernels.ScaleKernel(\n",
-    "                gpytorch.kernels.GridInterpolationKernel(\n",
-    "                    gpytorch.kernels.RBFKernel(), grid_size=128, num_dims=1\n",
-    "                )\n",
-    "            ), num_dims=2\n",
-    "        )\n",
-    "\n",
-    "    def forward(self, x):\n",
-    "        mean_x = self.mean_module(x)\n",
-    "        covar_x = self.covar_module(x)\n",
-    "        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)\n",
-    "\n",
-    "    \n",
-    "likelihood = gpytorch.likelihoods.GaussianLikelihood()\n",
-    "model = GPRegressionModel(train_x, train_y, likelihood)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Essentially, the `AdditiveStructureKernel` makes the base kernel (in this case, the `GridInterpolationKernel` wrapping the `RBFKernel`) to act as 1D kernels on each data dimension. The final kernel matrix will be a sum of these 1D kernel matrices."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Scaling to more dimensions (without additive structure)\n",
-    "\n",
-    "If you can't exploit additive structure, then try one of these other two methods:\n",
+    "If your data is high dimensional, try one of the following methods:\n",
     "\n",
     "1. SKIP - or [Scalable Kernel Interpolation for Products](./Scalable_Kernel_Interpolation_for_Products_CUDA.ipynb)\n",
     "2. KISS-GP with [Deep Kernel Learning](../06_PyTorch_NN_Integration_DKL/KISSGP_Deep_Kernel_Regression_CUDA.ipynb)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -508,9 +457,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/02_Scalable_Exact_GPs/Scalable_Kernel_Interpolation_for_Products_CUDA.ipynb
+++ b/examples/02_Scalable_Exact_GPs/Scalable_Kernel_Interpolation_for_Products_CUDA.ipynb
@@ -17,18 +17,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/jrg365/anaconda3/lib/python3.6/site-packages/matplotlib/__init__.py:465: UserWarning: matplotlibrc text.usetex option can not be used unless TeX is installed on your system\n",
-      "  warnings.warn('matplotlibrc text.usetex option can not be used unless '\n",
-      "/home/jrg365/anaconda3/lib/python3.6/site-packages/matplotlib/__init__.py:473: UserWarning: matplotlibrc text.usetex can not be used with *Agg backend unless dvipng-1.6 or later is installed on your system\n",
-      "  'your system' % dvipng_req)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import math\n",
     "import torch\n",
@@ -50,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -101,7 +90,7 @@
        "torch.Size([16599, 18])"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -118,44 +107,46 @@
     "\n",
     "We now define the GP model. For more details on the use of GP models, see our simpler examples. This model uses a `GridInterpolationKernel` (SKI) with an RBF base kernel. To use SKIP, we make two changes:\n",
     "\n",
-    "- First, we use only a 1 dimensional `GridInterpolationKernel` (e.g., by passing `num_dims=1`). The idea of SKIP is to use a product of 1 dimensional `GridInterpolationKernel`s instead of a single `d` dimensional one.\n",
-    "- Next, we create a `ProductStructureKernel` that wraps our 1D `GridInterpolationKernel` with `num_dims=18`. This specifies that we want to use product structure over 18 dimensions, using the 1D `GridInterpolationKernel` in each dimension.\n",
+    "- First, we define our `base_covar_module` to have a batch_shape equal to the dimensionality of the data.\n",
+    "  We make this change because we will the `base_covar_module` to construct a batch of univariate kernels\n",
+    "  which we will then multiply using SKIP.\n",
+    "- We use only a 1 dimensional `GridInterpolationKernel` (e.g., by passing `num_dims=1`). The idea of SKIP is to use a product of 1 dimensional `GridInterpolationKernel`s instead of a single `d` dimensional one.\n",
+    "- In the `forward` call, we reshape `x` to be `d x n x 1` before passing it through the `covar_module`.\n",
+    "  Our `covar_module` produces a batch of univariate kernels, and `x` must treat each dimension as a batch.\n",
+    "- After constructing our univariate covariance matrices, we multiply them all together by calling `.prod(dim=-3)`.\n",
     "\n",
-    "**Note:** If you've explored the rest of the package, you may be wondering what the differences between `AdditiveKernel`, `AdditiveStructureKernel`, `ProductKernel`, and `ProductStructureKernel` are. The `Structure` kernels (1) assume that we want to apply a single base kernel over a fully decomposed dataset (e.g., every dimension is additive or has product structure), and (2) are significantly more efficient as a result, because they can exploit batch parallel operations instead of using for loops."
+    "For more details on this construction, see the [Kernels with Additive or Product Structure tutorial](../00_Basic_Usage/kernels_with_additive_or_product_structure.ipynb)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from gpytorch.means import ConstantMean\n",
-    "from gpytorch.kernels import ScaleKernel, RBFKernel, ProductStructureKernel, GridInterpolationKernel\n",
+    "from gpytorch.kernels import ScaleKernel, RBFKernel, GridInterpolationKernel\n",
     "from gpytorch.distributions import MultivariateNormal\n",
     "\n",
     "class GPRegressionModel(gpytorch.models.ExactGP):\n",
     "    def __init__(self, train_x, train_y, likelihood):\n",
     "        super(GPRegressionModel, self).__init__(train_x, train_y, likelihood)\n",
     "        self.mean_module = ConstantMean()\n",
-    "        self.base_covar_module = RBFKernel()\n",
-    "        self.covar_module = ProductStructureKernel(\n",
-    "            ScaleKernel(\n",
-    "                GridInterpolationKernel(self.base_covar_module, grid_size=100, num_dims=1)\n",
-    "            ), num_dims=18\n",
+    "        self.base_covar_module = RBFKernel(batch_shape=torch.Size([train_x.size(-1)]))\n",
+    "        self.covar_module = ScaleKernel(\n",
+    "            GridInterpolationKernel(self.base_covar_module, grid_size=100, num_dims=1)\n",
     "        )\n",
     "\n",
     "    def forward(self, x):\n",
     "        mean_x = self.mean_module(x)\n",
-    "        covar_x = self.covar_module(x)\n",
+    "        univariate_covars = self.covar_module(x.mT.unsqueeze(-1))\n",
+    "        covar_x = univariate_covars.prod(dim=-3)\n",
     "        return MultivariateNormal(mean_x, covar_x)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,42 +171,77 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "scrolled": false
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/gpleiss/workspace/linear_operator/linear_operator/utils/sparse.py:51: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()\n",
+      "  if nonzero_indices.storage():\n",
+      "/home/gpleiss/workspace/linear_operator/linear_operator/utils/sparse.py:66: UserWarning: The torch.cuda.*DtypeTensor constructors are no longer recommended. It's best to use methods such as torch.tensor(data, dtype=*, device='cuda') to create tensors. (Triggered internally at ../torch/csrc/tensor/python_tensor.cpp:78.)\n",
+      "  res = cls(index_tensor, value_tensor, interp_size)\n",
+      "/home/gpleiss/workspace/linear_operator/linear_operator/utils/sparse.py:66: UserWarning: torch.sparse.SparseTensor(indices, values, shape, *, device=) is deprecated.  Please use torch.sparse_coo_tensor(indices, values, shape, dtype=, device=). (Triggered internally at ../torch/csrc/utils/tensor_new.cpp:621.)\n",
+      "  res = cls(index_tensor, value_tensor, interp_size)\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Iter 1/25 - Loss: 0.942\n",
-      "Iter 2/25 - Loss: 0.919\n",
-      "Iter 3/25 - Loss: 0.888\n",
-      "Iter 4/25 - Loss: 0.864\n",
-      "Iter 5/25 - Loss: 0.840\n",
-      "Iter 6/25 - Loss: 0.816\n",
-      "Iter 7/25 - Loss: 0.792\n",
-      "Iter 8/25 - Loss: 0.767\n",
-      "Iter 9/25 - Loss: 0.743\n",
-      "Iter 10/25 - Loss: 0.719\n",
-      "Iter 11/25 - Loss: 0.698\n",
-      "Iter 12/25 - Loss: 0.671\n",
-      "Iter 13/25 - Loss: 0.651\n",
-      "Iter 14/25 - Loss: 0.624\n",
-      "Iter 15/25 - Loss: 0.600\n",
-      "Iter 16/25 - Loss: 0.576\n",
-      "Iter 17/25 - Loss: 0.553\n",
-      "Iter 18/25 - Loss: 0.529\n",
-      "Iter 19/25 - Loss: 0.506\n",
-      "Iter 20/25 - Loss: 0.483\n",
-      "Iter 21/25 - Loss: 0.460\n",
-      "Iter 22/25 - Loss: 0.441\n",
-      "Iter 23/25 - Loss: 0.413\n",
-      "Iter 24/25 - Loss: 0.391\n",
-      "Iter 25/25 - Loss: 0.375\n",
-      "CPU times: user 1min 6s, sys: 26.8 s, total: 1min 33s\n",
-      "Wall time: 1min 48s\n"
+      "Iter 1/50 - Loss: 0.782\n",
+      "Iter 2/50 - Loss: 0.767\n",
+      "Iter 3/50 - Loss: 0.749\n",
+      "Iter 4/50 - Loss: 0.733\n",
+      "Iter 5/50 - Loss: 0.717\n",
+      "Iter 6/50 - Loss: 0.699\n",
+      "Iter 7/50 - Loss: 0.682\n",
+      "Iter 8/50 - Loss: 0.665\n",
+      "Iter 9/50 - Loss: 0.648\n",
+      "Iter 10/50 - Loss: 0.631\n",
+      "Iter 11/50 - Loss: 0.613\n",
+      "Iter 12/50 - Loss: 0.596\n",
+      "Iter 13/50 - Loss: 0.578\n",
+      "Iter 14/50 - Loss: 0.561\n",
+      "Iter 15/50 - Loss: 0.544\n",
+      "Iter 16/50 - Loss: 0.526\n",
+      "Iter 17/50 - Loss: 0.509\n",
+      "Iter 18/50 - Loss: 0.491\n",
+      "Iter 19/50 - Loss: 0.474\n",
+      "Iter 20/50 - Loss: 0.457\n",
+      "Iter 21/50 - Loss: 0.439\n",
+      "Iter 22/50 - Loss: 0.422\n",
+      "Iter 23/50 - Loss: 0.405\n",
+      "Iter 24/50 - Loss: 0.388\n",
+      "Iter 25/50 - Loss: 0.372\n",
+      "Iter 26/50 - Loss: 0.355\n",
+      "Iter 27/50 - Loss: 0.339\n",
+      "Iter 28/50 - Loss: 0.322\n",
+      "Iter 29/50 - Loss: 0.306\n",
+      "Iter 30/50 - Loss: 0.291\n",
+      "Iter 31/50 - Loss: 0.276\n",
+      "Iter 32/50 - Loss: 0.261\n",
+      "Iter 33/50 - Loss: 0.246\n",
+      "Iter 34/50 - Loss: 0.232\n",
+      "Iter 35/50 - Loss: 0.218\n",
+      "Iter 36/50 - Loss: 0.204\n",
+      "Iter 37/50 - Loss: 0.191\n",
+      "Iter 38/50 - Loss: 0.179\n",
+      "Iter 39/50 - Loss: 0.167\n",
+      "Iter 40/50 - Loss: 0.155\n",
+      "Iter 41/50 - Loss: 0.144\n",
+      "Iter 42/50 - Loss: 0.134\n",
+      "Iter 43/50 - Loss: 0.124\n",
+      "Iter 44/50 - Loss: 0.114\n",
+      "Iter 45/50 - Loss: 0.106\n",
+      "Iter 46/50 - Loss: 0.097\n",
+      "Iter 47/50 - Loss: 0.089\n",
+      "Iter 48/50 - Loss: 0.082\n",
+      "Iter 49/50 - Loss: 0.075\n",
+      "Iter 50/50 - Loss: 0.068\n",
+      "CPU times: user 53.2 s, sys: 3.96 s, total: 57.1 s\n",
+      "Wall time: 1min 16s\n"
      ]
     }
    ],
@@ -227,7 +253,7 @@
     "likelihood.train()\n",
     "\n",
     "# Use the adam optimizer\n",
-    "optimizer = torch.optim.Adam(model.parameters(), lr=0.01)\n",
+    "optimizer = torch.optim.Adam(model.parameters(), lr=0.05)\n",
     "\n",
     "# \"Loss\" for GPs - the marginal log likelihood\n",
     "mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, model)\n",
@@ -246,9 +272,7 @@
     "        optimizer.step()\n",
     "        torch.cuda.empty_cache()\n",
     "        \n",
-    "# See dkl_mnist.ipynb for explanation of this flag\n",
-    "with gpytorch.settings.use_toeplitz(True):\n",
-    "    %time train()"
+    "%time train()"
    ]
   },
   {
@@ -262,48 +286,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "model.eval()\n",
     "likelihood.eval()\n",
     "with gpytorch.settings.max_preconditioner_size(10), torch.no_grad():\n",
-    "    with gpytorch.settings.use_toeplitz(False), gpytorch.settings.max_root_decomposition_size(30), gpytorch.settings.fast_pred_var():\n",
+    "    with gpytorch.settings.max_root_decomposition_size(30), gpytorch.settings.fast_pred_var():\n",
     "        preds = model(test_x)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Test MAE: 0.07745790481567383\n"
+      "Test MAE: 0.18244513869285583\n"
      ]
     }
    ],
    "source": [
     "print('Test MAE: {}'.format(torch.mean(torch.abs(preds.mean - test_y))))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -317,9 +332,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/gpytorch/kernels/additive_structure_kernel.py
+++ b/gpytorch/kernels/additive_structure_kernel.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import warnings
 from typing import Optional, Tuple
 
 from .kernel import Kernel
@@ -47,6 +48,12 @@ class AdditiveStructureKernel(Kernel):
         num_dims: int,
         active_dims: Optional[Tuple[int, ...]] = None,
     ):
+        warnings.warn(
+            "AdditiveStructureKernel is deprecated, and will be removed in GPyTorch 2.0. "
+            'Please refer to the "Kernels with Additive or Product Structure" tutorial '
+            "in the GPyTorch docs for how to implement GPs with additive structure.",
+            DeprecationWarning,
+        )
         super(AdditiveStructureKernel, self).__init__(active_dims=active_dims)
         self.base_kernel = base_kernel
         self.num_dims = num_dims

--- a/gpytorch/kernels/grid_kernel.py
+++ b/gpytorch/kernels/grid_kernel.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import warnings
 from typing import Optional
 
 import torch
@@ -139,7 +140,9 @@ class GridKernel(Kernel):
                 # Use padded grid for batch mode
                 first_grid_point = torch.stack([proj[0].unsqueeze(0) for proj in grid], dim=-1)
                 full_grid = torch.stack(padded_grid, dim=-1)
-                covars = to_dense(self.base_kernel(first_grid_point, full_grid, last_dim_is_batch=True, **params))
+                with warnings.catch_warnings():  # Hide the GPyTorch 2.0 deprecation warning
+                    warnings.simplefilter("ignore", DeprecationWarning)
+                    covars = to_dense(self.base_kernel(first_grid_point, full_grid, last_dim_is_batch=True, **params))
 
                 if last_dim_is_batch:
                     # Toeplitz expects batches of columns so we concatenate the
@@ -155,7 +158,9 @@ class GridKernel(Kernel):
                     covar = KroneckerProductLinearOperator(*covars[::-1])
             else:
                 full_grid = torch.stack(padded_grid, dim=-1)
-                covars = to_dense(self.base_kernel(full_grid, full_grid, last_dim_is_batch=True, **params))
+                with warnings.catch_warnings():  # Hide the GPyTorch 2.0 deprecation warning
+                    warnings.simplefilter("ignore", DeprecationWarning)
+                    covars = to_dense(self.base_kernel(full_grid, full_grid, last_dim_is_batch=True, **params))
                 if last_dim_is_batch:
                     # Note that this requires all the dimensions to have the same number of grid points
                     covar = covars

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -485,6 +485,15 @@ class Kernel(Module):
             * `diag`: `... x N`
             * `diag` with `last_dim_is_batch=True`: `... x K x N`
         """
+        if last_dim_is_batch:
+            warnings.warn(
+                "The last_dim_is_batch argument is deprecated, and will be removed in GPyTorch 2.0. "
+                "If you are using it as part of AdditiveStructureKernel or ProductStructureKernel, "
+                'please update your code according to the "Kernels with Additive or Product Structure" '
+                "tutorial in the GPyTorch docs.",
+                DeprecationWarning,
+            )
+
         x1_, x2_ = x1, x2
 
         # Select the active dimensions

--- a/gpytorch/kernels/newton_girard_additive_kernel.py
+++ b/gpytorch/kernels/newton_girard_additive_kernel.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+
+import warnings
 from typing import Optional, Tuple
 
 import torch
@@ -23,6 +26,13 @@ class NewtonGirardAdditiveKernel(Kernel):
         :param active_dims:
         :param kwargs:
         """
+
+        warnings.warn(
+            "NewtonGirardAdditiveKernel is deprecated, and will be removed in GPyTorch 2.0. "
+            'Please refer to the "Kernels with Additive or Product Structure" tutorial '
+            "in the GPyTorch docs for how to implement GPs with additive structure.",
+            DeprecationWarning,
+        )
         super(NewtonGirardAdditiveKernel, self).__init__(active_dims=active_dims, **kwargs)
 
         self.base_kernel = base_kernel

--- a/gpytorch/kernels/product_structure_kernel.py
+++ b/gpytorch/kernels/product_structure_kernel.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import warnings
 from typing import Optional, Tuple
 
 from linear_operator.operators import to_linear_operator
@@ -54,6 +55,13 @@ class ProductStructureKernel(Kernel):
         num_dims: int,
         active_dims: Optional[Tuple[int, ...]] = None,
     ):
+        warnings.warn(
+            "ProductStructureKernel is deprecated, and will be removed in GPyTorch 2.0. "
+            'Please refer to the "Kernels with Additive or Product Structure" tutorial '
+            "in the GPyTorch docs for how to implement GPs with product structure.",
+            DeprecationWarning,
+        )
+
         super(ProductStructureKernel, self).__init__(active_dims=active_dims)
         self.base_kernel = base_kernel
         self.num_dims = num_dims

--- a/gpytorch/utils/__init__.py
+++ b/gpytorch/utils/__init__.py
@@ -10,6 +10,7 @@ import linear_operator
 from . import deprecation, errors, generic, grid, interpolation, quadrature, transforms, warnings
 from .memoize import cached
 from .nearest_neighbors import NNUtil
+from .sum_interaction_terms import sum_interaction_terms
 
 __all__ = [
     "cached",
@@ -19,6 +20,7 @@ __all__ = [
     "grid",
     "interpolation",
     "quadrature",
+    "sum_interaction_terms",
     "transforms",
     "warnings",
     "NNUtil",

--- a/gpytorch/utils/sum_interaction_terms.py
+++ b/gpytorch/utils/sum_interaction_terms.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 
 from typing import Optional, Union
 
@@ -39,7 +38,8 @@ def sum_interaction_terms(
     :param dim: The dimension to sum over (i.e. the batch dimension containing the base covariance matrices).
         Note that dim must be a negative integer (i.e. -3, not 0).
     """
-    assert dim < 0, "dim must be a negative integer"
+    if dim >= 0:
+        raise ValueError("Argument 'dim' must be a negative integer.")
 
     covars = to_dense(covars)
     ks = torch.arange(max_degree, dtype=covars.dtype, device=covars.device)

--- a/gpytorch/utils/sum_interaction_terms.py
+++ b/gpytorch/utils/sum_interaction_terms.py
@@ -1,4 +1,3 @@
-
 from typing import Optional, Union
 
 import torch

--- a/gpytorch/utils/sum_interaction_terms.py
+++ b/gpytorch/utils/sum_interaction_terms.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+from typing import Optional, Union
+
+import torch
+
+from jaxtyping import Float
+from linear_operator import LinearOperator, to_dense
+from torch import Tensor
+
+
+def sum_interaction_terms(
+    covars: Float[Union[LinearOperator, Tensor], "... D N N"],
+    max_degree: Optional[int] = None,
+    dim: int = -3,
+) -> Float[Tensor, "... N N"]:
+    r"""
+    Given a batch of D x N x N covariance matrices :math:`\boldsymbol K_1, \ldots, \boldsymbol K_D`,
+    compute the sum of each covariance matrix as well as the interaction terms up to degree `max_degree`
+    (denoted as :math:`M` below):
+
+    .. math::
+
+        \sum_{1 \leq i_1 < i_2 < \ldots <  i_M < D} \left[
+            \prod_{j=1}^M \boldsymbol K_{i_j}
+        \right].
+
+    This function is useful for computing the sum of additive kernels as defined in
+    `Additive Gaussian Processes (Duvenaud et al., 2011)`_.
+
+    Note that the summation is computed in :math:`\mathcal O(D)` time using the Newton-Girard formula.
+
+    .. _Additive Gaussian Processes (Duvenaud et al., 2011):
+        https://arxiv.org/pdf/1112.4394
+
+    :param covars: A batch of covariance matrices, representing the base covariances to sum over
+    :param max_degree: The maximum degree of the interaction terms to compute.
+        If not provided, this will default to `D`.
+    :param dim: The dimension to sum over (i.e. the batch dimension containing the base covariance matrices).
+        Note that dim must be a negative integer (i.e. -3, not 0).
+    """
+    assert dim < 0, "dim must be a negative integer"
+
+    covars = to_dense(covars)
+    ks = torch.arange(max_degree, dtype=covars.dtype, device=covars.device)
+    neg_one = torch.tensor(-1.0, dtype=covars.dtype, device=covars.device)
+
+    # S_times_factor[k] = factor[k] * S[k]
+    #                   = (-1)^{k} * \sum_{i=1}^D covar_i^{k+1}
+    S_times_factor_ks = torch.vmap(lambda k: neg_one.pow(k) * torch.sum(covars.pow(k + 1), dim=dim))(ks)
+
+    # E[deg] = 1/(deg+1) \sum_{j=0}^{deg} factor[k] * S[k] * E[deg-k]
+    #           = 1/(deg+1) [ (factor[deg] * S[deg]) + \sum_{j=1}^{deg - 1} factor * S_ks[k] * E_ks[deg-k] ]
+    E_ks = torch.empty_like(S_times_factor_ks)
+    E_ks[0] = S_times_factor_ks[0]
+    for deg in range(1, max_degree):
+        sum_term = torch.einsum("m...,m...->...", S_times_factor_ks[:deg], E_ks[:deg].flip(0))
+        E_ks[deg] = (S_times_factor_ks[deg] + sum_term) / (deg + 1)
+
+    return E_ks.sum(0)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def find_version(*file_paths):
 readme = open("README.md").read()
 
 
-torch_min = "1.11"
+torch_min = "2.0"
 install_requires = [
     "jaxtyping==0.2.19",
     "mpmath>=0.19,<=1.3",  # avoid incompatibiltiy with torch+sympy with mpmath 1.4

--- a/test/utils/test_sum_interaction_terms.py
+++ b/test/utils/test_sum_interaction_terms.py
@@ -33,5 +33,5 @@ class TestSumInteractionTerms(BaseTestCase, unittest.TestCase):
             for interaction_term_indices in combinations(range(D), degree):
                 actual = actual + prod([to_dense(covars[..., i, :, :]) for i in interaction_term_indices])
 
-        res = to_dense(gpytorch.utils.sum_interaction_terms(covars, max_degree=M))
+        res = gpytorch.utils.sum_interaction_terms(covars, max_degree=M)
         self.assertAllClose(res, actual)

--- a/test/utils/test_sum_interaction_terms.py
+++ b/test/utils/test_sum_interaction_terms.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import unittest
+from functools import reduce
+from itertools import combinations
+from operator import mul
+
+import torch
+from linear_operator import to_dense
+
+import gpytorch
+from gpytorch.test.base_test_case import BaseTestCase
+
+
+def prod(iterable):
+    return reduce(mul, iterable, 1)
+
+
+class TestSumInteractionTerms(BaseTestCase, unittest.TestCase):
+    def test_sum_interaction_terms(self):
+        batch_shape = torch.Size([2, 1])
+        D = 5
+        M = 4
+        N = 20
+
+        base_kernel = gpytorch.kernels.RBFKernel(batch_shape=torch.Size([D]))
+        x = torch.randn(*batch_shape, D, N, 1)
+        with torch.no_grad(), gpytorch.settings.lazily_evaluate_kernels(False):
+            covars = base_kernel(x)
+
+        actual = torch.zeros(*batch_shape, N, N)
+        for degree in range(1, M + 1):
+            for interaction_term_indices in combinations(range(D), degree):
+                actual = actual + prod([to_dense(covars[..., i, :, :]) for i in interaction_term_indices])
+
+        res = to_dense(gpytorch.utils.sum_interaction_terms(covars, max_degree=M))
+        self.assertAllClose(res, actual)


### PR DESCRIPTION
See conversation here: https://github.com/cornellius-gp/gpytorch/pull/2544#issuecomment-2207423974

#2544 will remove `last_dim_is_batch` for GPyTorch 2.0. This PR...

- Adds temporary deprecation warnings for our next (and final?) minor release.
- Adds a [new example notebook](https://gpytorch--2549.org.readthedocs.build/en/2549/examples/00_Basic_Usage/kernels_with_additive_or_product_structure.html) demonstrating how to do additive/product structure in the GPyTorch 2.0 ways (once we remove `AdditiveStructureKernel`, `ProductStructureKernel`, and `NewtonGirardAdditiveKernel`; the 3 kernels that relied on `last_dim_is_batch`.
- Adds `gpytorch.utils.sum_interaction_terms`, which replaces the core functionality of `NewtonGirardAdditiveKernel`.

The last change uses vmaps, so we can use this PR as an excuse to bump the PyTorch requirement to >= 2.0.