### PR TITLE
Fix(models): clear ExactGP state-dict pre-hooks that retain inputs

### DIFF
--- a/gpytorch/models/gp.py
+++ b/gpytorch/models/gp.py
@@ -6,4 +6,10 @@ from ..module import Module
 
 
 class GP(Module):
-    pass
+    def __init__(self):
+        super().__init__()
+        # Bound-method load_state_dict pre-hooks registered by gpytorch.Module create a
+        # reference cycle (module -> hooks -> bound method -> module) that delays GC of
+        # large attributes such as ExactGP.train_inputs and can OOM on CUDA when models
+        # are constructed repeatedly. Clearing after init breaks the cycle. See #2649.
+        self._load_state_dict_pre_hooks.clear()

--- a/test/models/test_exact_gp_hook_leak.py
+++ b/test/models/test_exact_gp_hook_leak.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import gc
+import unittest
+import weakref
+
+import torch
+
+import gpytorch
+from gpytorch.likelihoods import GaussianLikelihood
+from gpytorch.models import ExactGP
+
+
+class ExactGPModel(ExactGP):
+    def __init__(self, train_x, train_y, likelihood):
+        super().__init__(train_x, train_y, likelihood)
+        self.mean_module = gpytorch.means.ConstantMean()
+        self.covar_module = gpytorch.kernels.ScaleKernel(gpytorch.kernels.RBFKernel())
+
+    def forward(self, x):
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
+        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+
+
+class TestExactGPStateDictPreHookLeak(unittest.TestCase):
+    """Regression tests for #2649 (ExactGP retaining load_state_dict pre-hooks)."""
+
+    def _make_model(self, train_x, train_y):
+        likelihood = GaussianLikelihood()
+        return ExactGPModel(train_x, train_y, likelihood)
+
+    def test_init_clears_load_state_dict_pre_hooks(self):
+        train_x = torch.randn(20, 2)
+        train_y = torch.randn(20)
+        model = self._make_model(train_x, train_y)
+        self.assertEqual(len(model._load_state_dict_pre_hooks), 0)
+
+    def test_repeated_construction_does_not_retain_inputs(self):
+        # CPU-friendly proxy: construct/destroy models and ensure train inputs
+        # are not retained via pre-hook reference cycles.
+        input_refs = []
+        for _ in range(30):
+            train_x = torch.randn(20, 2)
+            train_y = torch.randn(20)
+            input_refs.append(weakref.ref(train_x))
+            model = self._make_model(train_x, train_y)
+            self.assertEqual(len(model._load_state_dict_pre_hooks), 0)
+            del model, train_x, train_y
+            gc.collect()
+
+        alive = sum(ref() is not None for ref in input_refs)
+        self.assertEqual(
+            alive,
+            0,
+            f"Expected train inputs to be collectable; {alive}/30 still alive",
+        )
+
+    def test_fantasy_model_clears_load_state_dict_pre_hooks(self):
+        train_x = torch.randn(20, 2)
+        train_y = torch.randn(20)
+        model = self._make_model(train_x, train_y)
+        model.eval()
+        model(torch.randn(5, 2))
+
+        fantasy = model.get_fantasy_model(torch.randn(3, 2), torch.randn(3))
+        self.assertEqual(len(model._load_state_dict_pre_hooks), 0)
+        self.assertEqual(len(fantasy._load_state_dict_pre_hooks), 0)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required for allocated-bytes check")
+    def test_repeated_construction_cuda_memory_does_not_grow_unbounded(self):
+        device = torch.device("cuda")
+        torch.cuda.empty_cache()
+        gc.collect()
+        torch.cuda.reset_peak_memory_stats()
+        baseline = torch.cuda.memory_allocated()
+
+        for _ in range(20):
+            train_x = torch.randn(20, 2, device=device)
+            train_y = torch.randn(20, device=device)
+            likelihood = GaussianLikelihood().to(device)
+            model = ExactGPModel(train_x, train_y, likelihood)
+            self.assertEqual(len(model._load_state_dict_pre_hooks), 0)
+            del model, likelihood, train_x, train_y
+            gc.collect()
+            torch.cuda.empty_cache()
+
+        growth = torch.cuda.memory_allocated() - baseline
+        self.assertLess(
+            growth,
+            1_000_000,
+            f"CUDA memory grew by {growth} bytes after constructing/destroying ExactGP models",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #2649

## Summary

`gpytorch.Module` registers a bound-method `load_state_dict` pre-hook in `__init__`. That creates a reference cycle:

`module → _load_state_dict_pre_hooks → bound method → module`

For `ExactGP`, that cycle keeps `train_inputs` / `train_targets` alive after the model goes out of scope, so repeatedly constructing ExactGP models leaks CUDA memory (reporter confirmed clearing `_load_state_dict_pre_hooks` fixes it).

## Fix

Clear `_load_state_dict_pre_hooks` at the end of `GP.__init__` (ExactGP’s base). That breaks the cycle on ExactGP construction. Fantasy models created via `deepcopy` then inherit an empty hook dict, so the fantasy path does not reintroduce the leak.

This matches the workaround confirmed on the issue and the spirit of the naefjo fantasy-hook clear (commit c7906a6), applied at the common GP construction path.

## Test plan

- [x] Added `test/models/test_exact_gp_hook_leak.py`:
  - assert hooks are empty after ExactGP init
  - construct/destroy models in a loop and assert train-input weakrefs are collectable (CPU proxy)
  - fantasy model also has empty hook lists
  - optional CUDA allocated-bytes check when CUDA is available
