### PR TITLE
Remove unused eps parameter from relevant kernels

### DIFF
--- a/gpytorch/kernels/cosine_kernel.py
+++ b/gpytorch/kernels/cosine_kernel.py
@@ -35,9 +35,6 @@ class CosineKernel(Kernel):
             Set this if you want to apply a prior to the period length parameter.  Default: `None`
         period_length_constraint (Constraint, optional):
             Set this if you want to apply a constraint to the period length parameter. Default: `Positive`.
-        eps (float):
-            The minimum value that the lengthscale/period length can take
-            (prevents divide by zero errors). Default: `1e-6`.
 
     Attributes:
         period_length (Tensor):

--- a/gpytorch/kernels/keops/matern_kernel.py
+++ b/gpytorch/kernels/keops/matern_kernel.py
@@ -52,8 +52,6 @@ class MaternKernel(KeOpsKernel):
     :param lengthscale_constraint: (Default: `Positive`) Set this if you want
         to apply a constraint to the lengthscale parameter.
     :type lengthscale_constraint: ~gpytorch.constraints.Interval, optional
-    :param eps: (Default: 1e-6) The minimum value that the lengthscale can take (prevents divide by zero errors).
-    :type eps: float, optional
     """
 
     has_lengthscale = True

--- a/gpytorch/kernels/keops/periodic_kernel.py
+++ b/gpytorch/kernels/keops/periodic_kernel.py
@@ -48,8 +48,6 @@ class PeriodicKernel(KeOpsKernel, GPeriodicKernel):
     :param lengthscale_constraint: (Default: `Positive`) Set this if you want
         to apply a constraint to the lengthscale parameter.
     :type lengthscale_constraint: ~gpytorch.constraints.Interval, optional
-    :param eps: (Default: 1e-6) The minimum value that the lengthscale can take (prevents divide by zero errors).
-    :type eps: float, optional
 
     :var torch.Tensor period_length: The period length parameter. Size/shape of parameter depends on the
         ard_num_dims and batch_shape arguments.

--- a/gpytorch/kernels/keops/rbf_kernel.py
+++ b/gpytorch/kernels/keops/rbf_kernel.py
@@ -32,8 +32,6 @@ class RBFKernel(KeOpsKernel):
         lengthscale parameter. (Default: `None`)
     :param lengthscale_constraint: Set this if you want to apply a constraint
         to the lengthscale parameter. (Default: `Positive`.)
-    :param eps: The minimum value that the lengthscale can take (prevents
-        divide by zero errors). (Default: `1e-6`.)
 
     :ivar torch.Tensor lengthscale: The lengthscale parameter. Size/shape of parameter depends on the
         ard_num_dims and batch_shape arguments.

--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -136,8 +136,6 @@ class Kernel(Module):
         lengthscale parameter. (Default: `None`.)
     :param lengthscale_constraint: Set this if you want to apply a constraint
         to the lengthscale parameter. (Default: :class:`~gpytorch.constraints.Positive`.)
-    :param eps: A small positive value added to the lengthscale to prevent
-        divide by zero errors. (Default: `1e-6`.)
 
     :ivar torch.Size batch_shape:
         The (minimum) number of batch dimensions supported by this kernel.
@@ -169,7 +167,6 @@ class Kernel(Module):
         active_dims: Optional[Tuple[int, ...]] = None,
         lengthscale_prior: Optional[Prior] = None,
         lengthscale_constraint: Optional[Interval] = None,
-        eps: float = 1e-6,
         **kwargs,
     ):
         super(Kernel, self).__init__()
@@ -178,8 +175,6 @@ class Kernel(Module):
             active_dims = torch.tensor(active_dims, dtype=torch.long)
         self.register_buffer("active_dims", active_dims)
         self.ard_num_dims = ard_num_dims
-
-        self.eps = eps
 
         param_transform = kwargs.get("param_transform")
 

--- a/gpytorch/kernels/matern52_kernel_grad.py
+++ b/gpytorch/kernels/matern52_kernel_grad.py
@@ -73,8 +73,6 @@ class Matern52KernelGrad(MaternKernel):
         lengthscale parameter. (Default: `None`)
     :param lengthscale_constraint: Set this if you want to apply a constraint
         to the lengthscale parameter. (Default: `Positive`.)
-    :param eps: The minimum value that the lengthscale can take (prevents
-        divide by zero errors). (Default: `1e-6`.)
 
     :ivar torch.Tensor lengthscale: The lengthscale parameter. Size/shape of parameter depends on the
         ard_num_dims and batch_shape arguments.

--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -56,8 +56,6 @@ class MaternKernel(Kernel):
     :param lengthscale_constraint: (Default: `Positive`) Set this if you want
         to apply a constraint to the lengthscale parameter.
     :type lengthscale_constraint: ~gpytorch.constraints.Interval, optional
-    :param eps: (Default: 1e-6) The minimum value that the lengthscale can take (prevents divide by zero errors).
-    :type eps: float, optional
 
     Example:
         >>> x = torch.randn(10, 5)

--- a/gpytorch/kernels/periodic_kernel.py
+++ b/gpytorch/kernels/periodic_kernel.py
@@ -59,8 +59,6 @@ class PeriodicKernel(Kernel):
     :param lengthscale_constraint: (Default: `Positive`) Set this if you want
         to apply a constraint to the lengthscale parameter.
     :type lengthscale_constraint: ~gpytorch.constraints.Interval, optional
-    :param eps: (Default: 1e-6) The minimum value that the lengthscale can take (prevents divide by zero errors).
-    :type eps: float, optional
 
     :var torch.Tensor period_length: The period length parameter. Size/shape of parameter depends on the
         ard_num_dims and batch_shape arguments.

--- a/gpytorch/kernels/piecewise_polynomial_kernel.py
+++ b/gpytorch/kernels/piecewise_polynomial_kernel.py
@@ -70,8 +70,6 @@ class PiecewisePolynomialKernel(Kernel):
     :param lengthscale_constraint: (Default: `Positive`) Set this if you want
         to apply a constraint to the lengthscale parameter.
     :type lengthscale_constraint: ~gpytorch.constraints.Positive, optional
-    :param eps: (Default: 1e-6) The minimum value that the lengthscale can take (prevents divide by zero errors).
-    :type eps: float, optional
 
     .. _Rasmussen and Williams (2006):
         http://www.gaussianprocess.org/gpml/

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -41,8 +41,6 @@ class RBFKernel(Kernel):
         lengthscale parameter. (Default: `None`)
     :param lengthscale_constraint: Set this if you want to apply a constraint
         to the lengthscale parameter. (Default: `Positive`.)
-    :param eps: The minimum value that the lengthscale can take (prevents
-        divide by zero errors). (Default: `1e-6`.)
 
     :ivar torch.Tensor lengthscale: The lengthscale parameter. Size/shape of parameter depends on the
         ard_num_dims and batch_shape arguments.

--- a/gpytorch/kernels/rbf_kernel_grad.py
+++ b/gpytorch/kernels/rbf_kernel_grad.py
@@ -31,8 +31,6 @@ class RBFKernelGrad(RBFKernel):
         lengthscale parameter. (Default: `None`)
     :param lengthscale_constraint: Set this if you want to apply a constraint
         to the lengthscale parameter. (Default: `Positive`.)
-    :param eps: The minimum value that the lengthscale can take (prevents
-        divide by zero errors). (Default: `1e-6`.)
 
     :ivar torch.Tensor lengthscale: The lengthscale parameter. Size/shape of parameter depends on the
         ard_num_dims and batch_shape arguments.

--- a/gpytorch/kernels/rbf_kernel_gradgrad.py
+++ b/gpytorch/kernels/rbf_kernel_gradgrad.py
@@ -31,8 +31,6 @@ class RBFKernelGradGrad(RBFKernel):
         lengthscale parameter. (Default: `None`)
     :param lengthscale_constraint: Set this if you want to apply a constraint
         to the lengthscale parameter. (Default: `Positive`.)
-    :param eps: The minimum value that the lengthscale can take (prevents
-        divide by zero errors). (Default: `1e-6`.)
 
     :ivar torch.Tensor lengthscale: The lengthscale parameter. Size/shape of parameter depends on the
         ard_num_dims and batch_shape arguments.

--- a/gpytorch/kernels/rq_kernel.py
+++ b/gpytorch/kernels/rq_kernel.py
@@ -43,8 +43,6 @@ class RQKernel(Kernel):
         to the lengthscale parameter. (Default: `Positive`.)
     :param alpha_constraint:
         Set this if you want to apply a constraint to the alpha parameter. (Default: `Positive`.)
-    :param eps: The minimum value that the lengthscale can take (prevents
-        divide by zero errors). (Default: `1e-6`.)
 
     :ivar torch.Tensor lengthscale: The lengthscale parameter. Size/shape of parameter depends on the
         ard_num_dims and batch_shape arguments.

--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -35,8 +35,6 @@ class SpectralMixtureKernel(Kernel):
     :param active_dims: Set this if you want to compute the covariance of only
         a few input dimensions. The ints corresponds to the indices of the dimensions. (Default: `None`.)
     :type active_dims: float, optional
-    :param eps: The minimum value that the lengthscale can take (prevents divide by zero errors). (Default: `1e-6`.)
-    :type eps: float, optional
 
     :param mixture_scales_prior: A prior to set on the mixture_scales parameter
     :type mixture_scales_prior: ~gpytorch.priors.Prior, optional


### PR DESCRIPTION
Fixes #2672 by removing `eps` parameter which is no longer used. At some point in the past, this was used to impose a lower bound on `lengthscale`, but such a lower bound is now enforced via `lengthscale_constraint` or similar parameters.

All unit tests still pass when running `python -m unittest`.