### PR TITLE
Add inducing point initialization utilities (K-means + median heuristic)

### DIFF
--- a/gpytorch/utils/__init__.py
+++ b/gpytorch/utils/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 import linear_operator
 
 from . import deprecation, errors, generic, grid, interpolation, quadrature, transforms, warnings
+from .inducing_point_initialization import kmeans_inducing_points, median_heuristic_lengthscale
 from .memoize import cached
 from .nearest_neighbors import NNUtil
 from .sum_interaction_terms import sum_interaction_terms
@@ -19,6 +20,8 @@ __all__ = [
     "generic",
     "grid",
     "interpolation",
+    "kmeans_inducing_points",
+    "median_heuristic_lengthscale",
     "quadrature",
     "sum_interaction_terms",
     "transforms",

--- a/gpytorch/utils/inducing_point_initialization.py
+++ b/gpytorch/utils/inducing_point_initialization.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import warnings
+
+import torch
+from torch import Tensor
+
+
+def kmeans_inducing_points(
+    train_x: Tensor,
+    n_inducing: int,
+    max_iter: int = 100,
+    batch_size: int | None = None,
+    seed: int | None = None,
+) -> Tensor:
+    r"""
+    Select inducing point locations with K-means clustering.
+
+    Runs K-means on ``train_x`` and returns the cluster centroids as
+    inducing points. For large datasets, pass ``batch_size`` to use
+    mini-batch K-means.
+
+    :param train_x: Training inputs, shape :math:`(N, D)`.
+    :type train_x: torch.Tensor
+    :param n_inducing: Number of inducing points (clusters).
+    :type n_inducing: int
+    :param max_iter: Max K-means iterations. Default: ``100``.
+    :type max_iter: int
+    :param batch_size: Mini-batch size. If ``None``, runs full-batch
+        K-means. Default: ``None``.
+    :type batch_size: int, optional
+    :param seed: Random seed. Default: ``None``.
+    :type seed: int, optional
+    :return: Inducing points, shape :math:`(M, D)`.
+    :rtype: torch.Tensor
+
+    Example:
+
+        >>> train_x = torch.randn(1000, 5)
+        >>> inducing_pts = kmeans_inducing_points(train_x, n_inducing=50)
+        >>> inducing_pts.shape
+        torch.Size([50, 5])
+    """
+    if train_x.ndim != 2:
+        raise ValueError(f"Expected 2D train_x (N, D), got {train_x.shape}")
+
+    n_data, d = train_x.shape
+
+    if n_inducing <= 0:
+        raise ValueError(f"n_inducing must be positive, got {n_inducing}")
+
+    if n_inducing >= n_data:
+        warnings.warn(
+            f"n_inducing ({n_inducing}) >= n_data ({n_data}), returning all training points.",
+            UserWarning,
+        )
+        return train_x.clone()
+
+    generator = torch.Generator(device=train_x.device)
+    if seed is not None:
+        generator.manual_seed(seed)
+
+    centroids = _kmeans_plusplus(train_x, n_inducing, generator)
+
+    use_minibatch = batch_size is not None and batch_size < n_data
+
+    for _ in range(max_iter):
+        batch = train_x
+        if use_minibatch:
+            idx = torch.randint(n_data, (batch_size,), generator=generator, device=train_x.device)
+            batch = train_x[idx]
+
+        dists = torch.cdist(batch, centroids)
+        assignments = dists.argmin(dim=1)
+
+        new_centroids = torch.zeros_like(centroids)
+        counts = torch.zeros(n_inducing, device=train_x.device, dtype=train_x.dtype)
+        new_centroids.scatter_add_(0, assignments.unsqueeze(1).expand(-1, d), batch)
+        counts.scatter_add_(0, assignments, torch.ones(batch.shape[0], device=train_x.device, dtype=train_x.dtype))
+
+        # Keep old centroid for empty clusters
+        nonempty = counts > 0
+        new_centroids[nonempty] /= counts[nonempty].unsqueeze(1)
+        new_centroids[~nonempty] = centroids[~nonempty]
+
+        if not use_minibatch:
+            shift = (new_centroids - centroids).norm(dim=1).max()
+            centroids = new_centroids
+            if shift < 1e-6:
+                break
+        else:
+            centroids = new_centroids
+
+    return centroids
+
+
+def _kmeans_plusplus(data: Tensor, k: int, generator: torch.Generator) -> Tensor:
+    """K-means++ centroid initialization."""
+    n = data.shape[0]
+    device = data.device
+
+    idx = torch.randint(n, (1,), generator=generator, device=device).item()
+    centroids = [data[idx]]
+
+    for _ in range(1, k):
+        stacked = torch.stack(centroids, dim=0)
+        min_dists_sq = torch.cdist(data, stacked).min(dim=1).values.square()
+        probs = min_dists_sq / min_dists_sq.sum()
+        idx = torch.multinomial(probs, 1, generator=generator).item()
+        centroids.append(data[idx])
+
+    return torch.stack(centroids, dim=0)
+
+
+def median_heuristic_lengthscale(
+    train_x: Tensor,
+    n_subsample: int = 1000,
+    seed: int | None = None,
+) -> Tensor:
+    r"""
+    Compute a lengthscale initialization via the median pairwise distance heuristic.
+
+    Returns the median of pairwise Euclidean distances on a random subsample
+    of ``train_x``.
+
+    :param train_x: Training inputs, shape :math:`(N, D)`.
+    :type train_x: torch.Tensor
+    :param n_subsample: Subsample size for pairwise distances.
+        Default: ``1000``.
+    :type n_subsample: int
+    :param seed: Random seed. Default: ``None``.
+    :type seed: int, optional
+    :return: Scalar lengthscale.
+    :rtype: torch.Tensor
+
+    Example:
+
+        >>> train_x = torch.randn(5000, 10)
+        >>> ls = median_heuristic_lengthscale(train_x)
+        >>> ls.shape
+        torch.Size([])
+    """
+    if train_x.ndim != 2:
+        raise ValueError(f"Expected 2D train_x (N, D), got {train_x.shape}")
+
+    n_data = train_x.shape[0]
+
+    if n_subsample >= n_data:
+        subsample = train_x
+    else:
+        generator = torch.Generator(device=train_x.device)
+        if seed is not None:
+            generator.manual_seed(seed)
+        idx = torch.randperm(n_data, generator=generator, device=train_x.device)[:n_subsample]
+        subsample = train_x[idx]
+
+    dists = torch.pdist(subsample)
+
+    if dists.numel() == 0:
+        warnings.warn("Too few points for pairwise distances, returning lengthscale=1.0.", UserWarning)
+        return torch.tensor(1.0, dtype=train_x.dtype, device=train_x.device)
+
+    return dists.median()

--- a/test/utils/test_inducing_point_initialization.py
+++ b/test/utils/test_inducing_point_initialization.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import random
+import unittest
+
+import torch
+
+from gpytorch.utils.inducing_point_initialization import kmeans_inducing_points, median_heuristic_lengthscale
+
+
+class TestKmeansInducingPoints(unittest.TestCase):
+    def setUp(self):
+        if os.getenv("UNLOCK_SEED") is None or os.getenv("UNLOCK_SEED").lower() == "false":
+            self.rng_state = torch.get_rng_state()
+            torch.manual_seed(0)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(0)
+            random.seed(0)
+
+    def tearDown(self):
+        if hasattr(self, "rng_state"):
+            torch.set_rng_state(self.rng_state)
+
+    def test_basic(self):
+        train_x = torch.randn(200, 5)
+        inducing = kmeans_inducing_points(train_x, n_inducing=20, seed=42)
+        self.assertEqual(inducing.shape, torch.Size([20, 5]))
+        self.assertEqual(inducing.dtype, train_x.dtype)
+        self.assertEqual(inducing.device, train_x.device)
+
+    def test_finds_clusters(self):
+        cluster1 = torch.randn(200, 2) + torch.tensor([10.0, 10.0])
+        cluster2 = torch.randn(200, 2) + torch.tensor([-10.0, -10.0])
+        train_x = torch.cat([cluster1, cluster2], dim=0)
+
+        inducing = kmeans_inducing_points(train_x, n_inducing=2, seed=42)
+
+        center1_dists = (inducing - torch.tensor([10.0, 10.0])).norm(dim=1)
+        center2_dists = (inducing - torch.tensor([-10.0, -10.0])).norm(dim=1)
+        self.assertLess(center1_dists.min().item(), 2.0)
+        self.assertLess(center2_dists.min().item(), 2.0)
+
+    def test_minibatch(self):
+        train_x = torch.randn(500, 3)
+        inducing = kmeans_inducing_points(train_x, n_inducing=20, batch_size=100, seed=42)
+        self.assertEqual(inducing.shape, torch.Size([20, 3]))
+
+    def test_n_inducing_exceeds_data(self):
+        train_x = torch.randn(10, 3)
+        with self.assertWarns(UserWarning):
+            inducing = kmeans_inducing_points(train_x, n_inducing=20, seed=42)
+        self.assertEqual(inducing.shape, train_x.shape)
+
+    def test_reproducibility(self):
+        train_x = torch.randn(200, 5)
+        inducing1 = kmeans_inducing_points(train_x, n_inducing=20, seed=42)
+        inducing2 = kmeans_inducing_points(train_x, n_inducing=20, seed=42)
+        self.assertTrue(torch.allclose(inducing1, inducing2))
+
+    def test_float64(self):
+        train_x = torch.randn(100, 3, dtype=torch.float64)
+        inducing = kmeans_inducing_points(train_x, n_inducing=10, seed=42)
+        self.assertEqual(inducing.dtype, torch.float64)
+
+
+class TestMedianHeuristicLengthscale(unittest.TestCase):
+    def setUp(self):
+        if os.getenv("UNLOCK_SEED") is None or os.getenv("UNLOCK_SEED").lower() == "false":
+            self.rng_state = torch.get_rng_state()
+            torch.manual_seed(0)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(0)
+            random.seed(0)
+
+    def tearDown(self):
+        if hasattr(self, "rng_state"):
+            torch.set_rng_state(self.rng_state)
+
+    def test_basic(self):
+        train_x = torch.randn(200, 3)
+        ls = median_heuristic_lengthscale(train_x)
+        self.assertEqual(ls.ndim, 0)
+        self.assertGreater(ls.item(), 0.0)
+        self.assertEqual(ls.dtype, train_x.dtype)
+
+    def test_scales_with_spread(self):
+        train_narrow = torch.randn(500, 3) * 0.1
+        train_wide = torch.randn(500, 3) * 10.0
+        ls_narrow = median_heuristic_lengthscale(train_narrow, seed=42)
+        ls_wide = median_heuristic_lengthscale(train_wide, seed=42)
+        self.assertGreater(ls_wide.item(), ls_narrow.item())
+
+    def test_subsample(self):
+        train_x = torch.randn(5000, 3)
+        ls = median_heuristic_lengthscale(train_x, n_subsample=100, seed=42)
+        self.assertGreater(ls.item(), 0.0)
+
+    def test_single_point(self):
+        train_x = torch.randn(1, 3)
+        with self.assertWarns(UserWarning):
+            ls = median_heuristic_lengthscale(train_x)
+        self.assertAlmostEqual(ls.item(), 1.0)
+
+    def test_reproducibility(self):
+        train_x = torch.randn(5000, 5)
+        ls1 = median_heuristic_lengthscale(train_x, n_subsample=200, seed=42)
+        ls2 = median_heuristic_lengthscale(train_x, n_subsample=200, seed=42)
+        self.assertEqual(ls1.item(), ls2.item())
+
+    def test_known_value(self):
+        # For [0, 1, ..., 99], median pairwise distance should match torch.pdist
+        train_x = torch.arange(100, dtype=torch.float32).unsqueeze(1)
+        ls = median_heuristic_lengthscale(train_x)
+        expected = torch.pdist(train_x).median().item()
+        self.assertAlmostEqual(ls.item(), expected, places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Add K-means inducing point init and median heuristic lengthscale

GPyTorch doesn't currently have built-in utilities for initializing inducing
point locations or lengthscales. This adds two functions to `gpytorch.utils`:

**`kmeans_inducing_points(train_x, n_inducing)`** - K-means++ on training data,
returns centroids. Also supports mini-batch K-means via `batch_size` arg

**`median_heuristic_lengthscale(train_x)`** - median of pairwise distances on a
subsample, for initializing RBF-family kernels

Both are pure PyTorch with no extra deps

```python
from gpytorch.utils import kmeans_inducing_points, median_heuristic_lengthscale

inducing_points = kmeans_inducing_points(train_x, n_inducing=100)
kernel = gpytorch.kernels.RBFKernel()
kernel.lengthscale = median_heuristic_lengthscale(train_x)
```