### PR TITLE
Fix mis-broadcast in exact_predictive_mean for batched multi-output GPs

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -386,8 +386,14 @@ class DefaultPredictionStrategy:
         # GP, and using addmv requires you to to_dense test_train_covar, which is obviously a huge no-no!
 
         # see https://github.com/cornellius-gp/gpytorch/pull/2317#discussion_r1157994719
+        # NOTE: This squeeze is only correct for multitask models, whose mean_cache
+        # carries a spurious singleton dimension at index 1. For batched multi-output
+        # models (a plain, non-multitask MultivariateNormal), a 4-dimensional
+        # mean_cache -- e.g. ``num_fantasies x batch x num_outputs x num_train`` from
+        # fantasizing -- must NOT be squeezed, otherwise a singleton batch dimension is
+        # dropped and the remaining dimensions mis-broadcast against test_train_covar.
         mean_cache = self.mean_cache
-        if len(mean_cache.shape) == 4:
+        if len(mean_cache.shape) == 4 and isinstance(self.train_prior_dist, MultitaskMultivariateNormal):
             mean_cache = mean_cache.squeeze(1)
 
         # Handle NaNs

--- a/test/models/test_exact_gp.py
+++ b/test/models/test_exact_gp.py
@@ -69,6 +69,20 @@ class SumExactGPModel(ExactGP):
         return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
 
 
+class BatchExactGPModel(ExactGP):
+    def __init__(self, train_x, train_y, likelihood, batch_shape):
+        super().__init__(train_x, train_y, likelihood)
+        self.mean_module = gpytorch.means.ConstantMean(batch_shape=batch_shape)
+        self.covar_module = gpytorch.kernels.ScaleKernel(
+            gpytorch.kernels.RBFKernel(batch_shape=batch_shape), batch_shape=batch_shape
+        )
+
+    def forward(self, x):
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
+        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+
+
 class TestExactGP(BaseModelTestCase, unittest.TestCase):
     def create_model(self, train_x, train_y, likelihood):
         model = ExactGPModel(train_x, train_y, likelihood)
@@ -174,6 +188,53 @@ class TestExactGP(BaseModelTestCase, unittest.TestCase):
             prior_out_cm = model(test_data)
         self.assertTrue(torch.allclose(prior_out.mean, prior_out_cm.mean))
         self.assertTrue(torch.allclose(prior_out.covariance_matrix, prior_out_cm.covariance_matrix))
+
+    def test_batched_multioutput_prediction_singleton_batch(self):
+        # Regression test for the batched multi-output prediction bug where a 4-dim
+        # mean_cache with a singleton batch dim (dim 1) was incorrectly squeezed,
+        # causing the batch dimensions to mis-broadcast. See BoTorch issue #3336.
+        torch.manual_seed(0)
+        dtype = torch.double
+        # aug batch = [b0, b1, m] = [4, 1, 2] -> mean_cache is 4-dim -> triggers the path
+        b0, b1, m, n, d = 4, 1, 2, 7, 2
+        aug_batch = torch.Size([b0, b1, m])
+        train_x = torch.rand(b0, b1, m, n, d, dtype=dtype)
+        train_y = torch.rand(b0, b1, m, n, dtype=dtype)
+
+        likelihood = GaussianLikelihood(batch_shape=aug_batch).to(dtype=dtype)
+        model = BatchExactGPModel(train_x, train_y, likelihood, aug_batch).to(dtype=dtype)
+        model.eval()
+        likelihood.eval()
+
+        # Leading MC-sample batch of 64, then [b0, b1]; output dim inserted at position -3.
+        test_x = torch.rand(64, b0, b1, 1, 5, d, dtype=dtype)
+        with torch.no_grad(), gpytorch.settings.fast_pred_var(False):
+            mean = model(test_x).mean
+        self.assertEqual(mean.shape, torch.Size([64, b0, b1, m, 5]))
+
+        # Ground truth: each output modeled independently (mean_cache is 3-dim, unaffected).
+        # Only the batched tensors (dim >= 3) carry the output dim to slice; scalar
+        # constraint bounds are shared across outputs and copied verbatim.
+        for j in range(m):
+            likelihood_j = GaussianLikelihood(batch_shape=torch.Size([b0, b1])).to(dtype=dtype)
+            likelihood_j.load_state_dict(
+                {k: (v[:, :, j] if v.dim() >= 3 else v) for k, v in likelihood.state_dict().items()}
+            )
+            model_j = BatchExactGPModel(train_x[:, :, j], train_y[:, :, j], likelihood_j, torch.Size([b0, b1])).to(
+                dtype=dtype
+            )
+            model_j.load_state_dict(
+                {
+                    k: (v[:, :, j] if v.dim() >= 3 else v)
+                    for k, v in model.state_dict().items()
+                    if k in model_j.state_dict()
+                }
+            )
+            model_j.eval()
+            likelihood_j.eval()
+            with torch.no_grad(), gpytorch.settings.fast_pred_var(False):
+                mean_j = model_j(test_x[..., 0, :, :]).mean  # drop inserted output dim slot
+            self.assertLess((mean[..., j, :] - mean_j).abs().max().item(), 1e-6)
 
     def test_lanczos_fantasy_model(self):
         lanczos_thresh = 10


### PR DESCRIPTION
## Summary

`DefaultPredictionStrategy.exact_predictive_mean` unconditionally squeezed dim 1 of any 4-dimensional `mean_cache`. This is only correct for multitask models (`MultitaskMultivariateNormal`), whose `mean_cache` carries a spurious singleton at index 1. For **batched multi-output (batch-independent)** models — a plain, non-multitask `MultivariateNormal` — a 4-dim `mean_cache` with a singleton batch dimension gets its batch dim dropped, and the remaining dimensions mis-broadcast against `test_train_covar`.

Fixes the crash reported in meta-pytorch/botorch#3336 ("Fantasizing on Multioutput Batch Independent GP adds another output dimension").

## Root cause

The `len == 4` shape heuristic was introduced in commit `b9dc064` ("Passing unit tests now", part of the original qKG work), **replacing** the earlier `isinstance(train_prior_dist, MultitaskMultivariateNormal)` gating. The shape-only check over-fires: it also catches plain batched multi-output models, for which the squeeze is wrong.

The bug only triggers when dim 1 (the candidate batch `b`) has size 1. For `b > 1`, `squeeze(1)` is a no-op, which is why single-output GPs and `q`-batched cases were unaffected.

### Shape trace

For a fantasized batched multi-output GP with a single candidate (`b == 1`):

```
mean_cache        [8, 1, 2, 12]  --squeeze(1)-->  [8, 2, 12]
test_train_covar  [64, 8, 1, 2, 21, 12]
```

The squeezed cache mis-broadcasts, multiplying the two `num_fantasies=8` dims into `[64, 8, 8, 2, 21]` (numel 172032) instead of aligning into `[64, 8, 1, 2, 21]` (numel 21504). `predictive_mean.view(...)` in `ExactGP.__call__` then fails:

```
RuntimeError: shape '[64, 8, 1, 2, 21]' is invalid for input of size 172032
```

## Fix

Guard the squeeze with the distribution-type check the code originally had, restoring the pre-`b9dc064` gating. Multitask behavior is byte-for-byte identical.

## Minimal repro (pure BoTorch)

```python
import torch
from botorch.models import SingleTaskGP
b0, b1, n, d, m = 8, 1, 11, 2, 2
tX = torch.rand(b0, b1, n, d, dtype=torch.double)
tY = torch.rand(b0, b1, n, m, dtype=torch.double)
model = SingleTaskGP(tX, tY)
model.posterior(torch.rand(64, b0, b1, 21, d, dtype=torch.double)).mean
# unpatched: RuntimeError: shape '[64, 8, 1, 2, 21]' is invalid for input of size 172032
# patched:   returns mean of shape [64, 8, 1, 21, 2]
```

## Testing

Added `test_batched_multioutput_prediction_singleton_batch` in `test/models/test_exact_gp.py`. It reproduces the crash deterministically (no fantasize randomness) using a batched multi-output GP whose training data has a 3-dim aug batch `[b0, b1, m] = [4, 1, 2]` (producing the same 4-dim `mean_cache`), and checks the multi-output means against independent per-output single-output GPs to `< 1e-6`. Mutation-checked: the test **fails** on unpatched code (`RuntimeError: shape '[64, 4, 1, 2, 5]' is invalid for input of size 10240`) and **passes** after the fix.

Verification:
- New regression test: fails unpatched, passes patched. ✅
- GPyTorch exact-GP + multitask + fantasy suites (`test_exact_gp`, `test_simple_gp_regression`, `test_batch_multitask_gp_regression`, `test_independent_multitask_gp_regression`, `test_kronecker_multitask_gp_regression`, `test_hadamard_multitask_gp_regression`, `test_derivative_gp_fantasy`): **88 passed** (85 baseline + 3 inherited runs of the new test). ✅
- Downstream BoTorch smoke tests (`test_gpytorch`, `test_gp_regression`, `test_model_list_gp_regression`, `test_knowledge_gradient`): **69 passed**. ✅
- `flake8` + `ufmt` clean. ✅
