### PR TITLE
Add documentation note about data standardization for ARD kernels

### DIFF
--- a/gpytorch/kernels/matern_kernel.py
+++ b/gpytorch/kernels/matern_kernel.py
@@ -39,6 +39,15 @@ class MaternKernel(Kernel):
         This kernel does not have an `outputscale` parameter. To add a scaling parameter,
         decorate this kernel with a :class:`gpytorch.kernels.ScaleKernel`.
 
+    .. note::
+
+        For ARD kernels (when :attr:`ard_num_dims` is not None), it is highly recommended
+        to standardize the input data (e.g., subtract the mean and divide by the standard
+        deviation) before passing it to the kernel. With input data that has very different
+        scales across dimensions, the kernel matrix can numerically underflow to zero,
+        causing zero gradients for the lengthscale parameters. Standardizing the data
+        ensures numerical stability and proper gradient flow during training.
+
     :param nu: (Default: 2.5) The smoothness parameter.
     :type nu: float (0.5, 1.5, or 2.5)
     :param ard_num_dims: (Default: `None`) Set this if you want a separate lengthscale for each

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -31,6 +31,15 @@ class RBFKernel(Kernel):
         This kernel does not have an `outputscale` parameter. To add a scaling parameter,
         decorate this kernel with a :class:`gpytorch.kernels.ScaleKernel`.
 
+    .. note::
+
+        For ARD kernels (when :attr:`ard_num_dims` is not None), it is highly recommended
+        to standardize the input data (e.g., subtract the mean and divide by the standard
+        deviation) before passing it to the kernel. With input data that has very different
+        scales across dimensions, the kernel matrix can numerically underflow to zero,
+        causing zero gradients for the lengthscale parameters. Standardizing the data
+        ensures numerical stability and proper gradient flow during training.
+
     :param ard_num_dims: Set this if you want a separate lengthscale for each input
         dimension. It should be `d` if :math:`\mathbf{x_1}` is a `n x d` matrix. (Default: `None`.)
     :param batch_shape: Set this if you want a separate lengthscale for each batch of input


### PR DESCRIPTION
Addresses issue #724: Add warning about zero gradients with high-variance data

For ARD kernels (when ard_num_dims is not None), input data with very different scales across dimensions can cause the kernel matrix to numerically underflow to zero, resulting in zero gradients for lengthscale parameters during training.

This change adds a note to the RBFKernel and MaternKernel docstrings recommending data standardization for numerical stability.