### PR TITLE
Unpin jaxtyping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ readme = open("README.md").read()
 
 torch_min = "2.0"
 install_requires = [
-    "jaxtyping==0.2.19",
+    "jaxtyping",
     "mpmath>=0.19,<=1.3",  # avoid incompatibiltiy with torch+sympy with mpmath 1.4
     "scikit-learn",
     "scipy>=1.6.0",


### PR DESCRIPTION
The required jaxtyping version conflicts with the requirements of other libraries. The code appears to be compatible with newer versions, so attempting to unpin to see if anything breaks.