### PR TITLE
Deprecating `length_safe_zip` in favor of `zip(..., strict=True)`

### DIFF
--- a/gpytorch/kernels/lcm_kernel.py
+++ b/gpytorch/kernels/lcm_kernel.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 from torch.nn import ModuleList
 
 from ..priors import Prior
-from ..utils.generic import length_safe_zip
 from .kernel import Kernel
 from .multitask_kernel import MultitaskKernel
 
@@ -50,7 +49,7 @@ class LCMKernel(Kernel):
         self.covar_module_list = ModuleList(
             [
                 MultitaskKernel(base_kernel, num_tasks=num_tasks, rank=r, task_covar_prior=task_covar_prior)
-                for base_kernel, r in length_safe_zip(base_kernels, rank)
+                for base_kernel, r in zip(base_kernels, rank, strict=True)
             ]
         )
 

--- a/gpytorch/likelihoods/likelihood_list.py
+++ b/gpytorch/likelihoods/likelihood_list.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from torch.nn import ModuleList
 
 from gpytorch.likelihoods import Likelihood
-from gpytorch.utils.generic import length_safe_zip
 
 
 def _get_tuple_args_(*args):
@@ -22,7 +21,7 @@ class LikelihoodList(Likelihood):
     def expected_log_prob(self, *args, **kwargs):
         return [
             likelihood.expected_log_prob(*args_, **kwargs)
-            for likelihood, args_ in length_safe_zip(self.likelihoods, _get_tuple_args_(*args))
+            for likelihood, args_ in zip(self.likelihoods, _get_tuple_args_(*args), strict=True)
         ]
 
     def forward(self, *args, **kwargs):
@@ -31,18 +30,18 @@ class LikelihoodList(Likelihood):
             # if noise kwarg is passed, assume it's an iterable of noise tensors
             return [
                 likelihood.forward(*args_, {**kwargs, "noise": noise_})
-                for likelihood, args_, noise_ in length_safe_zip(self.likelihoods, _get_tuple_args_(*args), noise)
+                for likelihood, args_, noise_ in zip(self.likelihoods, _get_tuple_args_(*args), noise, strict=True)
             ]
         else:
             return [
                 likelihood.forward(*args_, **kwargs)
-                for likelihood, args_ in length_safe_zip(self.likelihoods, _get_tuple_args_(*args))
+                for likelihood, args_ in zip(self.likelihoods, _get_tuple_args_(*args), strict=True)
             ]
 
     def pyro_sample_output(self, *args, **kwargs):
         return [
             likelihood.pyro_sample_output(*args_, **kwargs)
-            for likelihood, args_ in length_safe_zip(self.likelihoods, _get_tuple_args_(*args))
+            for likelihood, args_ in zip(self.likelihoods, _get_tuple_args_(*args), strict=True)
         ]
 
     def __call__(self, *args, **kwargs):
@@ -51,10 +50,10 @@ class LikelihoodList(Likelihood):
             # if noise kwarg is passed, assume it's an iterable of noise tensors
             return [
                 likelihood(*args_, {**kwargs, "noise": noise_})
-                for likelihood, args_, noise_ in length_safe_zip(self.likelihoods, _get_tuple_args_(*args), noise)
+                for likelihood, args_, noise_ in zip(self.likelihoods, _get_tuple_args_(*args), noise, strict=True)
             ]
         else:
             return [
                 likelihood(*args_, **kwargs)
-                for likelihood, args_ in length_safe_zip(self.likelihoods, _get_tuple_args_(*args))
+                for likelihood, args_ in zip(self.likelihoods, _get_tuple_args_(*args), strict=True)
             ]

--- a/gpytorch/mlls/sum_marginal_log_likelihood.py
+++ b/gpytorch/mlls/sum_marginal_log_likelihood.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from torch.nn import ModuleList
 
 from gpytorch.mlls import ExactMarginalLogLikelihood, MarginalLogLikelihood
-from gpytorch.utils.generic import length_safe_zip
 
 
 class SumMarginalLogLikelihood(MarginalLogLikelihood):
@@ -31,10 +30,10 @@ class SumMarginalLogLikelihood(MarginalLogLikelihood):
                 (e.g. parameters in case of heteroskedastic likelihoods)
         """
         if len(params) == 0:
-            sum_mll = sum(mll(output, target) for mll, output, target in length_safe_zip(self.mlls, outputs, targets))
+            sum_mll = sum(mll(output, target) for mll, output, target in zip(self.mlls, outputs, targets, strict=True))
         else:
             sum_mll = sum(
                 mll(output, target, *iparams)
-                for mll, output, target, iparams in length_safe_zip(self.mlls, outputs, targets, params)
+                for mll, output, target, iparams in zip(self.mlls, outputs, targets, params, strict=True)
             )
         return sum_mll.div_(len(self.mlls))

--- a/gpytorch/models/model_list.py
+++ b/gpytorch/models/model_list.py
@@ -7,7 +7,6 @@ from torch.nn import ModuleList
 
 from gpytorch.likelihoods import LikelihoodList
 from gpytorch.models import GP
-from gpytorch.utils.generic import length_safe_zip
 
 
 class AbstractModelList(GP, ABC):
@@ -39,7 +38,7 @@ class IndependentModelList(AbstractModelList):
 
     def forward(self, *args, **kwargs):
         return [
-            model.forward(*args_, **kwargs) for model, args_ in length_safe_zip(self.models, _get_tensor_args(*args))
+            model.forward(*args_, **kwargs) for model, args_ in zip(self.models, _get_tensor_args(*args), strict=True)
         ]
 
     def get_fantasy_model(self, inputs, targets, **kwargs):
@@ -66,18 +65,19 @@ class IndependentModelList(AbstractModelList):
 
         fantasy_models = [
             model.get_fantasy_model(*inputs_, *targets_, **kwargs_)
-            for model, inputs_, targets_, kwargs_ in length_safe_zip(
+            for model, inputs_, targets_, kwargs_ in zip(
                 self.models,
                 _get_tensor_args(*inputs),
                 _get_tensor_args(*targets),
                 kwargs,
+                strict=True,
             )
         ]
         return self.__class__(*fantasy_models)
 
     def __call__(self, *args, **kwargs):
         return [
-            model.__call__(*args_, **kwargs) for model, args_ in length_safe_zip(self.models, _get_tensor_args(*args))
+            model.__call__(*args_, **kwargs) for model, args_ in zip(self.models, _get_tensor_args(*args), strict=True)
         ]
 
     @property

--- a/gpytorch/utils/generic.py
+++ b/gpytorch/utils/generic.py
@@ -2,18 +2,6 @@
 
 from __future__ import annotations
 
-
-def length_safe_zip(*args):
-    """Python's `zip(...)` with checks to ensure the arguments have
-    the same number of elements.
-
-    NOTE: This converts all args that do not define "__len__" to a list.
-    """
-    args = [a if hasattr(a, "__len__") else list(a) for a in args]
-    if len({len(a) for a in args}) > 1:
-        raise ValueError(
-            "Expected the lengths of all arguments to be equal. Got lengths "
-            f"{[len(a) for a in args]} for args {args}. Did you pass in "
-            "fewer inputs than expected?"
-        )
-    return zip(*args)
+# This module previously contained the `length_safe_zip` function.
+# That function has been removed in favor of using Python's built-in
+# `zip(..., strict=True)` which provides the same length-checking behavior.


### PR DESCRIPTION
`zip` supports `strict` since Python 3.10, which appears to be GPyTorch's version floor, so we can start relying on the core implementation, simplifying the implementation.