### PR TITLE
Fix relative import in vlarge batch ariatinal strategy tests

### DIFF
--- a/test/variational/test_large_batch_variational_strategy.py
+++ b/test/variational/test_large_batch_variational_strategy.py
@@ -7,7 +7,7 @@ from gpytorch.test.base_test_case import BaseTestCase
 from gpytorch.variational.large_batch_variational_strategy import LargeBatchVariationalStrategy, QuadFormDiagonal
 from gpytorch.variational.variational_strategy import VariationalStrategy
 
-from test.variational.test_variational_strategy import TestVariationalGP
+from .test_variational_strategy import TestVariationalGP
 
 
 class TestQuadFormDiagonal(BaseTestCase, unittest.TestCase):


### PR DESCRIPTION
This breaks the test in some settings since `test` is not a proper package so the import fails. This uses a relative import instead.