### PR TITLE
fix(variational): clear eval cholesky caches after backward

### DIFF
--- a/gpytorch/variational/_variational_strategy.py
+++ b/gpytorch/variational/_variational_strategy.py
@@ -16,7 +16,6 @@ from ..kernels import Kernel
 from ..likelihoods import GaussianLikelihood
 from ..means import Mean
 from ..models import ApproximateGP, ExactGP
-from ..models.exact_prediction_strategies import DefaultPredictionStrategy
 from ..module import Module
 from ..utils.memoize import add_to_cache, cached, clear_cache_hook
 from . import _VariationalDistribution
@@ -41,9 +40,17 @@ class _BaseExactGP(ExactGP):
         return MultivariateNormal(mean, covar)
 
 
-def _add_cache_hook(tsr: Tensor, pred_strat: DefaultPredictionStrategy) -> Tensor:
+def _add_cache_hook(tsr: Tensor, module: Module) -> Tensor:
+    r"""Clear a module's caches once autograd has consumed a cached tensor.
+
+    Several inference-time caches may retain references to an old autograd graph. Registering this hook ensures that
+    those caches are dropped after backward so the next forward pass rebuilds them from the current graph.
+    """
+    def _clear_module_cache(*args, **kwargs) -> None:
+        module._clear_cache()
+
     if tsr.grad_fn is not None:
-        wrapper = functools.partial(clear_cache_hook, pred_strat)
+        wrapper = functools.partial(_clear_module_cache)
         functools.update_wrapper(wrapper, clear_cache_hook)
         tsr.grad_fn.register_hook(wrapper)
     return tsr

--- a/gpytorch/variational/_variational_strategy.py
+++ b/gpytorch/variational/_variational_strategy.py
@@ -46,6 +46,7 @@ def _add_cache_hook(tsr: Tensor, module: Module) -> Tensor:
     Several inference-time caches may retain references to an old autograd graph. Registering this hook ensures that
     those caches are dropped after backward so the next forward pass rebuilds them from the current graph.
     """
+
     def _clear_module_cache(*args, **kwargs) -> None:
         module._clear_cache()
 

--- a/gpytorch/variational/large_batch_variational_strategy.py
+++ b/gpytorch/variational/large_batch_variational_strategy.py
@@ -5,6 +5,7 @@ import torch
 from linear_operator.operators import DiagLinearOperator, LinearOperator, MatmulLinearOperator
 from torch import Tensor
 
+from gpytorch.variational._variational_strategy import _add_cache_hook
 from gpytorch.variational.variational_strategy import VariationalStrategy
 
 
@@ -94,9 +95,7 @@ class LargeBatchVariationalStrategy(VariationalStrategy):
                 chol.mT, inducing_values.unsqueeze(-1), upper=True, left=True
             )
             if not self.training:
-                if inv_chol_t_inducing_values.grad_fn is not None:
-                    inv_chol_t_inducing_values.grad_fn.register_hook(lambda *args: self._clear_cache())
-                self._cached_inv_chol_t_inducing_values = inv_chol_t_inducing_values
+                self._cached_inv_chol_t_inducing_values = _add_cache_hook(inv_chol_t_inducing_values, self)
 
         mean_update = (induc_data_covar.mT @ inv_chol_t_inducing_values).squeeze(-1).type(dtype)
 
@@ -112,9 +111,7 @@ class LargeBatchVariationalStrategy(VariationalStrategy):
             middle_term = torch.linalg.solve_triangular(chol, middle_term, upper=False, left=False)
             middle_term = torch.linalg.solve_triangular(chol.mT, middle_term, upper=True, left=True)
             if not self.training:
-                if middle_term.grad_fn is not None:
-                    middle_term.grad_fn.register_hook(lambda *args: self._clear_cache())
-                self._cached_middle_term = middle_term
+                self._cached_middle_term = _add_cache_hook(middle_term, self)
 
         # The covariance update `K_XZ K_ZZ^{-1/2} (S - I) K_ZZ^{-1/2} K_ZX`
         if diag and self.training:

--- a/gpytorch/variational/large_batch_variational_strategy.py
+++ b/gpytorch/variational/large_batch_variational_strategy.py
@@ -94,6 +94,8 @@ class LargeBatchVariationalStrategy(VariationalStrategy):
                 chol.mT, inducing_values.unsqueeze(-1), upper=True, left=True
             )
             if not self.training:
+                if inv_chol_t_inducing_values.grad_fn is not None:
+                    inv_chol_t_inducing_values.grad_fn.register_hook(lambda *args: self._clear_cache())
                 self._cached_inv_chol_t_inducing_values = inv_chol_t_inducing_values
 
         mean_update = (induc_data_covar.mT @ inv_chol_t_inducing_values).squeeze(-1).type(dtype)
@@ -110,6 +112,8 @@ class LargeBatchVariationalStrategy(VariationalStrategy):
             middle_term = torch.linalg.solve_triangular(chol, middle_term, upper=False, left=False)
             middle_term = torch.linalg.solve_triangular(chol.mT, middle_term, upper=True, left=True)
             if not self.training:
+                if middle_term.grad_fn is not None:
+                    middle_term.grad_fn.register_hook(lambda *args: self._clear_cache())
                 self._cached_middle_term = middle_term
 
         # The covariance update `K_XZ K_ZZ^{-1/2} (S - I) K_ZZ^{-1/2} K_ZX`

--- a/gpytorch/variational/unwhitened_variational_strategy.py
+++ b/gpytorch/variational/unwhitened_variational_strategy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import math
 
 import torch
@@ -21,7 +22,7 @@ from torch import Tensor
 
 from .. import settings
 from ..distributions import MultivariateNormal
-from ..utils.memoize import add_to_cache, cached
+from ..utils.memoize import add_to_cache, cached, clear_cache_hook
 from ._variational_strategy import _VariationalStrategy
 from .cholesky_variational_distribution import CholeskyVariationalDistribution
 
@@ -57,6 +58,10 @@ class UnwhitenedVariationalStrategy(_VariationalStrategy):
     def _cholesky_factor(self, induc_induc_covar: LinearOperator) -> TriangularLinearOperator:
         # Maybe used - if we're not using CG
         L = psd_safe_cholesky(to_dense(induc_induc_covar))
+        if L.grad_fn is not None:
+            wrapper = functools.partial(clear_cache_hook, self)
+            functools.update_wrapper(wrapper, clear_cache_hook)
+            L.grad_fn.register_hook(wrapper)
         return TriangularLinearOperator(L)
 
     @property

--- a/gpytorch/variational/unwhitened_variational_strategy.py
+++ b/gpytorch/variational/unwhitened_variational_strategy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import functools
 import math
 
 import torch
@@ -22,7 +21,7 @@ from torch import Tensor
 
 from .. import settings
 from ..distributions import MultivariateNormal
-from ..utils.memoize import add_to_cache, cached, clear_cache_hook
+from ..utils.memoize import add_to_cache, cached
 from ._variational_strategy import _VariationalStrategy
 from .cholesky_variational_distribution import CholeskyVariationalDistribution
 
@@ -59,9 +58,7 @@ class UnwhitenedVariationalStrategy(_VariationalStrategy):
         # Maybe used - if we're not using CG
         L = psd_safe_cholesky(to_dense(induc_induc_covar))
         if L.grad_fn is not None:
-            wrapper = functools.partial(clear_cache_hook, self)
-            functools.update_wrapper(wrapper, clear_cache_hook)
-            L.grad_fn.register_hook(wrapper)
+            L.grad_fn.register_hook(lambda *args: self._clear_cache())
         return TriangularLinearOperator(L)
 
     @property

--- a/gpytorch/variational/unwhitened_variational_strategy.py
+++ b/gpytorch/variational/unwhitened_variational_strategy.py
@@ -22,7 +22,7 @@ from torch import Tensor
 from .. import settings
 from ..distributions import MultivariateNormal
 from ..utils.memoize import add_to_cache, cached
-from ._variational_strategy import _VariationalStrategy
+from ._variational_strategy import _VariationalStrategy, _add_cache_hook
 from .cholesky_variational_distribution import CholeskyVariationalDistribution
 
 
@@ -57,9 +57,7 @@ class UnwhitenedVariationalStrategy(_VariationalStrategy):
     def _cholesky_factor(self, induc_induc_covar: LinearOperator) -> TriangularLinearOperator:
         # Maybe used - if we're not using CG
         L = psd_safe_cholesky(to_dense(induc_induc_covar))
-        if L.grad_fn is not None:
-            L.grad_fn.register_hook(lambda *args: self._clear_cache())
-        return TriangularLinearOperator(L)
+        return TriangularLinearOperator(_add_cache_hook(L, self))
 
     @property
     @cached(name="prior_distribution_memo")

--- a/gpytorch/variational/unwhitened_variational_strategy.py
+++ b/gpytorch/variational/unwhitened_variational_strategy.py
@@ -22,7 +22,7 @@ from torch import Tensor
 from .. import settings
 from ..distributions import MultivariateNormal
 from ..utils.memoize import add_to_cache, cached
-from ._variational_strategy import _VariationalStrategy, _add_cache_hook
+from ._variational_strategy import _add_cache_hook, _VariationalStrategy
 from .cholesky_variational_distribution import CholeskyVariationalDistribution
 
 

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import warnings
 from collections.abc import Iterable
 from typing import Any
@@ -190,6 +191,10 @@ class VariationalStrategy(_VariationalStrategy):
     @cached(name="cholesky_factor", ignore_args=True)
     def _cholesky_factor(self, induc_induc_covar: LinearOperator) -> TriangularLinearOperator:
         L = psd_safe_cholesky(to_dense(induc_induc_covar).type(_linalg_dtype_cholesky.value()))
+        if L.grad_fn is not None:
+            wrapper = functools.partial(clear_cache_hook, self)
+            functools.update_wrapper(wrapper, clear_cache_hook)
+            L.grad_fn.register_hook(wrapper)
         return TriangularLinearOperator(L)
 
     @property

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import functools
 import warnings
 from collections.abc import Iterable
 from typing import Any
@@ -192,9 +191,7 @@ class VariationalStrategy(_VariationalStrategy):
     def _cholesky_factor(self, induc_induc_covar: LinearOperator) -> TriangularLinearOperator:
         L = psd_safe_cholesky(to_dense(induc_induc_covar).type(_linalg_dtype_cholesky.value()))
         if L.grad_fn is not None:
-            wrapper = functools.partial(clear_cache_hook, self)
-            functools.update_wrapper(wrapper, clear_cache_hook)
-            L.grad_fn.register_hook(wrapper)
+            L.grad_fn.register_hook(lambda *args: self._clear_cache())
         return TriangularLinearOperator(L)
 
     @property

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -23,7 +23,7 @@ from torch import Tensor
 
 from gpytorch import settings
 
-from gpytorch.variational._variational_strategy import _VariationalStrategy, _add_cache_hook
+from gpytorch.variational._variational_strategy import _add_cache_hook, _VariationalStrategy
 from gpytorch.variational.cholesky_variational_distribution import CholeskyVariationalDistribution
 
 from ..distributions import MultivariateNormal

--- a/gpytorch/variational/variational_strategy.py
+++ b/gpytorch/variational/variational_strategy.py
@@ -23,7 +23,7 @@ from torch import Tensor
 
 from gpytorch import settings
 
-from gpytorch.variational._variational_strategy import _VariationalStrategy
+from gpytorch.variational._variational_strategy import _VariationalStrategy, _add_cache_hook
 from gpytorch.variational.cholesky_variational_distribution import CholeskyVariationalDistribution
 
 from ..distributions import MultivariateNormal
@@ -190,9 +190,7 @@ class VariationalStrategy(_VariationalStrategy):
     @cached(name="cholesky_factor", ignore_args=True)
     def _cholesky_factor(self, induc_induc_covar: LinearOperator) -> TriangularLinearOperator:
         L = psd_safe_cholesky(to_dense(induc_induc_covar).type(_linalg_dtype_cholesky.value()))
-        if L.grad_fn is not None:
-            L.grad_fn.register_hook(lambda *args: self._clear_cache())
-        return TriangularLinearOperator(L)
+        return TriangularLinearOperator(_add_cache_hook(L, self))
 
     @property
     @cached(name="prior_distribution_memo")

--- a/test/variational/test_large_batch_variational_strategy.py
+++ b/test/variational/test_large_batch_variational_strategy.py
@@ -113,6 +113,37 @@ class TestLargeBatchVariationalGP(TestVariationalGP):
     def test_against_variational_strategy_eval(self):
         self.test_against_variational_strategy(train=False)
 
+    def test_eval_mode_allows_repeated_backward(self, *args, **kwargs):
+        """Repeated eval-mode backward passes should clear all large-batch inference caches."""
+        model, _ = self._make_model_and_likelihood(
+            num_inducing=5,
+            batch_shape=self.batch_shape,
+            strategy_cls=self.strategy_cls,
+            distribution_cls=self.distribution_cls,
+        )
+        model.eval()
+
+        cached_inv_chol_t_inducing_values = []
+        cached_middle_terms = []
+        for _ in range(2):
+            test_x = torch.randn(*self.batch_shape, 3, 2, requires_grad=True)
+            test_y = torch.randn(*self.batch_shape, 3)
+
+            predictive_dist = model(test_x)
+            cached_inv_chol_t_inducing_values.append(model.variational_strategy._cached_inv_chol_t_inducing_values)
+            cached_middle_terms.append(model.variational_strategy._cached_middle_term)
+
+            loss = (predictive_dist.mean - test_y).mean()
+            loss.backward()
+
+            self.assertNotIn("cholesky_factor", model.variational_strategy._memoize_cache)
+            self.assertFalse(hasattr(model.variational_strategy, "_cached_inv_chol_t_inducing_values"))
+            self.assertFalse(hasattr(model.variational_strategy, "_cached_middle_term"))
+            self.assertIsNotNone(test_x.grad)
+
+        self.assertIsNot(*cached_inv_chol_t_inducing_values)
+        self.assertIsNot(*cached_middle_terms)
+
     def test_inference_caching(self):
         """Test that inference caching works correctly."""
         torch.manual_seed(42)

--- a/test/variational/test_variational_strategy.py
+++ b/test/variational/test_variational_strategy.py
@@ -76,6 +76,31 @@ class TestVariationalGP(VariationalTestCase, unittest.TestCase):
         self.assertAllClose(predictive_dist1.mean, predictive_dist2.mean)
         self.assertAllClose(predictive_dist1.variance, predictive_dist2.variance)
 
+    def test_eval_mode_allows_repeated_backward(self, *args, **kwargs):
+        model, _ = self._make_model_and_likelihood(
+            num_inducing=5,
+            batch_shape=self.batch_shape,
+            strategy_cls=self.strategy_cls,
+            distribution_cls=self.distribution_cls,
+        )
+        model.eval()
+
+        cached_cholesky_factors = []
+        for _ in range(2):
+            test_x = torch.randn(*self.batch_shape, 3, 2, requires_grad=True)
+            test_y = torch.randn(*self.batch_shape, 3)
+
+            predictive_dist = model(test_x)
+            cached_cholesky = model.variational_strategy._memoize_cache["cholesky_factor"]
+            cached_cholesky_factors.append(cached_cholesky)
+
+            loss = (predictive_dist.mean - test_y).mean()
+            loss.backward()
+            self.assertNotIn("cholesky_factor", model.variational_strategy._memoize_cache)
+            self.assertIsNotNone(test_x.grad)
+
+        self.assertIsNot(*cached_cholesky_factors)
+
 
 class TestPredictiveGP(TestVariationalGP):
     @property

--- a/test/variational/test_variational_strategy.py
+++ b/test/variational/test_variational_strategy.py
@@ -77,6 +77,7 @@ class TestVariationalGP(VariationalTestCase, unittest.TestCase):
         self.assertAllClose(predictive_dist1.variance, predictive_dist2.variance)
 
     def test_eval_mode_allows_repeated_backward(self, *args, **kwargs):
+        """Repeated eval-mode backward passes should rebuild cached Cholesky factors."""
         model, _ = self._make_model_and_likelihood(
             num_inducing=5,
             batch_shape=self.batch_shape,


### PR DESCRIPTION
## Summary

This fixes issue #2689, where variational GPs could fail on a second backward pass in `eval()` mode with:

`RuntimeError: Trying to backward through the graph a second time`

The root cause was reuse of cached Cholesky factors that still referenced the previous autograd graph.

## Changes

- Clear cached Cholesky factors after backward in `VariationalStrategy`
- Apply the same fix to `UnwhitenedVariationalStrategy`
- Add a regression test covering repeated eval-mode backward passes

## Testing

- Added regression coverage in `test/variational/test_variational_strategy.py`
- `python -m py_compile gpytorch/variational/variational_strategy.py gpytorch/variational/unwhitened_variational_strategy.py test/variational/test_variational_strategy.py`