### PR TITLE
Ensure root decomposition exists before `add_low_rank` in WISKI

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -531,6 +531,9 @@ class InterpolatedPredictionStrategy(DefaultPredictionStrategy):
         fant_noise = fant_likelihood.noise_covar(fant_wmat.transpose(-1, -2) if len(fant_wmat.shape) > 2 else fant_wmat)
         fant_root_vector = fant_noise.sqrt_inv_matmul(fant_wmat.transpose(-1, -2)).transpose(-1, -2)
 
+        # Ensure root decomposition exists before add_low_rank for efficient Woodbury updates.
+        # This computes the root once (O(n³)), then subsequent fantasy updates use O(nk²) rank updates.
+        _ = self.interp_inner_prod.root_decomposition(method="cholesky")
         new_wmat = self.interp_inner_prod.add_low_rank(fant_root_vector.to_dense())
         mean_diff = (targets - fant_mean).unsqueeze(-1)
         new_interp_response_cache = self.interp_response_cache + fant_wmat.matmul(fant_noise.solve(mean_diff))


### PR DESCRIPTION
Add explicit root_decomposition(method='cholesky') call before add_low_rank in the WISKI prediction strategy. This ensures roots exist for efficient Woodbury updates, since add_low_rank now only updates roots when cached roots already exist (see corresponding linear_operator fix).

This computes the root once (O(n³)), then subsequent fantasy updates use O(nk²) rank updates via the Woodbury formula. This might not be necessary to maintain the same asymptotic scaling, but I am adding this to maintain the same eager behavior as before https://github.com/cornellius-gp/linear_operator/pull/126.