### PR TITLE
[Docs] Fixes #2569: Incorrect Matern docs

### DIFF
--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -24,9 +24,9 @@ class MaternKernel(Kernel):
 
     where
 
-    * :math:`d = (\mathbf{x_1} - \mathbf{x_2})^\top \Theta^{-2} (\mathbf{x_1} - \mathbf{x_2})`
+    * :math:`d = \sqrt{(\mathbf{x_1} - \mathbf{x_2})^\top \Theta^{-2} (\mathbf{x_1} - \mathbf{x_2})}`
       is the distance between
-      :math:`x_1` and :math:`x_2` scaled by the lengthscale parameter :math:`\Theta`.
+      :math:`\mathbf{x_1}` and :math:`\mathbf{x_2}` scaled by the lengthscale parameter :math:`\Theta`.
     * :math:`\nu` is a smoothness parameter (takes values 1/2, 3/2, or 5/2). Smaller values are less smooth.
     * :math:`K_\nu` is a modified Bessel function.
 


### PR DESCRIPTION
## Problem
The current Matern documentation incorrectly states:
$d = (\mathbf{x}_1 - \mathbf{x}_2)^T \Theta^{-2} (\mathbf{x}_1 - \mathbf{x}_2)$

## Solution
Updated the formula to correctly show:
$d = \sqrt{(\mathbf{x}_1 - \mathbf{x}_2)^T \Theta^{-2} (\mathbf{x}_1 - \mathbf{x}_2)}$

This is consistent with the source code implementation and the docs for [Matern52KernelGrad](https://github.com/cornellius-gp/gpytorch/blob/master/gpytorch/kernels/matern52_kernel_grad.py).

Also made some vector notation bold font for clarity ($x_1$, $x_2$)

## Testing
- Documentation renders correctly
- No functional code changes (documentation only)

Fixes #2569