### PR TITLE
add offset parameter to linear kernel

### DIFF
--- a/gpytorch/kernels/linear_kernel.py
+++ b/gpytorch/kernels/linear_kernel.py
@@ -67,7 +67,12 @@ class LinearKernel(Kernel):
             self.register_prior("variance_prior", variance_prior, lambda m: m.variance, lambda m, v: m._set_variance(v))
 
         self.register_constraint("raw_variance", variance_constraint)
-        self.register_parameter(name="offset", parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1, 1 if ard_num_dims is None else ard_num_dims)))
+        self.register_parameter(
+            name="offset",
+            parameter=torch.nn.Parameter(
+                torch.zeros(*self.batch_shape, 1, 1 if ard_num_dims is None else ard_num_dims)
+            ),
+        )
 
     @property
     def variance(self) -> Tensor:
@@ -85,7 +90,7 @@ class LinearKernel(Kernel):
     def forward(
         self, x1: Tensor, x2: Tensor, diag: bool = False, last_dim_is_batch: Optional[bool] = False, **params
     ) -> Union[Tensor, LinearOperator]:
-        x1_ = (x1-self.offset) * self.variance.sqrt()
+        x1_ = (x1 - self.offset) * self.variance.sqrt()
         if last_dim_is_batch:
             x1_ = x1_.transpose(-1, -2).unsqueeze(-1)
 
@@ -95,7 +100,7 @@ class LinearKernel(Kernel):
             prod = RootLinearOperator(x1_)
 
         else:
-            x2_ = (x2 -self.offset)* self.variance.sqrt()
+            x2_ = (x2 - self.offset) * self.variance.sqrt()
             if last_dim_is_batch:
                 x2_ = x2_.transpose(-1, -2).unsqueeze(-1)
 

--- a/test/kernels/test_linear_kernel.py
+++ b/test/kernels/test_linear_kernel.py
@@ -33,7 +33,7 @@ class TestLinearKernel(unittest.TestCase, BaseKernelTestCase):
     def test_computes_linear_function_square(self):
         a = torch.tensor([[4, 1], [2, 0], [8, 3]], dtype=torch.float)
 
-        kernel = self.create_kernel_no_ard().initialize(variance=3.14)
+        kernel = self.create_kernel_no_ard().initialize(variance=3.14, offset=0.0)
         kernel.eval()
         actual = torch.matmul(a, a.t()) * 3.14
         res = kernel(a, a).to_dense()
@@ -59,7 +59,7 @@ class TestLinearKernel(unittest.TestCase, BaseKernelTestCase):
     def test_computes_linear_function_square_batch(self):
         a = torch.tensor([[[4, 1], [2, 0], [8, 3]], [[1, 1], [2, 1], [1, 3]]], dtype=torch.float)
 
-        kernel = self.create_kernel_no_ard().initialize(variance=1.0)
+        kernel = self.create_kernel_no_ard().initialize(variance=1.0, offset=0.0)
         kernel.eval()
         actual = torch.matmul(a, a.transpose(-1, -2))
         res = kernel(a, a).to_dense()


### PR DESCRIPTION
Without having an offset parameter, the linear model always has zero variance at the origin.

![download - 2025-01-13T104233 326](https://github.com/user-attachments/assets/d0f1c31f-f013-49c3-a688-15160829e576)


Adding the offset parameter centers the point at which the model has zero variance. Note: one could just center the training inputs at zero to achieve this, but doing this automatically in the model is convenient.

![download - 2025-01-13T104307 381](https://github.com/user-attachments/assets/010971e2-d5dc-4d40-b85b-5b1e8a445c1d)

