### PR TITLE
use the qualified name as the cache key

### DIFF
--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -55,7 +55,7 @@ def _cached(method=None, name=None):
 
     @functools.wraps(method)
     def g(self, *args, **kwargs):
-        cache_name = name if name is not None else method
+        cache_name = name if name is not None else method.__qualname__
         kwargs_pkl = pickle.dumps(kwargs)
         if not _is_in_cache(self, cache_name, *args, kwargs_pkl=kwargs_pkl):
             return _add_to_cache(self, cache_name, method(self, *args, **kwargs), *args, kwargs_pkl=kwargs_pkl)
@@ -73,7 +73,7 @@ def _cached_ignore_args(method=None, name=None):
 
     @functools.wraps(method)
     def g(self, *args, **kwargs):
-        cache_name = name if name is not None else method
+        cache_name = name if name is not None else method.__qualname__
         if not _is_in_cache_ignore_args(self, cache_name):
             return _add_to_cache_ignore_args(self, cache_name, method(self, *args, **kwargs))
         return _get_from_cache_ignore_args(self, cache_name)


### PR DESCRIPTION
This is a mirror of https://github.com/cornellius-gp/linear_operator/pull/124.

Some GPyTorch unit tests are broken due to that commit (specifically tests related to `LazyEvaluatedKernelTensor`). This PR  makes similar changes on the GPyTorch side so that GPyTorch is compatible with the latest linear operator.

(On a related note, `gpytorch/utils/memoize.py` seems to be a literal copy of `linear_operators/utils/memoize.py`.)