### PR TITLE
type hint fixes `Iterable[Kernel]` -> `Kernel`

### DIFF
--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -607,7 +607,7 @@ class AdditiveKernel(Kernel):
     def is_stationary(self) -> bool:
         return all(k.is_stationary for k in self.kernels)
 
-    def __init__(self, *kernels: Iterable[Kernel]):
+    def __init__(self, *kernels: Kernel):
         super(AdditiveKernel, self).__init__()
         self.kernels = ModuleList(kernels)
 
@@ -649,7 +649,7 @@ class ProductKernel(Kernel):
     def is_stationary(self) -> bool:
         return all(k.is_stationary for k in self.kernels)
 
-    def __init__(self, *kernels: Iterable[Kernel]):
+    def __init__(self, *kernels: Kernel):
         super(ProductKernel, self).__init__()
         self.kernels = ModuleList(kernels)
 


### PR DESCRIPTION
This PR fixes #2676, i.e., the type hint errors in the constructors of `AdditiveKernel` and `ProductKernel`.

I did a grep search, and it seems that there are no types mistakenly annotated as `Iterable[Kernel]` anymore. In the future, these type errors would be spotted more easily if we enforce strict type checking.