### PR TITLE
Fix memory leak in DefaultPredictionStrategy cache hooks (#2631)

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import functools
 import string
 import warnings
 

--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -25,7 +25,7 @@ from torch import Tensor
 from .. import settings
 from ..distributions import MultitaskMultivariateNormal
 from ..lazy import LazyEvaluatedKernelTensor
-from ..utils.memoize import add_to_cache, cached, clear_cache_hook, pop_from_cache
+from ..utils.memoize import add_to_cache, cached, pop_from_cache, register_cache_clear_hook
 
 
 def prediction_strategy(train_inputs, train_prior_dist, train_labels, likelihood):
@@ -108,10 +108,7 @@ class DefaultPredictionStrategy:
         if settings.detach_test_caches.on():
             res = res.detach()
 
-        if res.grad_fn is not None:
-            wrapper = functools.partial(clear_cache_hook, self)
-            functools.update_wrapper(wrapper, clear_cache_hook)
-            res.grad_fn.register_hook(wrapper)
+        register_cache_clear_hook(res, self)
 
         return res
 
@@ -313,10 +310,7 @@ class DefaultPredictionStrategy:
         if settings.detach_test_caches.on():
             mean_cache = mean_cache.detach()
 
-        if mean_cache.grad_fn is not None:
-            wrapper = functools.partial(clear_cache_hook, self)
-            functools.update_wrapper(wrapper, clear_cache_hook)
-            mean_cache.grad_fn.register_hook(wrapper)
+        register_cache_clear_hook(mean_cache, self)
 
         return mean_cache
 

--- a/gpytorch/utils/memoize.py
+++ b/gpytorch/utils/memoize.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import pickle
+import weakref
 
 from .errors import CachingError
 
@@ -44,6 +45,24 @@ def pop_from_cache_ignore_args(obj, name):
 
 def clear_cache_hook(module, *args, **kwargs):
     module._memoize_cache = {}
+
+
+def register_cache_clear_hook(tsr, module):
+    """Register a backward hook on tsr's grad_fn that clears module's cache.
+
+    Uses a weak reference to module to avoid creating an uncollectable
+    reference cycle through the C++ grad_fn object (which Python's cycle
+    GC cannot see through).
+    """
+    if tsr.grad_fn is not None:
+        weak_module = weakref.ref(module)
+
+        def hook(*args, **kwargs):
+            obj = weak_module()
+            if obj is not None:
+                obj._memoize_cache = {}
+
+        tsr.grad_fn.register_hook(hook)
 
 
 def _cached(method=None, name=None):

--- a/gpytorch/variational/_variational_strategy.py
+++ b/gpytorch/variational/_variational_strategy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import functools
 from abc import ABC, abstractproperty
 from copy import deepcopy
 

--- a/gpytorch/variational/_variational_strategy.py
+++ b/gpytorch/variational/_variational_strategy.py
@@ -18,7 +18,7 @@ from ..means import Mean
 from ..models import ApproximateGP, ExactGP
 from ..models.exact_prediction_strategies import DefaultPredictionStrategy
 from ..module import Module
-from ..utils.memoize import add_to_cache, cached, clear_cache_hook
+from ..utils.memoize import add_to_cache, cached, clear_cache_hook, register_cache_clear_hook
 from . import _VariationalDistribution
 
 
@@ -42,10 +42,7 @@ class _BaseExactGP(ExactGP):
 
 
 def _add_cache_hook(tsr: Tensor, pred_strat: DefaultPredictionStrategy) -> Tensor:
-    if tsr.grad_fn is not None:
-        wrapper = functools.partial(clear_cache_hook, pred_strat)
-        functools.update_wrapper(wrapper, clear_cache_hook)
-        tsr.grad_fn.register_hook(wrapper)
+    register_cache_clear_hook(tsr, pred_strat)
     return tsr
 
 


### PR DESCRIPTION
Fixes #2631 and https://github.com/meta-pytorch/botorch/issues/2728

Root cause
----------
When `detach_test_caches` is False (as used by BoTorch via `propagate_grads(True)`), the `_mean_cache` and
`_exact_predictive_covar_inv_quad_form_cache` properties register a `clear_cache_hook` on the cached tensor's `grad_fn`:

    wrapper = functools.partial(clear_cache_hook, self)
    mean_cache.grad_fn.register_hook(wrapper)

This creates a reference cycle:

    prediction_strategy -> _memoize_cache -> cached tensor
        -> grad_fn (C++ object) -> hook closure -> prediction_strategy

Because PyTorch's `grad_fn` is a C++ object, Python's cycle garbage collector cannot traverse the C++/Python boundary to detect the cycle. The entire chain becomes uncollectable. For fantasy models, the cached tensor's computation graph holds references back to the parent model's caches, so each iteration adds another uncollectable chain, causing memory to grow indefinitely until OOM.

Fix
---
Added `register_cache_clear_hook(tsr, module)` to `gpytorch/utils/memoize.py`. This helper uses `weakref.ref(module)` when registering the backward hook on `tsr.grad_fn`, breaking the reference cycle. When no external strong references to the prediction strategy remain, it and its caches are garbage-collected normally, and the hook becomes a no-op.

Updated all three call sites to use the new helper:
- `DefaultPredictionStrategy._exact_predictive_covar_inv_quad_form_cache`
- `DefaultPredictionStrategy._mean_cache`
- `_variational_strategy._add_cache_hook`

Validation (ran manually)
----------
Repro script (200 iterations of fantasy model creation + evaluation with `detach_test_caches(False)`):

```python
import tracemalloc

import torch
from gpytorch import settings as gpt_settings
from gpytorch.distributions import MultivariateNormal
from gpytorch.kernels import RBFKernel
from gpytorch.likelihoods import GaussianLikelihood
from gpytorch.means import ConstantMean
from gpytorch.models import ExactGP

d = 10
mc_points = torch.rand(32, d, dtype=torch.double)


class SimpleGP(ExactGP):
    def __init__(self, train_inputs, train_targets):
        super().__init__(train_inputs, train_targets, GaussianLikelihood())
        self.mean_module = ConstantMean()
        self.covar_module = RBFKernel()

    def forward(self, x):
        mean_x = self.mean_module(x)
        covar_x = self.covar_module(x)
        return MultivariateNormal(mean_x, covar_x)


gp = SimpleGP(
    train_inputs=torch.rand(256, d, dtype=torch.double),
    train_targets=torch.rand(256, dtype=torch.double),
).eval()
gp(torch.rand(5, d, dtype=torch.double))  # set the caches before fantasize.

X = torch.rand(128, 5, d, dtype=torch.double, requires_grad=False)
Y = torch.rand(128, 5, dtype=torch.double, requires_grad=False)

tracemalloc.start()

for i in range(1000):
    fantasy_model = gp.get_fantasy_model(inputs=X, targets=Y).eval()
    with gpt_settings.detach_test_caches(False):
        fantasy_model(mc_points)
    if (i + 1) % 100 == 0:
        current, peak = tracemalloc.get_traced_memory()
        print(f"Iter {i + 1}: current={current / 1024 / 1024:.1f}MB, peak={peak / 1024 / 1024:.1f}MB")
```

Before: OOM with 48GB RAM.
```bash
(botorch) saitcakmak@saitcakmak-mac gpytorch % git branch
  fix-memory-leak-mean-cache
* main
(botorch) saitcakmak@saitcakmak-mac gpytorch % python test.py
Iter 100: current=3.6MB, peak=3.6MB
Iter 200: current=6.7MB, peak=6.8MB
zsh: killed     python test.py
```

After:
```bash
(botorch) saitcakmak@saitcakmak-mac gpytorch % git branch
* fix-memory-leak-mean-cache
  main
(botorch) saitcakmak@saitcakmak-mac gpytorch % python test.py
Iter 100: current=1.1MB, peak=1.8MB
Iter 200: current=1.4MB, peak=2.0MB
Iter 300: current=1.6MB, peak=2.3MB
Iter 400: current=0.4MB, peak=2.6MB
Iter 500: current=0.9MB, peak=2.6MB
Iter 600: current=1.3MB, peak=2.6MB
Iter 700: current=1.5MB, peak=2.6MB
Iter 800: current=2.6MB, peak=2.6MB
Iter 900: current=2.8MB, peak=2.8MB
Iter 1000: current=3.0MB, peak=3.1MB
```