### PR TITLE
Add OrthogonalRandomFeaturesKernel

### DIFF
--- a/docs/source/kernels.rst
+++ b/docs/source/kernels.rst
@@ -221,3 +221,9 @@ Kernels for Scalable GP Regression Methods
 
 .. autoclass:: RFFKernel
    :members:
+
+:hidden:`OrthogonalRandomFeaturesKernel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: OrthogonalRandomFeaturesKernel
+   :members:

--- a/gpytorch/kernels/__init__.py
+++ b/gpytorch/kernels/__init__.py
@@ -23,6 +23,7 @@ from .matern_kernel import MaternKernel
 from .multi_device_kernel import MultiDeviceKernel
 from .multitask_kernel import MultitaskKernel
 from .newton_girard_additive_kernel import NewtonGirardAdditiveKernel
+from .orf_kernel import OrthogonalRandomFeaturesKernel
 from .periodic_kernel import PeriodicKernel
 from .piecewise_polynomial_kernel import PiecewisePolynomialKernel
 from .polynomial_kernel import PolynomialKernel
@@ -65,6 +66,7 @@ __all__ = [
     "PolynomialKernelGrad",
     "ProductKernel",
     "ProductStructureKernel",
+    "OrthogonalRandomFeaturesKernel",
     "RBFKernel",
     "RFFKernel",
     "RBFKernelGrad",

--- a/gpytorch/kernels/orf_kernel.py
+++ b/gpytorch/kernels/orf_kernel.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import math
+
+import torch
+from torch import Tensor
+
+from .rff_kernel import RFFKernel
+
+
+class OrthogonalRandomFeaturesKernel(RFFKernel):
+    r"""
+    Orthogonal Random Features (ORF) kernel approximation.
+
+    Improves upon :class:`RFFKernel` by using orthogonal random projections
+    instead of i.i.d. Gaussian samples. The weight matrix is constructed as
+    a block-diagonal of random orthogonal matrices scaled to preserve the
+    spectral norm of the standard Gaussian.
+
+    This reduces the variance of the kernel approximation while maintaining
+    the same computational complexity :math:`O(nD)`. ORF strictly dominates
+    standard RFF in mean squared error of the kernel approximation.
+
+    .. note::
+        The weight matrix is re-sampled every time :meth:`_init_weights` is called
+        (e.g. at the first forward pass if ``num_dims`` was not provided up front).
+
+    :param num_samples: Number of random features :math:`D`.
+    :type num_samples: int
+    :param num_dims: (Default ``None``.) Dimensionality of the data space :math:`d`.
+        If unspecified, it will be inferred the first time :meth:`forward` is called.
+    :type num_dims: int, optional
+
+    Example:
+        >>> kernel = gpytorch.kernels.OrthogonalRandomFeaturesKernel(num_samples=512)
+        >>> x = torch.randn(100, 5)
+        >>> covar = kernel(x, x).to_dense()
+
+    References:
+        - Yu et al., *Orthogonal Random Features*, NeurIPS 2016.
+        - Choromanski et al., *The Geometry of Random Features*, AISTATS 2018.
+    """
+
+    def _get_weight_matrix(self, d: int, D: int) -> Tensor:
+        """Build a block-orthogonal weight matrix of shape ``(D, d)``.
+
+        Each block of ``d`` frequency vectors shares an orthogonal direction basis
+        (Haar-distributed via QR) but has independent chi(d)-distributed norms,
+        so the marginal distribution of each frequency matches ``N(0, I_d)``.
+        """
+        blocks = math.ceil(D / d)
+        Ws = []
+        for _ in range(blocks):
+            G = torch.randn(d, d, dtype=self.raw_lengthscale.dtype, device=self.raw_lengthscale.device)
+            Q, _ = torch.linalg.qr(G)
+            # chi(d) norms: norms of independent d-dim Gaussian vectors
+            norms = torch.randn(d, d, dtype=self.raw_lengthscale.dtype, device=self.raw_lengthscale.device).norm(dim=1)
+            Ws.append(norms.unsqueeze(1) * Q)  # scale each row of Q by its chi(d) norm
+        W = torch.cat(Ws, dim=0)[:D]  # (D, d)
+        return W
+
+    def _init_weights(
+        self,
+        num_dims: int | None = None,
+        num_samples: int | None = None,
+        randn_weights: Tensor | None = None,
+    ) -> None:
+        if randn_weights is None and num_dims is not None and num_samples is not None:
+            d, D = num_dims, num_samples
+            batch_Ws = []
+            batch_shape = self._batch_shape if self._batch_shape else torch.Size([])
+            n_batch = int(torch.tensor(list(batch_shape) or [1]).prod().item())
+            for _ in range(n_batch):
+                batch_Ws.append(self._get_weight_matrix(d, D))
+            W = torch.stack(batch_Ws).view(*batch_shape, D, d) if batch_shape else batch_Ws[0]
+            # RFFKernel stores weights transposed as (batch..., d, D)
+            randn_weights = W.transpose(-1, -2)
+        super()._init_weights(num_dims=num_dims, num_samples=num_samples, randn_weights=randn_weights)

--- a/test/kernels/test_orf_kernel.py
+++ b/test/kernels/test_orf_kernel.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+
+from gpytorch.kernels import OrthogonalRandomFeaturesKernel
+from gpytorch.test.base_kernel_test_case import BaseKernelTestCase
+
+
+class TestOrthogonalRandomFeaturesKernel(unittest.TestCase, BaseKernelTestCase):
+    def create_kernel_no_ard(self, **kwargs):
+        return OrthogonalRandomFeaturesKernel(num_samples=5, **kwargs)
+
+    def create_kernel_ard(self, num_dims, **kwargs):
+        return OrthogonalRandomFeaturesKernel(num_dims=num_dims, num_samples=7, ard_num_dims=num_dims, **kwargs)
+
+    # Override active_dims tests: the base class creates two separate kernels with
+    # independent random weights, which gives different outputs for stochastic kernels.
+    # We share weights explicitly, consistent with TestRFFKernel.
+
+    def test_active_dims_list(self):
+        kernel = self.create_kernel_no_ard(active_dims=[0, 2, 4, 6])
+        x = self.create_data_no_batch()
+        covar_mat = kernel(x).evaluate_kernel().to_dense()
+        randn_weights = kernel.randn_weights
+        kernel_basic = self.create_kernel_no_ard()
+        kernel_basic._init_weights(randn_weights=randn_weights)
+        covar_mat_actual = kernel_basic(x[:, [0, 2, 4, 6]]).evaluate_kernel().to_dense()
+        self.assertLess(torch.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(), 1e-4)
+
+    def test_active_dims_range(self):
+        active_dims = list(range(3, 9))
+        kernel = self.create_kernel_no_ard(active_dims=active_dims)
+        x = self.create_data_no_batch()
+        covar_mat = kernel(x).evaluate_kernel().to_dense()
+        randn_weights = kernel.randn_weights
+        kernel_basic = self.create_kernel_no_ard()
+        kernel_basic._init_weights(randn_weights=randn_weights)
+        covar_mat_actual = kernel_basic(x[:, active_dims]).evaluate_kernel().to_dense()
+        self.assertLess(torch.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(), 1e-4)
+
+    def test_weight_matrix_directions_are_orthogonal(self):
+        """Within each d×d block, frequency directions (normalised rows) should be orthogonal."""
+        torch.manual_seed(1)
+        kernel = OrthogonalRandomFeaturesKernel(num_samples=6)
+        d, D = 3, 6
+        kernel._init_weights(num_dims=d, num_samples=D)
+        # randn_weights shape: (d, D) -- transpose to (D, d)
+        W = kernel.randn_weights.transpose(-1, -2)  # (D, d)
+        for i in range(D // d):
+            block = W[i * d : (i + 1) * d]  # (d, d)
+            # Normalize each row to get unit directions
+            unit_block = block / block.norm(dim=1, keepdim=True)
+            gram = unit_block @ unit_block.T  # should be close to I_d
+            self.assertLess(torch.norm(gram - torch.eye(d)).item(), 1e-4)
+
+    def test_output_shape(self):
+        """Kernel matrix should have the correct shape."""
+        kernel = OrthogonalRandomFeaturesKernel(num_samples=16)
+        x = torch.randn(10, 4)
+        out = kernel(x, x).to_dense()
+        self.assertEqual(out.shape, torch.Size([10, 10]))
+
+    def test_output_is_symmetric(self):
+        """K(x, x) should be symmetric."""
+        torch.manual_seed(0)
+        kernel = OrthogonalRandomFeaturesKernel(num_samples=32)
+        x = torch.randn(8, 3)
+        K = kernel(x, x).to_dense()
+        self.assertLess(torch.norm(K - K.T).item(), 1e-5)
+
+    def test_diagonal_is_one(self):
+        """With lengthscale=1 the diagonal should equal 1 (unbiased RBF approximation)."""
+        torch.manual_seed(42)
+        kernel = OrthogonalRandomFeaturesKernel(num_samples=128)
+        kernel.initialize(lengthscale=1.0)
+        x = torch.randn(20, 4)
+        K = kernel(x, x).to_dense()
+        diag = K.diagonal()
+        # Each z(x)^T z(x) = sum(cos^2 + sin^2) / D = 1 exactly
+        self.assertLess(torch.norm(diag - 1.0).item(), 1e-5)
+
+    def test_approximation_quality(self):
+        """With enough features, ORF should closely approximate the RBF kernel."""
+        torch.manual_seed(0)
+        n, d, D = 15, 4, 1024
+        x = torch.randn(n, d)
+
+        kernel = OrthogonalRandomFeaturesKernel(num_samples=D)
+        kernel.initialize(lengthscale=1.0)
+
+        dists = torch.cdist(x, x).pow(2)
+        K_true = torch.exp(-0.5 * dists)
+        K_orf = kernel(x, x).to_dense()
+
+        rel_error = (K_orf - K_true).norm() / K_true.norm()
+        self.assertLess(rel_error.item(), 0.05, f"Relative approximation error {rel_error:.4f} > 0.05")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `OrthogonalRandomFeaturesKernel` - a drop-in replacement for `RFFKernel`
that uses block-orthogonal random projections instead of i.i.d. Gaussian samples.

ORF strictly dominates standard RFF in mean squared error of kernel approximation
(Choromanski et al., 2017) while maintaining the same computational complexity O(nD)
and the same interface.

## Usage

```python
# Before
kernel = gpytorch.kernels.RFFKernel(num_samples=512)

# After — identical interface, better approximation
kernel = gpytorch.kernels.OrthogonalRandomFeaturesKernel(num_samples=512)
```

## Implementation details

Each block of `d` frequency vectors shares a Haar-distributed orthogonal basis (via QR
decomposition) but has independent chi(d)-distributed norms, so the marginal distribution
of each frequency matches N(0, I_d) — preserving the unbiasedness of the RBF approximation.

## Changes
- `gpytorch/kernels/orf_kernel.py` — new kernel
- `gpytorch/kernels/__init__.py` — export
- `test/kernels/test_orf_kernel.py` — 18 tests (BaseKernelTestCase + ORF-specific)
- `docs/source/kernels.rst` — documentation entry

## References
- Yu et al., *Orthogonal Random Features*, NeurIPS 2016
- Choromanski et al., *The Geometry of Random Features*, AISTATS 2018