### PR TITLE
Change Python 3.9 to 3.10

### DIFF
--- a/examples/08_Advanced_Usage/SVGP_Model_Updating.ipynb
+++ b/examples/08_Advanced_Usage/SVGP_Model_Updating.ipynb
@@ -468,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I‘m Not quite sure about this fix because I havent tested it out whether this even works with 3.10, but 3.9 (nevertheless) is not even supported anymore so this example would Not make any Sense any more, so maybe a. Delete it b. Hope that it works in this way or c. Replace it with another example

but this seems to be the quickest (and hopefully correct) fix, hoping that it works (because currently it was definitely not making any Sense if we deny 3.9 in General)

please don’t judge my writing correctness, I just quickly Typed this on my phone