### PR TITLE
Implement MVN.unsqueeze

### DIFF
--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -158,7 +158,7 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
             )
             super(MultivariateNormal, new).__init__(loc=new_loc, scale_tril=new_scale_tril)
             # Set the covar matrix, since it is always available for GPyTorch MVN.
-            new.covariance_matrix = self.covariance_matrix
+            new.covariance_matrix = self.covariance_matrix.expand(batch_size + self.covariance_matrix.shape[-2:])
         return new
 
     def get_base_samples(self, sample_shape: torch.Size = torch.Size()) -> Tensor:

--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -136,6 +136,8 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
         See :py:meth:`torch.distributions.Distribution.expand
         <torch.distributions.distribution.Distribution.expand>`.
         """
+        # NOTE: Pyro may call this method with list[int] instead of torch.Size.
+        batch_size = torch.Size(batch_size)
         new_loc = self.loc.expand(batch_size + self.loc.shape[-1:])
         if self.islazy:
             new_covar = self._covar.expand(batch_size + self._covar.shape[-2:])

--- a/gpytorch/distributions/multivariate_normal.py
+++ b/gpytorch/distributions/multivariate_normal.py
@@ -170,8 +170,13 @@ class MultivariateNormal(TMultivariateNormal, Distribution):
         If `dim = -1`, then the returned MultivariateNormal will have
         `batch_shape = torch.Size([2, 3, 1])`.
         """
-        # If dim is negative, get the positive equivalent.
+        if dim > len(self.batch_shape) or dim < -len(self.batch_shape) - 1:
+            raise IndexError(
+                "Dimension out of range (expected to be in range of "
+                f"[{-len(self.batch_shape) - 1}, {len(self.batch_shape)}], but got {dim})."
+            )
         if dim < 0:
+            # If dim is negative, get the positive equivalent.
             dim = len(self.batch_shape) + dim + 1
 
         new_loc = self.loc.unsqueeze(dim)

--- a/test/distributions/test_multivariate_normal.py
+++ b/test/distributions/test_multivariate_normal.py
@@ -370,8 +370,20 @@ class TestMultivariateNormal(BaseTestCase, unittest.TestCase):
                 self.assertEqual(new.batch_shape, expected_batch)
                 self.assertEqual(new.event_shape, mvn.event_shape)
                 self.assertTrue(torch.equal(new.mean, mean.unsqueeze(positive_dim)))
+                self.assertEqual(new.mean.shape, expected_batch + torch.Size([3]))
                 self.assertTrue(torch.allclose(new.covariance_matrix, covmat.unsqueeze(positive_dim)))
+                self.assertEqual(new.covariance_matrix.shape, expected_batch + torch.Size([3, 3]))
                 self.assertTrue(torch.allclose(new.scale_tril, mvn.scale_tril.unsqueeze(positive_dim)))
+                self.assertEqual(new.scale_tril.shape, expected_batch + torch.Size([3, 3]))
+
+        # Check for dim validation.
+        with self.assertRaisesRegex(IndexError, "Dimension out of range"):
+            mvn.unsqueeze(3)
+        with self.assertRaisesRegex(IndexError, "Dimension out of range"):
+            mvn.unsqueeze(-4)
+        # Should not raise error up to 2 or -3.
+        mvn.unsqueeze(2)
+        mvn.unsqueeze(-3)
 
 
 if __name__ == "__main__":

--- a/test/distributions/test_multivariate_normal.py
+++ b/test/distributions/test_multivariate_normal.py
@@ -343,8 +343,11 @@ class TestMultivariateNormal(BaseTestCase, unittest.TestCase):
             self.assertEqual(expanded.batch_shape, torch.Size([2]))
             self.assertEqual(expanded.event_shape, mvn.event_shape)
             self.assertTrue(torch.equal(expanded.mean, mean.expand(2, -1)))
+            self.assertEqual(expanded.mean.shape, torch.Size([2, 3]))
             self.assertTrue(torch.allclose(expanded.covariance_matrix, covmat.expand(2, -1, -1)))
+            self.assertEqual(expanded.covariance_matrix.shape, torch.Size([2, 3, 3]))
             self.assertTrue(torch.allclose(expanded.scale_tril, mvn.scale_tril.expand(2, -1, -1)))
+            self.assertEqual(expanded.scale_tril.shape, torch.Size([2, 3, 3]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements an `unsqueeze` method for MVN, that constructs a new MVN with the underlying tensors / linear operators unsqueezed along the given batch dimension. The choice of unsqueezing along the batch dimensions is consistent with the definition of `expand`.

`MVN.expand` allows us to start with `MVN.batch_shape = b2 x b1` and add additional batch dimensions to the left, so that `new_MVN.batch_shape = b3 x b2 x b1`. `unsqueeze`, when combined with `expand` will allow us to add batch dimensions in the middle, so that `new_MVN.batch_shape = b2 x b3 x b1 or b2 x b1 x b3`.

The use case for this is to match MVNs produced by two models of different batch shapes. Assume that `m1.batch_shape = mb2 x mb1` and `m2.batch_shape = mb1`. If we evaluate these two models with `X = xb1 x q x d`, we get `m1(X).batch_shape. = xb1 x mb2 x mb1` and `m2(X) = xb1 x mb1`. By calling `m2(X).unsqueeze(-2).expand(-1, mb2, -1)`, we can match the batch shapes of the two MVNs, allowing them to be combined into a single MTMVN using the `from_independent_mvns` method.