### PR TITLE
Added ability for priors of transformed distributions to have their p…

### DIFF
--- a/gpytorch/priors/prior.py
+++ b/gpytorch/priors/prior.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 
 from abc import ABC
+from typing import Any, Mapping
 
+from torch.distributions import TransformedDistribution
 from torch.nn import Module
 
 from ..distributions import Distribution
+from .utils import _load_transformed_to_base_dist
 
 
 class Prior(Distribution, Module, ABC):
@@ -25,3 +28,25 @@ class Prior(Distribution, Module, ABC):
         :rtype: torch.Tensor
         """
         return super(Prior, self).log_prob(self.transform(x))
+
+    def load_state_dict(self, state_dict: Mapping[str, Any], *args, **kwargs):
+        Module.load_state_dict(self, state_dict, *args, **kwargs)
+        if isinstance(self, TransformedDistribution):
+            _load_transformed_to_base_dist(self)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if hasattr(self, name) and "_transformed_" in name:
+            base_attr_name = name.replace("_transformed_", "")
+            raise AttributeError(
+                "Priors of TransformedDistributions "
+                "should not have their '_transformed' attributes modified, these are "
+                "just copies of the base attribute. "
+                f"Please modify the base attribute (e.g. {base_attr_name}) instead."
+            )
+
+        elif hasattr(self, f"_transformed_{name}"):
+            self.base_dist.__setattr__(name, value)
+            super().__setattr__(f"_transformed_{name}", value)
+
+        else:
+            return super().__setattr__(name, value)

--- a/gpytorch/priors/prior.py
+++ b/gpytorch/priors/prior.py
@@ -10,6 +10,11 @@ from ..distributions import Distribution
 from .utils import _load_transformed_to_base_dist
 
 
+TRANSFORMED_ERROR_MSG = """Priors of TransformedDistributions should not have their \
+'_transformed' attributes modified, these are just copies of the base attribute. \
+Please modify the base attribute (e.g. {}) instead."""
+
+
 class Prior(Distribution, Module, ABC):
     """
     Base class for Priors in GPyTorch.
@@ -37,12 +42,7 @@ class Prior(Distribution, Module, ABC):
     def __setattr__(self, name: str, value: Any) -> None:
         if hasattr(self, name) and "_transformed_" in name:
             base_attr_name = name.replace("_transformed_", "")
-            raise AttributeError(
-                "Priors of TransformedDistributions "
-                "should not have their '_transformed' attributes modified, these are "
-                "just copies of the base attribute. "
-                f"Please modify the base attribute (e.g. {base_attr_name}) instead."
-            )
+            raise AttributeError(TRANSFORMED_ERROR_MSG.format(base_attr_name))
 
         elif hasattr(self, f"_transformed_{name}"):
             self.base_dist.__setattr__(name, value)

--- a/gpytorch/priors/torch_priors.py
+++ b/gpytorch/priors/torch_priors.py
@@ -1,15 +1,7 @@
 #!/usr/bin/env python3
 
 import torch
-from torch.distributions import (
-    Gamma,
-    HalfCauchy,
-    HalfNormal,
-    LogNormal,
-    MultivariateNormal,
-    Normal,
-    Uniform,
-)
+from torch.distributions import Gamma, HalfCauchy, HalfNormal, LogNormal, MultivariateNormal, Normal, Uniform
 from torch.nn import Module as TModule
 
 from .prior import Prior

--- a/gpytorch/priors/torch_priors.py
+++ b/gpytorch/priors/torch_priors.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python3
 
 import torch
-from torch.distributions import Gamma, HalfCauchy, HalfNormal, LogNormal, MultivariateNormal, Normal, Uniform
+from torch.distributions import (
+    Gamma,
+    HalfCauchy,
+    HalfNormal,
+    LogNormal,
+    MultivariateNormal,
+    Normal,
+    Uniform,
+)
 from torch.nn import Module as TModule
 
 from .prior import Prior
@@ -40,6 +48,7 @@ class HalfNormalPrior(Prior, HalfNormal):
     def __init__(self, scale, validate_args=None, transform=None):
         TModule.__init__(self)
         HalfNormal.__init__(self, scale=scale, validate_args=validate_args)
+        _bufferize_attributes(self, ("scale",))
         self._transform = transform
 
     def expand(self, batch_shape):
@@ -54,6 +63,7 @@ class LogNormalPrior(Prior, LogNormal):
     def __init__(self, loc, scale, validate_args=None, transform=None):
         TModule.__init__(self)
         LogNormal.__init__(self, loc=loc, scale=scale, validate_args=validate_args)
+        _bufferize_attributes(self, ("loc", "scale"))
         self._transform = transform
 
     def expand(self, batch_shape):
@@ -84,6 +94,7 @@ class HalfCauchyPrior(Prior, HalfCauchy):
     def __init__(self, scale, validate_args=None, transform=None):
         TModule.__init__(self)
         HalfCauchy.__init__(self, scale=scale, validate_args=validate_args)
+        _bufferize_attributes(self, ("scale",))
         self._transform = transform
 
     def expand(self, batch_shape):

--- a/gpytorch/priors/utils.py
+++ b/gpytorch/priors/utils.py
@@ -1,11 +1,36 @@
 #!/usr/bin/env python3
 
+from torch.distributions import TransformedDistribution
+
 
 def _bufferize_attributes(module, attributes):
-    attr_clones = {attr: getattr(module, attr).clone() for attr in attributes}
-    for attr, value in attr_clones.items():
-        delattr(module, attr)
-        module.register_buffer(attr, value)
+    r"""
+    Adds the parameters of the prior as a torch buffer to enable saving/
+    loading to/from state_dicts.
+    For TransformedDistributions Adds a _transformed_ attribute to the
+    parameters. This enables its parameters to be saved and
+    loaded to/from state_dicts, as the original parameters cannot be.
+    """
+    if isinstance(module, TransformedDistribution):
+        for attr in attributes:
+            module.register_buffer(f"_transformed_{attr}", getattr(module, attr))
+    else:
+        attr_clones = {attr: getattr(module, attr).clone() for attr in attributes}
+        for attr, value in attr_clones.items():
+            delattr(module, attr)
+            module.register_buffer(attr, value)
+
+
+def _load_transformed_to_base_dist(module):
+    r"""loads the  _transformed_ attributes to the parameters of a torch
+    TransformedDistribution. This enables its parameters to be saved and
+    loaded to/from state_dicts, as the original parameters cannot be.
+    """
+    transf_str = "_transformed_"
+    transformed_attrs = [attr for attr in dir(module) if transf_str in attr]
+    for transf_attr in transformed_attrs:
+        base_attr_name = transf_attr.replace(transf_str, "")
+        setattr(module.base_dist, base_attr_name, getattr(module, transf_attr))
 
 
 def _del_attributes(module, attributes, raise_on_error=False):

--- a/test/priors/test_prior.py
+++ b/test/priors/test_prior.py
@@ -7,9 +7,9 @@ from gpytorch.priors import GammaPrior, HalfCauchyPrior, LogNormalPrior, NormalP
 from torch import Tensor
 
 
-TRANSFORMED_ERROR_MSG = """Priors of TransformedDistributions should not have their 
-'_transformed' attributes modified, these are just copies of the base attribute. 
-Please modify the base attribute \(e.g. {}\) instead."""
+TRANSFORMED_ERROR_MSG = """Priors of TransformedDistributions should not have their \
+'_transformed' attributes modified, these are just copies of the base attribute. \
+Please modify the base attribute (e.g. {}) instead."""
 
 
 class TestPrior(unittest.TestCase):

--- a/test/priors/test_prior.py
+++ b/test/priors/test_prior.py
@@ -2,9 +2,9 @@
 
 import unittest
 
-from gpytorch.priors import GammaPrior, HalfCauchyPrior, LogNormalPrior, NormalPrior
-
 from torch import Tensor
+
+from gpytorch.priors import GammaPrior, HalfCauchyPrior, LogNormalPrior, NormalPrior
 
 
 TRANSFORMED_ERROR_MSG = """Priors of TransformedDistributions should not have their \

--- a/test/priors/test_prior.py
+++ b/test/priors/test_prior.py
@@ -7,7 +7,9 @@ from gpytorch.priors import GammaPrior, HalfCauchyPrior, LogNormalPrior, NormalP
 from torch import Tensor
 
 
-TRANSFORMED_ERROR_MSG = """Priors of TransformedDistributions should not have their '_transformed' attributes modified, these are just copies of the base attribute. Please modify the base attribute \(e.g. {}\) instead."""
+TRANSFORMED_ERROR_MSG = """Priors of TransformedDistributions should not have their 
+'_transformed' attributes modified, these are just copies of the base attribute. 
+Please modify the base attribute \(e.g. {}\) instead."""
 
 
 class TestPrior(unittest.TestCase):
@@ -61,8 +63,8 @@ class TestPrior(unittest.TestCase):
         norm.loc = Tensor([1.01])
         ln.loc = Tensor([1.01])
         self.assertEqual(ln._transformed_loc, 1.01)
-        with self.assertRaisesRegex(AttributeError, TRANSFORMED_ERROR_MSG.format("loc")):
+        with self.assertRaises(AttributeError):
             ln._transformed_loc = 1.1
 
-        with self.assertRaisesRegex(AttributeError, TRANSFORMED_ERROR_MSG.format("scale")):
+        with self.assertRaises(AttributeError):
             hc._transformed_scale = 1.01

--- a/test/priors/test_prior.py
+++ b/test/priors/test_prior.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from gpytorch.priors import GammaPrior, HalfCauchyPrior, LogNormalPrior, NormalPrior
+
+from torch import Tensor
+
+
+TRANSFORMED_ERROR_MSG = """Priors of TransformedDistributions should not have their '_transformed' attributes modified, these are just copies of the base attribute. Please modify the base attribute \(e.g. {}\) instead."""
+
+
+class TestPrior(unittest.TestCase):
+    def test_state_dict(self):
+        normal = NormalPrior(0.1, 1).state_dict()
+        self.assertTrue("loc" in normal)
+        self.assertTrue("scale" in normal)
+        self.assertEqual(normal["loc"], 0.1)
+
+        gamma = GammaPrior(1.1, 2).state_dict()
+        self.assertTrue("concentration" in gamma)
+        self.assertTrue("rate" in gamma)
+        self.assertEqual(gamma["concentration"], 1.1)
+
+        ln = LogNormalPrior(2.1, 1.2).state_dict()
+        self.assertTrue("_transformed_loc" in ln)
+        self.assertTrue("_transformed_scale" in ln)
+        self.assertEqual(ln["_transformed_loc"], 2.1)
+
+        hc = HalfCauchyPrior(1.3).state_dict()
+        self.assertTrue("_transformed_scale" in hc)
+
+    def test_load_state_dict(self):
+        ln1 = LogNormalPrior(loc=0.5, scale=0.1)
+        ln2 = LogNormalPrior(loc=2.5, scale=2.1)
+        gm1 = GammaPrior(concentration=0.5, rate=0.1)
+        gm2 = GammaPrior(concentration=2.5, rate=2.1)
+        hc1 = HalfCauchyPrior(scale=1.1)
+        hc2 = HalfCauchyPrior(scale=101.1)
+
+        ln2.load_state_dict(ln1.state_dict())
+        self.assertEqual(ln2.loc, ln1.loc)
+        self.assertEqual(ln2.scale, ln1.scale)
+
+        gm2.load_state_dict(gm1.state_dict())
+        self.assertEqual(gm2.concentration, gm1.concentration)
+        self.assertEqual(gm2.rate, gm1.rate)
+
+        hc2.load_state_dict(hc1.state_dict())
+        self.assertEqual(hc2.scale, hc1.scale)
+
+    def test_transformed_attributes(self):
+        norm = NormalPrior(loc=2.5, scale=2.1)
+        ln = LogNormalPrior(loc=2.5, scale=2.1)
+        hc = HalfCauchyPrior(scale=2.2)
+
+        with self.assertRaisesRegex(AttributeError, "'NormalPrior' object has no attribute '_transformed_loc'"):
+            getattr(norm, "_transformed_loc")
+
+        self.assertTrue(getattr(ln, "_transformed_loc"), 2.5)
+        norm.loc = Tensor([1.01])
+        ln.loc = Tensor([1.01])
+        self.assertEqual(ln._transformed_loc, 1.01)
+        with self.assertRaisesRegex(AttributeError, TRANSFORMED_ERROR_MSG.format("loc")):
+            ln._transformed_loc = 1.1
+
+        with self.assertRaisesRegex(AttributeError, TRANSFORMED_ERROR_MSG.format("scale")):
+            hc._transformed_scale = 1.01

--- a/test/priors/test_utils.py
+++ b/test/priors/test_utils.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+
+from gpytorch.priors import (
+    GammaPrior,
+    HalfCauchyPrior,
+    HalfCauchyPrior,
+    LogNormalPrior,
+    NormalPrior,
+)
+from gpytorch.priors.utils import _load_transformed_to_base_dist
+
+
+class TestUtils(unittest.TestCase):
+    def test_bufferize_attributes(self):
+        prior = NormalPrior(0.01, 1)
+        self.assertEqual(prior.loc, 0.01)
+        self.assertEqual(prior.loc.requires_grad, False)
+
+        prior = GammaPrior(1, 2)
+        self.assertEqual(prior.rate, 2.0)
+        self.assertEqual(prior.rate.requires_grad, False)
+
+        prior = LogNormalPrior(2.1, 1.2)
+        self.assertEqual(prior._transformed_loc, 2.1)
+        self.assertEqual(prior.loc, 2.1)
+        self.assertEqual(prior._transformed_scale, 1.2)
+        self.assertEqual(prior._transformed_scale.requires_grad, False)
+
+        prior = HalfCauchyPrior(1.3)
+        self.assertEqual(prior._transformed_scale, 1.3)
+        self.assertEqual(prior._transformed_scale.requires_grad, False)
+
+    def test_load_transformed_to_base_dist(self):
+        lognormal = LogNormalPrior(loc=2.5, scale=2.1)
+        self.assertEqual(lognormal._transformed_loc, 2.5)
+        self.assertEqual(lognormal._transformed_scale, 2.1)
+
+        lognormal._transformed_loc = torch.Tensor([0.11])
+        lognormal._transformed_scale = torch.Tensor([11])
+        _load_transformed_to_base_dist(lognormal)
+        self.assertEqual(lognormal._transformed_loc, 0.11)
+        self.assertEqual(lognormal._transformed_scale, 11)
+        self.assertEqual(lognormal.loc, 0.11)
+        self.assertEqual(lognormal.scale, 11)
+
+        halfcauchy = HalfCauchyPrior(scale=11.1)
+        self.assertEqual(halfcauchy._transformed_scale, 11.1)
+        halfcauchy._transformed_scale = torch.Tensor([0.11])
+        _load_transformed_to_base_dist(halfcauchy)
+        self.assertEqual(halfcauchy._transformed_scale, 0.11)
+        self.assertEqual(halfcauchy.scale, 0.11)

--- a/test/priors/test_utils.py
+++ b/test/priors/test_utils.py
@@ -2,8 +2,9 @@
 
 import unittest
 
-from gpytorch.priors import GammaPrior, HalfCauchyPrior, LogNormalPrior, NormalPrior
 from torch import Tensor
+
+from gpytorch.priors import GammaPrior, HalfCauchyPrior, LogNormalPrior, NormalPrior
 
 
 class TestPrior(unittest.TestCase):


### PR DESCRIPTION
A suggested fix to https://github.com/cornellius-gp/gpytorch/issues/2550.

The proposed solution adds a `_transformed_` buffer to all of the priors of `TransformedDistributions` (LogNormal, HalfNormal, HalfCauchy), as their original parameters cannot be saved to `state_dict`. Thus these parameters will be saved and loaded from state_dict, and sets the value of the parameters of the corresponding base distributions.

Added some tests for these methods as well, hopefully they are sufficient.
