### PR TITLE
Fix bug #2606: Setting mixing_weights=False in SoftmaxLikelihood still adds the learnable parameter W

### DIFF
--- a/gpytorch/likelihoods/softmax_likelihood.py
+++ b/gpytorch/likelihoods/softmax_likelihood.py
@@ -41,7 +41,7 @@ class SoftmaxLikelihood(Likelihood):
         if num_classes is None:
             raise ValueError("num_classes is required")
         self.num_classes = num_classes
-        if mixing_weights is not None:
+        if mixing_weights:
             if num_features is None:
                 raise ValueError("num_features is required with mixing weights")
             self.num_features: int = num_features

--- a/test/likelihoods/test_softmax_likelihood.py
+++ b/test/likelihoods/test_softmax_likelihood.py
@@ -61,3 +61,7 @@ class TestSoftmaxLikelihoodNoMixing(TestSoftmaxLikelihood):
 
     def create_likelihood(self):
         return SoftmaxLikelihood(num_features=6, num_classes=6, mixing_weights=False)
+
+    def _test_learnable_parameters(self):
+        likelihood = self.create_likelihood()
+        self.assertEqual(len(list(likelihood.parameters())), 0)


### PR DESCRIPTION
fix bug #2606 