### PR TITLE
Add MPS regression test for ExactGP to track Apple Silicon backend support

### DIFF
--- a/test/models/test_exact_gp.py
+++ b/test/models/test_exact_gp.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
+import math
 import unittest
 
 import torch
-import math
 
 import gpytorch
 from gpytorch import settings

--- a/test/models/test_exact_gp.py
+++ b/test/models/test_exact_gp.py
@@ -3,6 +3,7 @@
 import unittest
 
 import torch
+import math
 
 import gpytorch
 from gpytorch import settings
@@ -196,6 +197,35 @@ class TestExactGP(BaseModelTestCase, unittest.TestCase):
             new_y = torch.randn(new_n)
             # just check that this can run without error
             model.get_fantasy_model(new_x, new_y)
+
+    @unittest.skipIf(not torch.backends.mps.is_available(), "MPS not available")
+    def test_exact_gp_mps(self):
+        device = torch.device("mps")
+
+        train_x = torch.linspace(0, 1, 50, device=device).float()
+        train_y = torch.sin(train_x * (2 * math.pi)).float()
+
+        likelihood = gpytorch.likelihoods.GaussianLikelihood().to(device)
+        model = ExactGPModel(train_x, train_y, likelihood).to(device)
+
+        model.eval()
+        likelihood.eval()
+        with torch.no_grad():
+            test_x = torch.linspace(0.05, 0.95, 25, device=device).float()
+            output = model(test_x)
+            self.assertEqual(output.mean.device.type, "mps")
+
+        model.train()
+        likelihood.train()
+        mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, model)
+
+        output = model(train_x)
+        loss = -mll(output, train_y)
+        loss.backward()
+
+        for param in model.parameters():
+            if param.requires_grad:
+                self.assertIsNotNone(param.grad)
 
 
 class TestInterpolatedExactGP(TestExactGP):

--- a/test/models/test_exact_gp.py
+++ b/test/models/test_exact_gp.py
@@ -210,6 +210,7 @@ class TestExactGP(BaseModelTestCase, unittest.TestCase):
 
         model.eval()
         likelihood.eval()
+
         with torch.no_grad():
             test_x = torch.linspace(0.05, 0.95, 25, device=device).float()
             output = model(test_x)


### PR DESCRIPTION
With the recent fixes coming upstream from PyTorch (specifically the native linalg.cholesky support in [PR #172536](https://hud.pytorch.org/pr/172536)), Apple Silicon (MPS) is technically capable of running native ExactGP models without triggering math crashes. However, GPyTorch currently lacks a dedicated hardware test to track MPS compatibility.

This PR adds a minimal test_exact_gp_mps regression test to the hardware triad (CPU/CUDA/MPS) to prevent future silent regressions.

Note on Performance Bottlenecks
While this test passes (proving the math is stable on M1/M2 chips), it surfaces a PyTorch-level fallback warning indicating that aten::_cholesky_solve_helper is missing from the Metal backend, causing a silent CPU fallback. I will add proposal to bypass this overhead in Issue #2209