### PR TITLE
Update MVN.expand() to support non-lazy MVN & reuse scale_tril where possible

### DIFF
--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -158,7 +158,7 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
             )
             super(MultivariateNormal, new).__init__(loc=new_loc, scale_tril=new_scale_tril)
             # Set the covar matrix, since it is always available for GPyTorch MVN.
-            new.covariance_matrix = self.covariance_matrix
+            new.covariance_matrix = self.covariance_matrix.expand(batch_size + self.covariance_matrix.shape[-2:])
         return new
 
     def get_base_samples(self, sample_shape: torch.Size = torch.Size()) -> Tensor:

--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -136,6 +136,8 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
         See :py:meth:`torch.distributions.Distribution.expand
         <torch.distributions.distribution.Distribution.expand>`.
         """
+        # NOTE: Pyro may call this method with list[int] instead of torch.Size.
+        batch_size = torch.Size(batch_size)
         new_loc = self.loc.expand(batch_size + self.loc.shape[-1:])
         if self.islazy:
             new_covar = self._covar.expand(batch_size + self._covar.shape[-2:])

--- a/test/distributions/test_multivariate_normal.py
+++ b/test/distributions/test_multivariate_normal.py
@@ -343,8 +343,11 @@ class TestMultivariateNormal(BaseTestCase, unittest.TestCase):
             self.assertEqual(expanded.batch_shape, torch.Size([2]))
             self.assertEqual(expanded.event_shape, mvn.event_shape)
             self.assertTrue(torch.equal(expanded.mean, mean.expand(2, -1)))
+            self.assertEqual(expanded.mean.shape, torch.Size([2, 3]))
             self.assertTrue(torch.allclose(expanded.covariance_matrix, covmat.expand(2, -1, -1)))
+            self.assertEqual(expanded.covariance_matrix.shape, torch.Size([2, 3, 3]))
             self.assertTrue(torch.allclose(expanded.scale_tril, mvn.scale_tril.expand(2, -1, -1)))
+            self.assertEqual(expanded.scale_tril.shape, torch.Size([2, 3, 3]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The previous implementation of `MVN.expand()` would error out when MVN was not lazy (since `self._covar` is not defined) and would discard the `scale_tril`, requiring its re-computation down the line. This PR updates `MVN.expand()` to support both lazy and non-lazy MVN and to re-use `scale_tril` whenever possible.

Test Plan:
Added unittests for `MVN.expand()`.