### PR TITLE
Export "constraints" submodule from package root

### DIFF
--- a/gpytorch/__init__.py
+++ b/gpytorch/__init__.py
@@ -9,6 +9,7 @@ from torch import Tensor
 
 from . import (
     beta_features,
+    constraints,
     distributions,
     kernels,
     lazy,
@@ -286,6 +287,7 @@ except Exception:  # pragma: no cover
 
 __all__ = [
     # Submodules
+    "constraints",
     "distributions",
     "kernels",
     "lazy",


### PR DESCRIPTION
Export "constraints" submodule from package root to help type checkers.

```python
import gpytorch

# this should not trigger any type checker warnings
constraint = gpytorch.constraints.Positive()
```