### PR TITLE
Fix thread-unsafe active_dims mutation in lazy kernel eval

### DIFF
--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -6,6 +6,7 @@ import warnings
 from abc import abstractmethod
 from collections.abc import Callable, Iterable
 from copy import deepcopy
+from types import EllipsisType
 
 import torch
 from linear_operator import to_dense, to_linear_operator
@@ -452,7 +453,13 @@ class Kernel(Module):
             yield kernel
 
     def __call__(
-        self, x1: Tensor, x2: Tensor | None = None, diag: bool = False, last_dim_is_batch: bool = False, **params
+        self,
+        x1: Tensor,
+        x2: Tensor | None = None,
+        diag: bool = False,
+        last_dim_is_batch: bool = False,
+        active_dims: Tensor | None | EllipsisType = ...,
+        **params,
     ) -> LazyEvaluatedKernelTensor | LinearOperator | Tensor:
         r"""
         Computes the covariance between :math:`\mathbf x_1` and :math:`\mathbf x_2`.
@@ -471,6 +478,9 @@ class Kernel(Module):
         :param last_dim_is_batch: If True, treat the last dimension
             of `x1` and `x2` as another batch dimension.
             (Useful for additive structure over the dimensions). (Default: False.)
+        :param active_dims: Dimensions of the last feature axis to use. Defaults to
+            :attr:`self.active_dims`. Pass ``None`` to skip slicing (e.g. when inputs
+            have already been restricted to the active dimensions).
 
         :return: An object that will lazily evaluate to the kernel matrix or vector.
             The shape depends on the kernel's evaluation mode:
@@ -491,11 +501,12 @@ class Kernel(Module):
 
         x1_, x2_ = x1, x2
 
-        # Select the active dimensions
-        if self.active_dims is not None:
-            x1_ = x1_.index_select(-1, self.active_dims)
+        # Select the active dimensions (override does not mutate self.active_dims)
+        dims = self.active_dims if active_dims is ... else active_dims
+        if dims is not None:
+            x1_ = x1_.index_select(-1, dims)
             if x2_ is not None:
-                x2_ = x2_.index_select(-1, self.active_dims)
+                x2_ = x2_.index_select(-1, dims)
 
         # Give x1_ and x2_ a last dimension, if necessary
         if x1_.ndimension() == 1:

--- a/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
+++ b/gpytorch/lazy/lazy_evaluated_kernel_tensor.py
@@ -350,16 +350,16 @@ class LazyEvaluatedKernelTensor(LinearOperator):
         x2 = self.x2
 
         with settings.lazily_evaluate_kernels(False):
-            temp_active_dims = self.kernel.active_dims
-            self.kernel.active_dims = None
+            # Inputs were already sliced by Kernel.__call__; pass active_dims=None so
+            # we skip slicing without mutating the shared kernel's active_dims buffer.
             res = self.kernel(
                 x1,
                 x2,
                 diag=False,
                 last_dim_is_batch=self.last_dim_is_batch,
+                active_dims=None,
                 **self.params,
             )
-            self.kernel.active_dims = temp_active_dims
 
         # Check the size of the output
         if settings.debug.on():

--- a/test/lazy/test_lazy_evaluated_kernel_tensor.py
+++ b/test/lazy/test_lazy_evaluated_kernel_tensor.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import math
+import threading
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -161,6 +162,103 @@ class TestLazyEvaluatedKernelTensorBatch(LinearOperatorTestCase, unittest.TestCa
             lazy_tensor = k(X)
         self.assertFalse(lazy_tensor.to_dense().requires_grad)
 
+    def test_evaluate_kernel_does_not_mutate_active_dims(self):
+        """evaluate_kernel must not temporarily clear the shared kernel's active_dims.
+
+        Mutating active_dims creates a race when the same kernel is evaluated
+        concurrently (see cornellius-gp/gpytorch#2763).
+        """
+        kernel = gpytorch.kernels.RBFKernel(active_dims=[0])
+        kernel.eval()
+        x1 = torch.tensor([[0.0, 0.0]])
+        x2 = torch.tensor([[0.0, 2.0]])
+        lazy_tensor = kernel(x1, x2)
+
+        active_dims_before = kernel.active_dims
+        self.assertIsNotNone(active_dims_before)
+
+        writes: list = []
+        original_setattr = torch.nn.Module.__setattr__
+
+        def tracking_setattr(module, name, value):
+            if name == "active_dims" and module is kernel:
+                writes.append(value)
+            return original_setattr(module, name, value)
+
+        with patch.object(torch.nn.Module, "__setattr__", tracking_setattr):
+            res = lazy_tensor.evaluate_kernel().to_dense()
+
+        self.assertEqual(writes, [])
+        self.assertIs(kernel.active_dims, active_dims_before)
+        # Feature 0 only: both points are 0 -> covariance 1 (not exp(-2) from full features)
+        self.assertAlmostEqual(res.item(), 1.0, places=5)
+
+    def test_active_dims_override_skips_slicing(self):
+        """Passing active_dims=None skips slicing without changing the kernel buffer."""
+        kernel = gpytorch.kernels.RBFKernel(active_dims=[0])
+        kernel.eval()
+        active_dims_before = kernel.active_dims.clone()
+
+        # Already restricted to the active dimension
+        x1 = torch.tensor([[0.0]])
+        x2 = torch.tensor([[0.0]])
+        with gpytorch.settings.lazily_evaluate_kernels(False):
+            res = kernel(x1, x2, active_dims=None).to_dense()
+
+        self.assertTrue(torch.equal(kernel.active_dims, active_dims_before))
+        self.assertAlmostEqual(res.item(), 1.0, places=5)
+
+        # Full features with default active_dims still use only dim 0
+        x1_full = torch.tensor([[0.0, 0.0]])
+        x2_full = torch.tensor([[0.0, 2.0]])
+        with gpytorch.settings.lazily_evaluate_kernels(False):
+            res_sliced = kernel(x1_full, x2_full).to_dense()
+        self.assertAlmostEqual(res_sliced.item(), 1.0, places=5)
+
+    def test_active_dims_concurrent_evaluate_kernel(self):
+        """Concurrent lazy eval and eager calls must not observe active_dims=None."""
+        kernel = gpytorch.kernels.RBFKernel(active_dims=[0])
+        kernel.eval()
+        x1 = torch.tensor([[0.0, 0.0]])
+        x2 = torch.tensor([[0.0, 2.0]])
+        expected = 1.0
+        # Wrong value if active_dims is observed as None (uses both features)
+        racy_wrong = math.exp(-2.0)
+
+        stop = threading.Event()
+        errors: list[float] = []
+        barrier = threading.Barrier(2)
+
+        def lazy_eval_loop():
+            barrier.wait()
+            while not stop.is_set():
+                # New LazyEvaluatedKernelTensor each time so evaluate_kernel is not cached
+                kernel(x1, x2).to_dense()
+
+        def eager_eval_loop():
+            barrier.wait()
+            while not stop.is_set():
+                with gpytorch.settings.lazily_evaluate_kernels(False):
+                    val = kernel(x1, x2).to_dense().item()
+                if abs(val - expected) > 1e-4:
+                    errors.append(val)
+                    stop.set()
+                    return
+            # also stop if we finish without error (timeout path sets stop)
+
+        t_lazy = threading.Thread(target=lazy_eval_loop)
+        t_eager = threading.Thread(target=eager_eval_loop)
+        t_lazy.start()
+        t_eager.start()
+        t_eager.join(timeout=2.0)
+        stop.set()
+        t_lazy.join(timeout=2.0)
+
+        self.assertFalse(
+            errors,
+            f"Concurrent eval observed wrong values (e.g. racy {racy_wrong:.4f}): {errors}",
+        )
+
 
 class TestLazyEvaluatedKernelTensorMultitaskBatch(TestLazyEvaluatedKernelTensorBatch):
     seed = 0
@@ -181,6 +279,16 @@ class TestLazyEvaluatedKernelTensorMultitaskBatch(TestLazyEvaluatedKernelTensorB
         lazy_tensor = self.create_linear_op()
         lazy_tensor.kernel.data_covar_module.raw_lengthscale_constraint.transform = lambda x: x + 0.1
         self._test_half(lazy_tensor)
+
+    # Race / mutation tests are specific to plain RBFKernel + active_dims
+    def test_evaluate_kernel_does_not_mutate_active_dims(self):
+        pass
+
+    def test_active_dims_override_skips_slicing(self):
+        pass
+
+    def test_active_dims_concurrent_evaluate_kernel(self):
+        pass
 
 
 class TestLazyEvaluatedKernelTensorAdditive(TestLazyEvaluatedKernelTensorBatch):
@@ -211,3 +319,12 @@ class TestLazyEvaluatedKernelTensorAdditive(TestLazyEvaluatedKernelTensorBatch):
         lazy_tensor = self.create_linear_op()
         lazy_tensor.kernel.base_kernel.raw_lengthscale_constraint.transform = lambda x: x + 0.1
         self._test_half(lazy_tensor)
+
+    def test_evaluate_kernel_does_not_mutate_active_dims(self):
+        pass
+
+    def test_active_dims_override_skips_slicing(self):
+        pass
+
+    def test_active_dims_concurrent_evaluate_kernel(self):
+        pass


### PR DESCRIPTION
LazyEvaluatedKernelTensor.evaluate_kernel() temporarily set the shared kernel's active_dims to None so already-sliced inputs were not sliced again. Concurrent callers could observe active_dims=None and use the wrong features.

Add an active_dims override on Kernel.__call__ and pass None from evaluate_kernel instead of mutating shared state.