### PR TITLE
fix(kernels): skip non-batch buffers in Kernel.__getitem__ and expand…

### DIFF
--- a/gpytorch/kernels/kernel.py
+++ b/gpytorch/kernels/kernel.py
@@ -392,6 +392,14 @@ class Kernel(Module):
 
         # Reshape the buffers of the kernel
         for buffr_name, buffr in self.named_buffers(recurse=False):
+            # Skip non-batch buffers (e.g. active_dims, has_initialized_grid).
+            # Only expand buffers whose leading dimensions match the batch shape
+            # AND whose total ndim exceeds batch_ndim (i.e. they have non-batch dims).
+            # active_dims is 1D metadata -- when batch_ndim >= 1, its ndim <= batch_ndim
+            # so we correctly skip it even when its shape coincidentally matches batch_shape.
+            batch_ndim = len(orig_batch_shape)
+            if batch_ndim > 0 and (buffr.shape[:batch_ndim] != orig_batch_shape or buffr.ndim <= batch_ndim):
+                continue
             # For a given buffer, get the number of dimensions that do not correspond to the batch shape
             non_batch_shape = buffr.shape[len(orig_batch_shape) :]
             new_buffer_shape = torch.Size([*new_batch_shape, *non_batch_shape])
@@ -576,7 +584,15 @@ class Kernel(Module):
             new_kernel.batch_shape = new_param.shape[:new_batch_shape_len]
 
         for buffr_name, buffr in self.named_buffers(recurse=False):
-            # For a given buffer, get the number of dimensions that do not correspond to the batch shape
+            # Skip non-batch buffers (e.g. active_dims, has_initialized_grid).
+            # Only index buffers whose leading dimensions match the batch shape
+            # AND whose total ndim exceeds batch_ndim (i.e. they have non-batch dims).
+            # active_dims is 1D metadata -- when batch_ndim >= 1, its ndim <= batch_ndim
+            # so we correctly skip it even when its shape coincidentally matches batch_shape.
+            batch_ndim = len(self.batch_shape)
+            if batch_ndim > 0:
+                if buffr.shape[:batch_ndim] != self.batch_shape or buffr.ndim <= batch_ndim:
+                    continue
             new_buffr = new_kernel.__getattr__(buffr_name)
             new_buffr.data = new_buffr.__getitem__(index)
             ndim_removed = len(buffr.shape) - len(new_buffr.shape)

--- a/test/lazy/test_lazy_evaluated_kernel_tensor.py
+++ b/test/lazy/test_lazy_evaluated_kernel_tensor.py
@@ -4,12 +4,12 @@ import math
 import unittest
 from unittest.mock import MagicMock, patch
 
+import gpytorch
+
 import linear_operator
 import torch
 from linear_operator import to_dense
 from linear_operator.test.linear_operator_test_case import LinearOperatorTestCase
-
-import gpytorch
 
 
 class TestLazyEvaluatedKernelTensorBatch(LinearOperatorTestCase, unittest.TestCase):
@@ -211,3 +211,160 @@ class TestLazyEvaluatedKernelTensorAdditive(TestLazyEvaluatedKernelTensorBatch):
         lazy_tensor = self.create_linear_op()
         lazy_tensor.kernel.base_kernel.raw_lengthscale_constraint.transform = lambda x: x + 0.1
         self._test_half(lazy_tensor)
+
+
+class TestKernelBatchGetitemActiveDims(unittest.TestCase):
+    """Test that batch indexing works correctly when kernels have active_dims.
+
+    Regression tests for https://github.com/cornellius-gp/gpytorch/issues/2591
+    """
+
+    def test_issue_2591_repro(self):
+        """Exact repro from issue #2591: index > 0 must not raise IndexError."""
+        x = torch.linspace(-1, 1, 100).reshape(-1, 1)
+        kernel = gpytorch.kernels.RBFKernel(ard_num_dims=1, active_dims=[0], batch_shape=torch.Size([2]))
+        self.assertEqual(kernel(x).shape, torch.Size([2, 100, 100]))
+        self.assertEqual(kernel(x)[0, :, :].shape, torch.Size([100, 100]))
+        self.assertEqual(kernel(x)[1, :, :].shape, torch.Size([100, 100]))
+
+    def test_active_dims_batch_index_crash(self):
+        """Indexing a batched kernel with active_dims having fewer elements
+        than batch_size should not crash with IndexError."""
+        kernel = gpytorch.kernels.RBFKernel(
+            active_dims=torch.tensor([0]),
+            batch_shape=torch.Size([2]),
+        )
+        x = torch.randn(2, 5, 3)
+
+        result = kernel(x)[1]
+        self.assertEqual(result.shape, torch.Size([5, 5]))
+
+    def test_active_dims_batch_index_preserves_active_dims(self):
+        """After batch indexing, active_dims should remain unchanged."""
+        kernel = gpytorch.kernels.RBFKernel(
+            active_dims=torch.tensor([0, 1]),
+            batch_shape=torch.Size([2]),
+        )
+        x = torch.randn(2, 5, 3)
+
+        result = kernel(x)[1]
+        indexed_kernel = result.kernel
+        self.assertTrue(
+            torch.equal(indexed_kernel.active_dims, torch.tensor([0, 1])),
+            f"active_dims corrupted after indexing: {indexed_kernel.active_dims}",
+        )
+
+    def test_active_dims_batch_index_preserves_batch_shape(self):
+        """Scalar index should remove the batch dim, not corrupt it."""
+        kernel = gpytorch.kernels.RBFKernel(
+            active_dims=torch.tensor([0, 1]),
+            batch_shape=torch.Size([2]),
+        )
+        x = torch.randn(2, 5, 3)
+
+        result = kernel(x)[1]
+        indexed_kernel = result.kernel
+        self.assertEqual(
+            indexed_kernel.batch_shape,
+            torch.Size([]),
+            f"batch_shape corrupted: {indexed_kernel.batch_shape}",
+        )
+
+    def test_active_dims_batch_slice_index(self):
+        """Slice indexing should preserve batch dim in batch_shape."""
+        kernel = gpytorch.kernels.RBFKernel(
+            active_dims=torch.tensor([0, 1]),
+            batch_shape=torch.Size([3]),
+        )
+        x = torch.randn(3, 5, 3)
+
+        result = kernel(x)[0:2]
+        indexed_kernel = result.kernel
+        self.assertEqual(
+            indexed_kernel.batch_shape,
+            torch.Size([2]),
+            f"batch_shape wrong after slice: {indexed_kernel.batch_shape}",
+        )
+        self.assertTrue(
+            torch.equal(indexed_kernel.active_dims, torch.tensor([0, 1])),
+            f"active_dims corrupted: {indexed_kernel.active_dims}",
+        )
+
+    def test_scale_kernel_active_dims_batch_index(self):
+        """ScaleKernel wrapping an RBFKernel with active_dims should also
+        handle batch indexing correctly."""
+        kernel = gpytorch.kernels.ScaleKernel(
+            gpytorch.kernels.RBFKernel(
+                active_dims=torch.tensor([0, 1]),
+                batch_shape=torch.Size([2]),
+            ),
+            batch_shape=torch.Size([2]),
+        )
+        x = torch.randn(2, 5, 3)
+
+        result = kernel(x)[1]
+        self.assertEqual(result.shape, torch.Size([5, 5]))
+
+    def test_active_dims_batch_index_semantic_correctness(self):
+        """The indexed result should be semantically equivalent to
+        evaluating the corresponding batch slice directly."""
+        kernel = gpytorch.kernels.RBFKernel(
+            active_dims=torch.tensor([0, 1]),
+            batch_shape=torch.Size([2]),
+        )
+        x = torch.randn(2, 5, 3)
+
+        result_lazy = to_dense(kernel(x)[1])
+        result_direct = to_dense(kernel(x[1:2]))[0]
+
+        self.assertTrue(
+            torch.allclose(result_lazy, result_direct, atol=1e-5),
+            "Results differ: lazy vs direct",
+        )
+
+    def test_active_dims_none_batch_index(self):
+        """When active_dims is None (the default), batch indexing should
+        still work correctly (no regression)."""
+        kernel = gpytorch.kernels.RBFKernel(batch_shape=torch.Size([2]))
+        x = torch.randn(2, 5, 3)
+
+        result = kernel(x)[1]
+        self.assertEqual(result.shape, torch.Size([5, 5]))
+
+    def test_active_dims_batch_getitem_direct_kernel(self):
+        """Direct kernel indexing (not via LazyEvaluatedKernelTensor)
+        should also work correctly."""
+        kernel = gpytorch.kernels.RBFKernel(
+            active_dims=torch.tensor([0]),
+            batch_shape=torch.Size([2]),
+        )
+
+        indexed = kernel[1]
+        self.assertEqual(indexed.batch_shape, torch.Size([]))
+        self.assertTrue(
+            torch.equal(indexed.active_dims, torch.tensor([0])),
+            f"active_dims corrupted: {indexed.active_dims}",
+        )
+
+    def test_expand_batch_preserves_active_dims(self):
+        """expand_batch should not expand non-batch buffers like active_dims."""
+        kernel = gpytorch.kernels.RBFKernel(
+            active_dims=torch.tensor([0, 1]),
+            batch_shape=torch.Size([2]),
+        )
+
+        expanded = kernel.expand_batch(torch.Size([4, 2]))
+        self.assertEqual(expanded.batch_shape, torch.Size([4, 2]))
+        self.assertTrue(
+            torch.equal(expanded.active_dims, torch.tensor([0, 1])),
+            f"active_dims corrupted after expand_batch: {expanded.active_dims}",
+        )
+
+    def test_expand_batch_expands_batch_buffers(self):
+        """expand_batch should correctly expand batch-shaped buffers."""
+        kernel = gpytorch.kernels.RBFKernel(
+            batch_shape=torch.Size([2]),
+        )
+        expanded = kernel.expand_batch(torch.Size([4, 2]))
+        self.assertEqual(expanded.batch_shape, torch.Size([4, 2]))
+        self.assertEqual(expanded.lengthscale.shape, torch.Size([4, 2, 1, 1]))


### PR DESCRIPTION
…_batch

Kernel.__getitem__ and expand_batch were applying batch indices to all registered buffers, including non-batch metadata like active_dims. That caused IndexError when batch-indexing LazyEvaluatedKernelTensor with index > 0 (cornellius-gp/gpytorch#2591), and could silently corrupt active_dims when shapes happened to align.

Skip buffers whose leading dims do not match batch_shape (or whose ndim does not exceed the batch ndim), so only true batch buffers are indexed or expanded.