### PR TITLE
Fix fantasy updates for multitask exact GPs

### DIFF
--- a/gpytorch/models/exact_prediction_strategies.py
+++ b/gpytorch/models/exact_prediction_strategies.py
@@ -170,7 +170,6 @@ class DefaultPredictionStrategy:
             num_tasks = full_output.event_shape[-1]
             full_mean = full_mean.view(*batch_shape, -1, num_tasks)
             fant_mean = full_mean[..., (num_train // num_tasks) :, :]
-            full_targets = full_targets.view(*target_batch_shape, -1)
         else:
             full_mean = full_mean.view(*batch_shape, -1)
             fant_mean = full_mean[..., num_train:]
@@ -214,8 +213,14 @@ class DefaultPredictionStrategy:
             [fant_train_covar, self.mean_cache],
         )
 
-        small_system_rhs = targets - fant_mean - ftcm
-        small_system_rhs = small_system_rhs.unsqueeze(-1)
+        small_system_rhs = targets - fant_mean
+        if isinstance(full_output, MultitaskMultivariateNormal):
+            # The mean cache - and therefore ftcm - is flattened over the task dimension, in the same
+            # interleaved ordering as the joint covariance matrix. The fantasy residuals are shaped
+            # `... x m x t`, so the task dimension has to be flattened away before the solve. Only the
+            # last two dimensions are collapsed, which leaves any batch dimensions untouched.
+            small_system_rhs = small_system_rhs.reshape(*small_system_rhs.shape[:-2], -1)
+        small_system_rhs = (small_system_rhs - ftcm).unsqueeze(-1)
         # Schur complement of a spd matrix is guaranteed to be positive definite
         schur_cholesky = psd_safe_cholesky(schur_complement)
         fant_cache_lower = torch.cholesky_solve(small_system_rhs, schur_cholesky)
@@ -238,9 +243,12 @@ class DefaultPredictionStrategy:
             new_covar_cache = new_lt.root_inv_decomposition().root
 
         # Expand inputs accordingly if necessary (for fantasies at the same points)
-        if full_inputs[0].dim() <= full_targets.dim():
+        # In the multitask case, full_targets and full_mean carry a trailing task dimension, which
+        # has to be excluded when counting batch dimensions.
+        num_data_dims = 2 if isinstance(full_output, MultitaskMultivariateNormal) else 1
+        if full_inputs[0].dim() - 2 < full_targets.dim() - num_data_dims:
             fant_batch_shape = full_targets.shape[:1]
-            n_batch = len(full_mean.shape[:-1])
+            n_batch = len(full_mean.shape[:-num_data_dims])
             repeat_shape = fant_batch_shape + torch.Size([1] * n_batch)
             full_inputs = [fi.expand(fant_batch_shape + fi.shape) for fi in full_inputs]
             full_mean = full_mean.expand(fant_batch_shape + full_mean.shape)

--- a/test/examples/test_kronecker_multitask_gp_regression.py
+++ b/test/examples/test_kronecker_multitask_gp_regression.py
@@ -12,6 +12,7 @@ from gpytorch.distributions import MultitaskMultivariateNormal
 from gpytorch.kernels import MultitaskKernel, RBFKernel
 from gpytorch.likelihoods import MultitaskGaussianLikelihood
 from gpytorch.means import ConstantMean, MultitaskMean
+from gpytorch.utils.memoize import get_from_cache
 
 
 # Simple training data: let's try to learn a sine function
@@ -89,6 +90,62 @@ class TestKroneckerMultiTaskGPRegression(unittest.TestCase):
 
         self.assertLess(mean_abs_error_task_1.squeeze().item(), 0.05)
         self.assertLess(mean_abs_error_task_2.squeeze().item(), 0.05)
+
+    def _get_fantasy_data(self):
+        # A well spaced subset of the data, so that the kernel matrix of the untrained model is well conditioned
+        sub_x, sub_y = train_x[::5], train_y[::5]
+        return sub_x[:15], sub_y[:15], sub_x[15:], sub_y[15:], sub_x, sub_y
+
+    def _get_full_model(self, model, full_x, full_y):
+        # The same model, but conditioned on the fantasy points from the start
+        full_model = MultitaskGPModel(full_x, full_y, MultitaskGaussianLikelihood(num_tasks=2))
+        full_model.load_state_dict(model.state_dict())
+        full_model.eval()
+        return full_model
+
+    def test_multitask_fantasy_model(self):
+        # Fantasy updates used to fail for multitask models whenever more than one point was added
+        obs_x, obs_y, fant_x, fant_y, full_x, full_y = self._get_fantasy_data()
+        test_x = torch.linspace(0, 1, 11)
+
+        model = MultitaskGPModel(obs_x, obs_y, MultitaskGaussianLikelihood(num_tasks=2))
+        model.eval()
+        model(test_x)  # Fill in the test time caches
+        fant_model = model.get_fantasy_model(fant_x, fant_y)
+
+        # A fantasy update has to give the same posterior as conditioning on all of the data at once
+        full_model = self._get_full_model(model, full_x, full_y)
+        fant_pred, full_pred = fant_model(test_x), full_model(test_x)
+        self.assertEqual(fant_pred.mean.shape, full_pred.mean.shape)
+        self.assertTrue(torch.allclose(fant_pred.mean, full_pred.mean, atol=1e-4))
+        self.assertTrue(torch.allclose(fant_pred.covariance_matrix, full_pred.covariance_matrix, atol=1e-4))
+
+        # Check the incrementally updated mean cache - which is what the fantasy strategy computes -
+        # against the one obtained by solving the full system from scratch
+        self.assertTrue(
+            torch.allclose(
+                get_from_cache(fant_model.prediction_strategy, "mean_cache"),
+                full_model.prediction_strategy.mean_cache,
+                atol=1e-4,
+            )
+        )
+
+    def test_multitask_fantasy_model_batch_targets(self):
+        # The fantasy targets may have an extra batch dimension (f x m x t) with shared fantasy inputs
+        obs_x, obs_y, fant_x, fant_y, full_x, full_y = self._get_fantasy_data()
+        test_x = torch.linspace(0, 1, 11)
+        num_fantasies = 3
+
+        model = MultitaskGPModel(obs_x, obs_y, MultitaskGaussianLikelihood(num_tasks=2))
+        model.eval()
+        model(test_x)  # Fill in the test time caches
+        fant_model = model.get_fantasy_model(fant_x, fant_y.unsqueeze(0).repeat(num_fantasies, 1, 1))
+
+        full_model = self._get_full_model(model, full_x, full_y)
+        fant_pred, full_pred = fant_model(test_x), full_model(test_x)
+        self.assertEqual(fant_pred.mean.shape, torch.Size([num_fantasies, *full_pred.mean.shape]))
+        for fantasy_mean in fant_pred.mean:
+            self.assertTrue(torch.allclose(fantasy_mean, full_pred.mean, atol=1e-4))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #2577.

`DefaultPredictionStrategy.get_fantasy_strategy` flattens the task dimension into the joint covariance
and the mean cache (`num_train = n * t`), but the fantasy targets and the fantasy prior mean stay
`... x m x t`. Three spots never reconcile the two:

1. `small_system_rhs = targets - fant_mean - ftcm` subtracts a `... x (m * t)` vector from a
   `... x m x t` residual, which is the `RuntimeError: The size of tensor a (2) must match the size of
   tensor b (10) at non-singleton dimension 1` reported in the issue. It only survives for `m == 1`,
   where a `1 x t` residual broadcasts - which is why the test added in #2317 passes.
2. The multitask branch pre-flattens `full_targets` before passing it to the new prediction strategy as
   `train_labels`, but `DefaultPredictionStrategy.__init__` expects the unflattened `... x (n + m) x t`
   labels and flattens them itself. This is invisible without batch dimensions and raises
   "Flattening the training labels failed" with them.
3. The "fantasies at the same points" branch counts batch dimensions with
   `full_inputs[0].dim() <= full_targets.dim()` and `len(full_mean.shape[:-1])`, both of which are off by
   one when there is a trailing task dimension.

This PR flattens the fantasy residual over the task dimension (collapsing only the last two dimensions,
so leading batch dimensions are preserved), leaves `full_targets` in the shape the constructor expects,
and counts batch dimensions with a `num_data_dims` that accounts for the task dimension. The single-task
path is unchanged: `full_inputs[0].dim() - 2 < full_targets.dim() - 1` is the same predicate as before
and `num_data_dims` is `1`.

This supersedes #2587, which fixes only (1) via `torch.reshape(targets, (-1, ftcm.shape[-1]))`. As
@gpleiss noted there, that collapses batch dimensions into the data dimension, so it turns the error into
wrong numbers for batched GPs; it also stops short of (2) and (3), which a batched multitask fantasy
update hits immediately afterwards.

The flattening is row-major over `(m, t)`, i.e. the interleaved ordering already assumed by
`MultitaskKernel`, by `DefaultPredictionStrategy.__init__`'s flattening of `train_labels`, and by the
existing `full_mean.view(*batch_shape, -1, num_tasks)` in this method.

### Tests

Two regression tests in `test/examples/test_kronecker_multitask_gp_regression.py`, which already defines
the model from the issue:

- `test_multitask_fantasy_model`: adds 5 fantasy points and checks the fantasy posterior mean and
  covariance against a model conditioned on all of the data up front, plus the incrementally updated
  `mean_cache` against a from-scratch solve.
- `test_multitask_fantasy_model_batch_targets`: `f x m x t` fantasy targets with shared fantasy inputs,
  covering the batch bookkeeping.

Both fail on `main` with the error from the issue and pass here. `test_derivative_gp_fantasy` (the #2317
test) and `test_fixed_noise_fanatasy_updates` still pass.