### PR TITLE
refactor: modernize GitHub Actions workflow dependencies to latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: run_test_suite
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install dependencies
@@ -37,8 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: run_test_suite
     steps:
-    - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@v4
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: false
         python-version: "3.10"

--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -14,9 +14,9 @@ jobs:
   run_linter:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install dependencies
@@ -31,7 +31,7 @@ jobs:
       run: |
         SKIP=flake8 pre-commit run --files test/**/*.py gpytorch/**/*.py
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
 
   run_unit_tests:
     runs-on: ubuntu-latest
@@ -40,9 +40,9 @@ jobs:
         pytorch-version: ["main", "stable"]
         extras: ["with-extras", "no-extras"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install dependencies
@@ -67,9 +67,9 @@ jobs:
   run_examples:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install dependencies


### PR DESCRIPTION
Fixes #2739

## Changes Made

Updated outdated GitHub Actions dependencies in both workflow files:

### run_test_suite.yml
- `actions/checkout@v2` → `actions/checkout@v4`
- `actions/setup-python@v2` → `actions/setup-python@v5`
- `codecov/codecov-action@v3` → `codecov/codecov-action@v5`

### deploy.yml
- `actions/checkout@v2` → `actions/checkout@v4`
- `actions/setup-python@v2` → `actions/setup-python@v5`
- `conda-incubator/setup-miniconda@v2` → `conda-incubator/setup-miniconda@v3`

## Impact
- No breaking changes to the Python package API
- Improves CI maintainability and reduces workflow fragility
- All changes are drop-in compatible upgrades