### PR TITLE
A variational strategy optimized for large batch stochastic training

### DIFF
--- a/gpytorch/variational/__init__.py
+++ b/gpytorch/variational/__init__.py
@@ -12,6 +12,7 @@ from .independent_multitask_variational_strategy import (
     IndependentMultitaskVariationalStrategy,
     MultitaskVariationalStrategy,
 )
+from .large_batch_variational_strategy import LargeBatchVariationalStrategy
 from .lmc_variational_strategy import LMCVariationalStrategy
 from .mean_field_variational_distribution import MeanFieldVariationalDistribution
 from .natural_variational_distribution import _NaturalVariationalDistribution, NaturalVariationalDistribution
@@ -29,6 +30,7 @@ __all__ = [
     "GridInterpolationVariationalStrategy",
     "IndependentMultitaskVariationalStrategy",
     "LMCVariationalStrategy",
+    "LargeBatchVariationalStrategy",
     "MultitaskVariationalStrategy",
     "OrthogonallyDecoupledVariationalStrategy",
     "VariationalStrategy",

--- a/gpytorch/variational/large_batch_variational_strategy.py
+++ b/gpytorch/variational/large_batch_variational_strategy.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+from typing import Optional
+
+import torch
+from linear_operator import to_dense
+from linear_operator.operators import LinearOperator, MatmulLinearOperator, SumLinearOperator
+from torch import Tensor
+
+from gpytorch.variational.variational_strategy import VariationalStrategy
+
+from ..distributions import MultivariateNormal
+from ..settings import _linalg_dtype_cholesky
+from ..utils.errors import CachingError
+from ..utils.memoize import pop_from_cache_ignore_args
+
+
+class LargeBatchVariationalStrategy(VariationalStrategy):
+    r"""A lightweight and performant variational strategy that is optimized for large batch training.
+
+    This class groups the middle term `K_ZZ^{-1/2} (S - I) K_ZZ^{-1/2}` in double precision.
+    """
+
+    def forward(
+        self,
+        x: Tensor,
+        inducing_points: Tensor,
+        inducing_values: Tensor,
+        variational_inducing_covar: Optional[LinearOperator] = None,
+        **kwargs,
+    ) -> MultivariateNormal:
+        # Compute full prior distribution
+        full_inputs = torch.cat([inducing_points, x], dim=-2)
+        full_output = self.model.forward(full_inputs, **kwargs)
+        full_covar = full_output.lazy_covariance_matrix
+
+        # Covariance terms
+        num_induc = inducing_points.size(-2)
+        test_mean = full_output.mean[..., num_induc:]
+        induc_induc_covar = full_covar[..., :num_induc, :num_induc].add_jitter(self.jitter_val)
+        induc_data_covar = full_covar[..., :num_induc, num_induc:].to_dense()
+        data_data_covar = full_covar[..., num_induc:, num_induc:]
+
+        L = self._cholesky_factor(induc_induc_covar)
+        if L.shape != induc_induc_covar.shape:
+            # Aggressive caching can cause nasty shape incompatibilies when evaluating with different batch shapes
+            # TODO: Use a hook fo this
+            try:
+                pop_from_cache_ignore_args(self, "cholesky_factor")
+            except CachingError:
+                pass
+            L = self._cholesky_factor(induc_induc_covar)
+
+        # Need to make `L` dense because linear operators do not support triangular solves with `left=False`
+        L = to_dense(L)
+
+        # Compute the mean of q(f)
+        # k_XZ K_ZZ^{-1/2} (m - K_ZZ^{-1/2} \mu_Z) + \mu_X
+        vec = torch.linalg.solve_triangular(
+            L.mT.type(full_inputs.dtype), inducing_values.unsqueeze(-1), upper=True, left=True
+        )
+        predictive_mean = (induc_data_covar.mT @ vec).squeeze(-1) + test_mean
+
+        # Compute the covariance of q(f)
+        # K_XX + k_XZ K_ZZ^{-1/2} (S - I) K_ZZ^{-1/2} k_ZX
+        middle_term = self.prior_distribution.lazy_covariance_matrix.mul(-1)
+        if variational_inducing_covar is not None:
+            middle_term = to_dense(variational_inducing_covar) + to_dense(middle_term)
+
+        middle_term = middle_term.type(_linalg_dtype_cholesky.value())
+        middle_term = torch.linalg.solve_triangular(L, middle_term, upper=False, left=False)
+        middle_term = torch.linalg.solve_triangular(L.mT, middle_term, upper=True, left=True)
+
+        right_term = middle_term @ induc_data_covar.type(_linalg_dtype_cholesky.value())
+        right_term = right_term.type(full_inputs.dtype)
+
+        predictive_covar = SumLinearOperator(
+            data_data_covar.add_jitter(self.jitter_val),
+            MatmulLinearOperator(induc_data_covar.transpose(-1, -2), right_term),
+        )
+
+        # Return the distribution
+        return MultivariateNormal(predictive_mean, predictive_covar)

--- a/test/variational/test_large_batch_variational_strategy.py
+++ b/test/variational/test_large_batch_variational_strategy.py
@@ -1,0 +1,96 @@
+import unittest
+
+import torch
+
+import gpytorch
+from gpytorch.models.approximate_gp import ApproximateGP
+from gpytorch.test.base_test_case import BaseTestCase
+from gpytorch.variational.cholesky_variational_distribution import CholeskyVariationalDistribution
+from gpytorch.variational.large_batch_variational_strategy import LargeBatchVariationalStrategy
+from gpytorch.variational.variational_strategy import VariationalStrategy
+
+
+class _GPModel(ApproximateGP):
+    def __init__(
+        self,
+        inducing_points,
+        variational_strategy_class: type[VariationalStrategy] = VariationalStrategy,
+        random_initialization: bool = False,
+    ):
+        variational_distribution = CholeskyVariationalDistribution(inducing_points.size(-2))
+        variational_strategy = variational_strategy_class(
+            self, inducing_points, variational_distribution, learn_inducing_locations=True
+        )
+        super().__init__(variational_strategy)
+        self.variational_strategy.variational_params_initialized.fill_(1)
+
+        self.mean_module = gpytorch.means.ConstantMean()
+        self.covar_module = gpytorch.kernels.RBFKernel()
+
+    def forward(self, x):
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
+        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+
+
+class CustomVariationalStrategyMixin:
+    def test_train_mode(self):
+        torch.set_default_dtype(torch.float32)
+
+        inducing_points = torch.rand(2, 2)
+        train_x = torch.rand(5, 2)
+
+        torch.manual_seed(42)
+        model1 = _GPModel(
+            inducing_points=inducing_points.clone(),
+            variational_strategy_class=self.variational_strategy_class,
+        )
+        model1.train()
+        output1 = model1(train_x)
+
+        loss1 = output1.mean.mean() + output1.covariance_matrix.diag().mean()
+        loss1.backward()
+
+        torch.manual_seed(42)
+        model2 = _GPModel(
+            inducing_points=inducing_points.clone(),
+            variational_strategy_class=VariationalStrategy,
+        )
+        model2.train()
+        output2 = model2(train_x)
+
+        loss2 = output2.mean.mean() + output2.covariance_matrix.diag().mean()
+        loss2.backward()
+
+        self.assertAllClose(output1.mean, output2.mean)
+        self.assertAllClose(output1.covariance_matrix.diag(), output2.covariance_matrix.diag())
+
+        self.assertAllClose(
+            model1.mean_module.constant.grad,
+            model2.mean_module.constant.grad,
+        )
+        self.assertAllClose(
+            model1.covar_module.raw_lengthscale.grad,
+            model2.covar_module.raw_lengthscale.grad,
+        )
+        self.assertAllClose(
+            model1.variational_strategy.inducing_points.grad,
+            model2.variational_strategy.inducing_points.grad,
+            atol=1e-5,
+        )
+        self.assertAllClose(
+            model1.variational_strategy._variational_distribution.variational_mean.grad,
+            model2.variational_strategy._variational_distribution.variational_mean.grad,
+            atol=1e-4,
+            rtol=1e-4,
+        )
+        self.assertAllClose(
+            model1.variational_strategy._variational_distribution.chol_variational_covar.grad,
+            model2.variational_strategy._variational_distribution.chol_variational_covar.grad,
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+
+class TestLargeBatchVariationalStrategy(unittest.TestCase, BaseTestCase, CustomVariationalStrategyMixin):
+    variational_strategy_class = LargeBatchVariationalStrategy


### PR DESCRIPTION
This PR is a variational strategy implementation that is optimized for large batch stochastic training on data center GPUs (in particular A100). This yields about 3.81x speed up for large batch training on A100 compared to the current variational strategy implementation.

# What's Changed?
Let `m` be the number of inducing points and `n` be the number of test data points (i.e., the batch size). The complexity of the forward pass is O(m^2 n) assuming `m << n`.

The running time bottleneck is computing the predictive variance, which requires computing
```
k_XZ K_ZZ^{-1/2} (S - I) K_ZZ^{-1/2} k_ZX
```

**GPyTorch.** The current GPyTorch implementation computes it in this way:
```
interp_term = K_ZZ^{-1/2} k_ZX  # O(m^2 n) triangular solve
lazy_tensor = MatmulLinearOperator(
    interp_term.transpose(-2, -1),
    (S - I) @ interp_term,  # TWO O(m^2 n) matrix multiplications!
)
```
In total, there are three O(m^2 n) operations. Note that there are two matrix multiplications in the last line. This is because `S - I` is stored as a `SumLinearOperator` and `S` is a `CholLinearOperator`. The Cholesky factor of `S` invokes two matrix multiplications.

**This PR.** We could save two O(m^2 n) matrix multiplications by grouping the operations in a better way: 
```
middle_term = K_ZZ^{-1/2} @ (S - I) @ K_ZZ^{-1/2}  # O(m^3), store middle_term as a tensor
lazy_tensor = MatmulLinearOperator(k_XZ,  middle_term @ k_ZX)  # a single O(m^2 n) matmul
```
In total, there is only a single O(m^2 n) matrix operations.

The caveat is that the regrouping is not numerically friendly, and so we have to do the computation in double precision. This is not an issue because data center GPUs nowadays have very good FP64 tensor cores. Empirically, we observed that FP64 matmul is just as fast as FP32 matmul on A100.

# Benchmark
We run SVGP training on four large-scale UCI datasets. The results available in https://api.wandb.ai/links/kayween/lw2terwd

The test MAE and test NLL are virtually identical to the current GPyTorch implementation. This PR speeds up SVGP training by 3.81x on houseelectric.