### PR TITLE
Buildthedocs fail

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ build:
       - pip install "numpy<2"  # Numpy 2.0 is not fully supported until PyTorch 2.2
       - pip install torch==2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     pre_build:
+      - pip install "setuptools<78"  # setuptools 78+ removed pkg_resources, which m2r2 needs
       - python -m setuptools_scm  # Get correct version number
 
 # Build documentation in the docs/ directory with Sphinx


### PR DESCRIPTION
Pin setuptools<78 in RTD config to fix docs build. m2r2 imports pkg_resources, which was removed in setuptools 78+. RTD auto-upgrades to the latest setuptools, breaking the build.